### PR TITLE
feat(m1): core interfaces — strategy, venue, swap, inference, signer, risk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect
+	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDc
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
 github.com/sethvargo/go-retry v0.3.0 h1:EEt31A35QhrcRZtrYFDTBg91cqZVnFL2navjDrah2SE=
 github.com/sethvargo/go-retry v0.3.0/go.mod h1:mNX17F0C/HguQMyMyJxcnU471gOZGxCLyYaFyAZraas=
+github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
+github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 h1:+jumHNA0Wrelhe64i8F6HNlS8pkoyMv5sreGx2Ry5Rw=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8/go.mod h1:3n1Cwaq1E1/1lhQhtRK2ts/ZwZEhjcQeJQ1RuC6Q/8U=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=

--- a/internal/exchange/exchange.go
+++ b/internal/exchange/exchange.go
@@ -1,0 +1,44 @@
+// Package exchange defines the Venue contract: the orderbook-style perpetuals
+// venue interface. Concrete adapters (e.g. Hyperliquid) live in subpackages.
+//
+// SwapVenue, the DEX equivalent for spot leg execution, lives in
+// internal/swap. The two interfaces are deliberately distinct because the
+// execution semantics differ (place-and-wait vs request-quote-execute-confirm).
+package exchange
+
+import (
+	"context"
+
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// Venue is an orderbook venue capable of placing and cancelling orders and
+// streaming market data. All methods MUST be safe for concurrent use.
+type Venue interface {
+	// Name is a stable identifier matching the agents.venue column.
+	Name() string
+
+	// Subscribe opens a stream of MarketEvents for the given symbols. The
+	// channel is closed when the supplied context is cancelled or the
+	// underlying connection terminates with an unrecoverable error.
+	Subscribe(ctx context.Context, symbols []string) (<-chan types.MarketEvent, error)
+
+	// Place submits an order. Implementations MUST honour OrderIntent.ClientID
+	// for idempotency: a second call with the same ClientID MUST NOT result
+	// in a second order, and SHOULD return the original ack if available.
+	Place(ctx context.Context, intent types.OrderIntent) (types.OrderAck, error)
+
+	// Cancel removes an open order. Cancelling an unknown or already-terminal
+	// order MUST NOT return an error.
+	Cancel(ctx context.Context, id types.OrderID) error
+
+	// Positions returns currently-open positions across all symbols.
+	Positions(ctx context.Context) ([]types.Position, error)
+
+	// Balances returns the venue-side balance per asset.
+	Balances(ctx context.Context) ([]types.Balance, error)
+
+	// FundingRates returns the latest funding observation per symbol. If
+	// symbols is empty, all subscribed symbols are returned.
+	FundingRates(ctx context.Context, symbols []string) ([]types.FundingRate, error)
+}

--- a/internal/exchange/exchange_test.go
+++ b/internal/exchange/exchange_test.go
@@ -1,0 +1,64 @@
+package exchange_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/exchange/noop"
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+func TestNoopVenuePlaceCancel(t *testing.T) {
+	v := noop.New()
+
+	intent := types.OrderIntent{
+		Venue:    "noop",
+		Symbol:   "WIF-PERP",
+		Side:     types.SideSell,
+		Type:     types.OrderTypeLimit,
+		Price:    decimal.NewFromInt(1),
+		Size:     decimal.NewFromInt(10),
+		ClientID: "client-1",
+	}
+	ack, err := v.Place(context.Background(), intent)
+	if err != nil {
+		t.Fatalf("Place: %v", err)
+	}
+	if ack.ClientID != "client-1" {
+		t.Errorf("ClientID: got %q", ack.ClientID)
+	}
+	if ack.Status != types.OrderStatusOpen {
+		t.Errorf("Status: got %q", ack.Status)
+	}
+	if got := v.Placed(); len(got) != 1 || got[0].Symbol != "WIF-PERP" {
+		t.Errorf("Placed: got %+v", got)
+	}
+
+	if err := v.Cancel(context.Background(), ack.ID); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if got := v.Cancellations(); len(got) != 1 || got[0] != ack.ID {
+		t.Errorf("Cancellations: got %+v", got)
+	}
+}
+
+func TestNoopVenueSubscribeClosesOnCtxCancel(t *testing.T) {
+	v := noop.New()
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := v.Subscribe(ctx, []string{"WIF-PERP"})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	cancel()
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Errorf("expected closed channel")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("channel not closed within 1s")
+	}
+}

--- a/internal/exchange/noop/noop.go
+++ b/internal/exchange/noop/noop.go
@@ -1,0 +1,84 @@
+// Package noop provides a Venue implementation that returns empty data and
+// records calls. Used for tests of the agent runtime and as a stand-in
+// while real adapters are being developed.
+package noop
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/teslashibe/permafrost/internal/exchange"
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// Name is the registered venue identifier.
+const Name = "noop"
+
+// Venue is a no-op exchange.
+type Venue struct {
+	mu       sync.Mutex
+	placed   []types.OrderIntent
+	cancels  []types.OrderID
+}
+
+// New constructs a fresh no-op venue.
+func New() *Venue { return &Venue{} }
+
+// Compile-time check.
+var _ exchange.Venue = (*Venue)(nil)
+
+func (v *Venue) Name() string { return Name }
+
+func (v *Venue) Subscribe(ctx context.Context, _ []string) (<-chan types.MarketEvent, error) {
+	ch := make(chan types.MarketEvent)
+	go func() {
+		<-ctx.Done()
+		close(ch)
+	}()
+	return ch, nil
+}
+
+func (v *Venue) Place(_ context.Context, intent types.OrderIntent) (types.OrderAck, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.placed = append(v.placed, intent)
+	return types.OrderAck{
+		ID:         types.OrderID("noop-" + string(intent.ClientID)),
+		ClientID:   intent.ClientID,
+		AcceptedAt: time.Now().UTC(),
+		Status:     types.OrderStatusOpen,
+		Remaining:  intent.Size,
+	}, nil
+}
+
+func (v *Venue) Cancel(_ context.Context, id types.OrderID) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.cancels = append(v.cancels, id)
+	return nil
+}
+
+func (v *Venue) Positions(_ context.Context) ([]types.Position, error)         { return nil, nil }
+func (v *Venue) Balances(_ context.Context) ([]types.Balance, error)           { return nil, nil }
+func (v *Venue) FundingRates(_ context.Context, _ []string) ([]types.FundingRate, error) {
+	return nil, nil
+}
+
+// Placed returns the intents recorded by Place, in submission order.
+func (v *Venue) Placed() []types.OrderIntent {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	out := make([]types.OrderIntent, len(v.placed))
+	copy(out, v.placed)
+	return out
+}
+
+// Cancellations returns ids passed to Cancel, in submission order.
+func (v *Venue) Cancellations() []types.OrderID {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	out := make([]types.OrderID, len(v.cancels))
+	copy(out, v.cancels)
+	return out
+}

--- a/internal/inference/inference.go
+++ b/internal/inference/inference.go
@@ -1,0 +1,116 @@
+// Package inference defines the Provider contract: a single OpenAI-compatible
+// chat-completion interface used by Permafrost strategies and runtime
+// components. One implementation in internal/inference/openai serves OpenAI,
+// OpenRouter, Groq, vLLM, Ollama, etc. via base_url.
+//
+// Strategies depend on inference.Provider, never on a concrete client. Native
+// non-OpenAI SDKs (Anthropic Messages, Gemini, Bedrock) may be added later
+// as additional implementations of Provider without touching strategies.
+package inference
+
+import (
+	"context"
+	"errors"
+)
+
+// Role labels the speaker of a Message.
+type Role string
+
+const (
+	RoleSystem    Role = "system"
+	RoleUser      Role = "user"
+	RoleAssistant Role = "assistant"
+	RoleTool      Role = "tool"
+)
+
+// Message is one turn in a conversation.
+type Message struct {
+	Role       Role        `json:"role"`
+	Content    string      `json:"content"`
+	Name       string      `json:"name,omitempty"`
+	ToolCalls  []ToolCall  `json:"tool_calls,omitempty"`
+	ToolCallID string      `json:"tool_call_id,omitempty"`
+}
+
+// ToolSpec describes a function the model may call. The Schema is a JSON
+// Schema document for the function's arguments.
+type ToolSpec struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Schema      []byte `json:"schema"` // raw JSON Schema
+}
+
+// ToolCall is a model-issued invocation of a registered tool.
+type ToolCall struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"` // raw JSON
+}
+
+// Schema instructs the model to return JSON conforming to the supplied schema.
+type Schema struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	JSON        []byte `json:"json"` // raw JSON Schema
+	Strict      bool   `json:"strict"`
+}
+
+// Request is a chat-completion request.
+type Request struct {
+	Model       string
+	System      string
+	Messages    []Message
+	Tools       []ToolSpec
+	JSONSchema  *Schema
+	Temperature float64
+	TopP        float64
+	MaxTokens   int
+	Stop        []string
+	User        string // pass-through for providers that support it
+}
+
+// Response is what Provider.Complete returns.
+type Response struct {
+	Content      string     // primary message body
+	ToolCalls    []ToolCall // populated when the model issued tool calls
+	FinishReason string     // "stop" | "length" | "tool_calls" | provider-specific
+	TokensIn     int
+	TokensOut    int
+	Model        string
+	Provider     string
+	LatencyMS    int64
+	CostUSD      float64 // 0 if provider/model pricing unknown
+	Raw          []byte  // opaque provider response for audit/debug
+}
+
+// EmbedRequest asks the provider to embed one or more inputs.
+type EmbedRequest struct {
+	Model string
+	Input []string
+}
+
+// EmbedResponse carries the resulting vectors.
+type EmbedResponse struct {
+	Vectors  [][]float32
+	TokensIn int
+	Model    string
+	Provider string
+	CostUSD  float64
+}
+
+// Provider is the single inference contract. Implementations MUST be safe
+// for concurrent use.
+type Provider interface {
+	Name() string
+	Complete(ctx context.Context, req Request) (Response, error)
+	Embed(ctx context.Context, req EmbedRequest) (EmbedResponse, error)
+}
+
+// ErrUnsupportedFeature is returned when the underlying provider/model does
+// not support the requested feature (e.g. tool calls on a base Ollama model).
+// Strategies SHOULD handle this with a graceful fallback (e.g. ask for JSON
+// in the prompt and parse it).
+var ErrUnsupportedFeature = errors.New("inference: unsupported feature")
+
+// ErrRateLimited is returned when the provider signals a rate-limit / 429.
+var ErrRateLimited = errors.New("inference: rate limited")

--- a/internal/inference/inference_test.go
+++ b/internal/inference/inference_test.go
@@ -1,0 +1,57 @@
+package inference_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/teslashibe/permafrost/internal/inference"
+	"github.com/teslashibe/permafrost/internal/inference/mock"
+)
+
+func TestMock_Static(t *testing.T) {
+	want := inference.Response{Content: "hello", Provider: "mock", Model: "m"}
+	p := mock.New(mock.WithResponse(want))
+
+	got, err := p.Complete(context.Background(), inference.Request{Model: "m"})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if got.Content != want.Content {
+		t.Errorf("Content: got %q want %q", got.Content, want.Content)
+	}
+	calls := p.Calls()
+	if len(calls) != 1 || calls[0].Model != "m" {
+		t.Errorf("Calls: got %+v", calls)
+	}
+}
+
+func TestMock_Queue(t *testing.T) {
+	p := mock.New(mock.WithQueue(
+		inference.Response{Content: "first"},
+		inference.Response{Content: "second"},
+	))
+
+	for i, want := range []string{"first", "second"} {
+		got, err := p.Complete(context.Background(), inference.Request{})
+		if err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+		if got.Content != want {
+			t.Errorf("call %d: got %q want %q", i, got.Content, want)
+		}
+	}
+
+	if _, err := p.Complete(context.Background(), inference.Request{}); !errors.Is(err, mock.ErrQueueExhausted) {
+		t.Fatalf("expected ErrQueueExhausted, got %v", err)
+	}
+}
+
+func TestSentinelErrors(t *testing.T) {
+	if inference.ErrUnsupportedFeature == nil {
+		t.Fatal("ErrUnsupportedFeature must be non-nil")
+	}
+	if inference.ErrRateLimited == nil {
+		t.Fatal("ErrRateLimited must be non-nil")
+	}
+}

--- a/internal/inference/mock/mock.go
+++ b/internal/inference/mock/mock.go
@@ -1,0 +1,115 @@
+// Package mock provides a deterministic Provider for tests and backtests.
+//
+// It supports two modes:
+//   - Static: returns a fixed Response (set via WithResponse) for every call.
+//   - Scripted: returns successive Responses from a queue (set via WithQueue),
+//     panicking if the queue is exhausted.
+package mock
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/teslashibe/permafrost/internal/inference"
+)
+
+// Name is the registered provider identifier.
+const Name = "mock"
+
+// Provider is a mock inference implementation.
+//
+// Behaviour:
+//   - If WithResponse is supplied, every Complete returns that Response.
+//   - If WithQueue is supplied, successive Completes return queue entries
+//     in order; once exhausted, Complete returns ErrQueueExhausted.
+//   - If both are supplied, the queue takes precedence and falls back to
+//     the static Response after exhaustion.
+//   - If neither is supplied, Complete returns a stable empty Response.
+type Provider struct {
+	mu          sync.Mutex
+	queue       []inference.Response
+	static      *inference.Response
+	staticSet   bool
+	queueSet    bool
+	calls       []inference.Request
+	embedFn     func(inference.EmbedRequest) (inference.EmbedResponse, error)
+}
+
+// Option mutates Provider at construction time.
+type Option func(*Provider)
+
+// WithResponse sets a static Response returned for every Complete call.
+func WithResponse(r inference.Response) Option {
+	return func(p *Provider) {
+		p.static = &r
+		p.staticSet = true
+	}
+}
+
+// WithQueue enqueues Responses returned in order. Once exhausted, subsequent
+// calls return ErrQueueExhausted (unless WithResponse was also supplied, in
+// which case the static Response is used as a fallback).
+func WithQueue(rs ...inference.Response) Option {
+	return func(p *Provider) {
+		p.queue = append(p.queue, rs...)
+		p.queueSet = true
+	}
+}
+
+// WithEmbedFunc installs a custom embedder.
+func WithEmbedFunc(fn func(inference.EmbedRequest) (inference.EmbedResponse, error)) Option {
+	return func(p *Provider) { p.embedFn = fn }
+}
+
+// New constructs a mock Provider.
+func New(opts ...Option) *Provider {
+	p := &Provider{}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// Compile-time check.
+var _ inference.Provider = (*Provider)(nil)
+
+func (p *Provider) Name() string { return Name }
+
+// ErrQueueExhausted is returned when WithQueue is set and the queue is empty.
+var ErrQueueExhausted = errors.New("mock: response queue exhausted")
+
+func (p *Provider) Complete(_ context.Context, req inference.Request) (inference.Response, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls = append(p.calls, req)
+
+	if len(p.queue) > 0 {
+		next := p.queue[0]
+		p.queue = p.queue[1:]
+		return next, nil
+	}
+	if p.queueSet && !p.staticSet {
+		return inference.Response{}, ErrQueueExhausted
+	}
+	if p.staticSet {
+		return *p.static, nil
+	}
+	return inference.Response{Provider: Name, Model: "mock", FinishReason: "stop"}, nil
+}
+
+func (p *Provider) Embed(_ context.Context, req inference.EmbedRequest) (inference.EmbedResponse, error) {
+	if p.embedFn != nil {
+		return p.embedFn(req)
+	}
+	return inference.EmbedResponse{Provider: Name, Model: req.Model}, nil
+}
+
+// Calls returns a snapshot of the requests received by Complete.
+func (p *Provider) Calls() []inference.Request {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]inference.Request, len(p.calls))
+	copy(out, p.calls)
+	return out
+}

--- a/internal/risk/noop/noop.go
+++ b/internal/risk/noop/noop.go
@@ -1,0 +1,27 @@
+// Package noop provides a permissive Engine that allows everything. For
+// tests only — never wire this into a live agent.
+package noop
+
+import (
+	"context"
+
+	"github.com/teslashibe/permafrost/internal/risk"
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// Engine allows every intent and reports the portfolio as healthy.
+type Engine struct{}
+
+// New constructs the engine.
+func New() *Engine { return &Engine{} }
+
+// Compile-time check.
+var _ risk.Engine = (*Engine)(nil)
+
+func (Engine) PreTrade(_ context.Context, _ string, _ any, _ types.PortfolioSnapshot) types.Verdict {
+	return types.Verdict{Kind: types.VerdictAllow}
+}
+
+func (Engine) Portfolio(_ context.Context, _ types.PortfolioSnapshot) types.Verdict {
+	return types.Verdict{Kind: types.VerdictAllow}
+}

--- a/internal/risk/risk.go
+++ b/internal/risk/risk.go
@@ -1,0 +1,24 @@
+// Package risk defines the Engine contract: pre-trade and portfolio-level
+// risk checks. Concrete engines (built in M9) live in this package.
+package risk
+
+import (
+	"context"
+
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// Engine evaluates trade intents and portfolio state against agent limits
+// and global circuit breakers.
+//
+// PreTrade is called once per intent (OrderIntent or SwapIntent) emitted by
+// a Strategy. The agent runtime drops any intent that returns a Block verdict
+// and emits a metric+log on Warn verdicts.
+//
+// Portfolio is called periodically (and after every fill/swap) against the
+// consolidated PortfolioSnapshot; a Block verdict triggers an automatic
+// agent halt and (configurably) a kill-switch unwind.
+type Engine interface {
+	PreTrade(ctx context.Context, agentID string, intent any, snap types.PortfolioSnapshot) types.Verdict
+	Portfolio(ctx context.Context, snap types.PortfolioSnapshot) types.Verdict
+}

--- a/internal/risk/risk_test.go
+++ b/internal/risk/risk_test.go
@@ -1,0 +1,35 @@
+package risk_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/teslashibe/permafrost/internal/risk/noop"
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+func TestNoopEngineAllows(t *testing.T) {
+	e := noop.New()
+	if v := e.PreTrade(context.Background(), "agent", types.OrderIntent{}, types.PortfolioSnapshot{}); v.IsBlock() {
+		t.Errorf("PreTrade should allow, got %+v", v)
+	}
+	if v := e.Portfolio(context.Background(), types.PortfolioSnapshot{}); v.IsBlock() {
+		t.Errorf("Portfolio should allow, got %+v", v)
+	}
+}
+
+func TestVerdictKinds(t *testing.T) {
+	cases := []struct {
+		v       types.Verdict
+		isBlock bool
+	}{
+		{types.Verdict{Kind: types.VerdictAllow}, false},
+		{types.Verdict{Kind: types.VerdictWarn}, false},
+		{types.Verdict{Kind: types.VerdictBlock}, true},
+	}
+	for _, c := range cases {
+		if got := c.v.IsBlock(); got != c.isBlock {
+			t.Errorf("%+v IsBlock=%v want %v", c.v, got, c.isBlock)
+		}
+	}
+}

--- a/internal/strategy/noop/noop.go
+++ b/internal/strategy/noop/noop.go
@@ -1,0 +1,26 @@
+// Package noop provides a Strategy that emits no intents. Useful for tests
+// of the agent runtime and as a reference implementation of the interface.
+package noop
+
+import (
+	"context"
+
+	"github.com/teslashibe/permafrost/internal/strategy"
+)
+
+// Name is the registered identifier for this strategy.
+const Name = "noop"
+
+// Strategy returns no intents. Decide always succeeds.
+type Strategy struct{}
+
+// New constructs a no-op strategy. The cfg argument is ignored.
+func New(_ map[string]any) (strategy.Strategy, error) { return &Strategy{}, nil }
+
+func (Strategy) Name() string                                                       { return Name }
+func (Strategy) Warmup(context.Context, strategy.WarmupInput) error                 { return nil }
+func (Strategy) Decide(context.Context, strategy.DecisionInput) (strategy.Decision, error) {
+	return strategy.Decision{Notes: "noop"}, nil
+}
+
+func init() { strategy.Register(Name, New) }

--- a/internal/strategy/registry.go
+++ b/internal/strategy/registry.go
@@ -1,0 +1,60 @@
+package strategy
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// Constructor builds a Strategy from a config blob. Each implementation
+// registers a Constructor in init() so the agent runtime can instantiate
+// strategies by name (matching the agents.strategy column in the DB).
+type Constructor func(cfg map[string]any) (Strategy, error)
+
+var (
+	regMu       sync.RWMutex
+	constructors = map[string]Constructor{}
+)
+
+// Register adds a strategy constructor under the given name. It panics on
+// double registration to surface bugs at process start. Names should be
+// snake_case (e.g. "funding_arb_basic").
+func Register(name string, c Constructor) {
+	regMu.Lock()
+	defer regMu.Unlock()
+	if _, dup := constructors[name]; dup {
+		panic(fmt.Sprintf("strategy %q already registered", name))
+	}
+	constructors[name] = c
+}
+
+// Get returns the constructor registered for name, or an error if no such
+// strategy is registered.
+func Get(name string) (Constructor, error) {
+	regMu.RLock()
+	defer regMu.RUnlock()
+	c, ok := constructors[name]
+	if !ok {
+		return nil, fmt.Errorf("strategy %q not registered", name)
+	}
+	return c, nil
+}
+
+// List returns all registered strategy names in sorted order.
+func List() []string {
+	regMu.RLock()
+	defer regMu.RUnlock()
+	out := make([]string, 0, len(constructors))
+	for name := range constructors {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Reset clears the registry. For tests only.
+func Reset() {
+	regMu.Lock()
+	defer regMu.Unlock()
+	constructors = map[string]Constructor{}
+}

--- a/internal/strategy/strategy.go
+++ b/internal/strategy/strategy.go
@@ -1,0 +1,79 @@
+// Package strategy defines the Strategy contract: the pure-logic interface
+// that proposes orders and swaps in response to market state.
+//
+// A Strategy is stateless across restarts; all persistent state lives in the
+// store. Implementations live in subpackages such as
+// internal/strategy/funding_arb_basic.
+package strategy
+
+import (
+	"context"
+	"time"
+
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// Strategy is the framework's primary contract. The agent runtime calls
+// Warmup once after creation and Decide on every scheduled tick.
+type Strategy interface {
+	// Name is a stable identifier used in configs, the registry, and the DB.
+	Name() string
+
+	// Warmup is called once after the strategy is constructed. Implementations
+	// may use it to fetch initial state, validate config, or pre-compute
+	// indicators. It MUST be idempotent.
+	Warmup(ctx context.Context, in WarmupInput) error
+
+	// Decide produces the next batch of intents given the current state.
+	// Implementations MUST be deterministic given DecisionInput; any random
+	// or external dependency should be threaded through Signals or be opaque
+	// to the framework.
+	Decide(ctx context.Context, in DecisionInput) (Decision, error)
+}
+
+// WarmupInput is supplied once at strategy construction time.
+type WarmupInput struct {
+	AgentID string
+	Config  map[string]any
+	Now     time.Time
+}
+
+// DecisionInput carries everything the strategy needs to make a single
+// decision tick. The framework guarantees:
+//   - Cash, Positions, BasisPositions reflect on-chain/venue state at Now.
+//   - Market is consistent across symbols (same wall-clock fetch round).
+//   - Signals is opaque to the framework; strategies may populate it with
+//     LLM outputs or computed indicators between ticks.
+type DecisionInput struct {
+	AgentID         string
+	Now             time.Time
+	Market          types.MarketSnapshot
+	PerpPositions   []types.Position
+	SpotBalances    []types.WalletBalance
+	BasisPositions  []types.BasisPosition
+	Cash            map[string]types.Balance // keyed by location: "hyperliquid", "solana"
+	Signals         map[string]any
+	Limits          types.RiskLimits
+}
+
+// Decision is a Strategy's response to one DecisionInput. The agent runtime
+// executes Swaps before Orders to preserve the spot-first invariant for
+// basis strategies.
+//
+// A strategy that owns the paired-execution invariant should:
+//   - on entry: emit a SwapIntent (long spot) and an OrderIntent (short perp)
+//     in the same Decision; Swaps run and confirm before Orders;
+//   - on partial state recovery: omit one of the legs and rely on the next
+//     tick to reconcile.
+type Decision struct {
+	Orders     []types.OrderIntent
+	Swaps      []types.SwapIntent
+	Cancels    []types.OrderID
+	Notes      string  // human/LLM-readable rationale
+	Confidence float64 // 0..1; advisory
+}
+
+// HasIntents reports whether the decision proposes any state-changing action.
+func (d Decision) HasIntents() bool {
+	return len(d.Orders) > 0 || len(d.Swaps) > 0 || len(d.Cancels) > 0
+}

--- a/internal/strategy/strategy_test.go
+++ b/internal/strategy/strategy_test.go
@@ -1,0 +1,71 @@
+package strategy_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/teslashibe/permafrost/internal/strategy"
+	_ "github.com/teslashibe/permafrost/internal/strategy/noop"
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+func TestRegistry(t *testing.T) {
+	names := strategy.List()
+	found := false
+	for _, n := range names {
+		if n == "noop" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("noop strategy not in registry: %v", names)
+	}
+
+	ctor, err := strategy.Get("noop")
+	if err != nil {
+		t.Fatalf("Get noop: %v", err)
+	}
+	s, err := ctor(nil)
+	if err != nil {
+		t.Fatalf("noop ctor: %v", err)
+	}
+	if s.Name() != "noop" {
+		t.Errorf("Name: got %q", s.Name())
+	}
+
+	if _, err := strategy.Get("does-not-exist"); err == nil {
+		t.Errorf("Get unknown should error")
+	}
+}
+
+func TestNoopDecide(t *testing.T) {
+	ctor, _ := strategy.Get("noop")
+	s, _ := ctor(nil)
+	dec, err := s.Decide(context.Background(), strategy.DecisionInput{AgentID: "x"})
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if dec.HasIntents() {
+		t.Errorf("noop should produce no intents, got %+v", dec)
+	}
+}
+
+func TestDecisionHasIntents(t *testing.T) {
+	cases := []struct {
+		name string
+		dec  strategy.Decision
+		want bool
+	}{
+		{"empty", strategy.Decision{}, false},
+		{"orders", strategy.Decision{Orders: []types.OrderIntent{{}}}, true},
+		{"swaps", strategy.Decision{Swaps: []types.SwapIntent{{}}}, true},
+		{"cancels", strategy.Decision{Cancels: []types.OrderID{"x"}}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.dec.HasIntents(); got != tc.want {
+				t.Errorf("HasIntents: got %v want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/swap/noop/noop.go
+++ b/internal/swap/noop/noop.go
@@ -1,0 +1,75 @@
+// Package noop provides a SwapVenue implementation that quotes a 1:1 trade
+// at zero gas, "confirms" instantly, and records calls. For tests only.
+package noop
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/swap"
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// Name is the registered identifier.
+const Name = "noop"
+
+// SwapVenue is a deterministic stub.
+type SwapVenue struct {
+	mu     sync.Mutex
+	swaps  []types.Quote
+}
+
+// New constructs a fresh stub.
+func New() *SwapVenue { return &SwapVenue{} }
+
+// Compile-time check.
+var _ swap.SwapVenue = (*SwapVenue)(nil)
+
+func (v *SwapVenue) Name() string         { return Name }
+func (v *SwapVenue) Chain() types.ChainID { return "noop" }
+
+func (v *SwapVenue) Quote(_ context.Context, req types.QuoteRequest) (types.Quote, error) {
+	out := req.Amount
+	if req.Mode == types.QuoteExactOut {
+		out = req.Amount
+	}
+	return types.Quote{
+		InToken:   req.InToken,
+		OutToken:  req.OutToken,
+		InAmount:  req.Amount,
+		OutAmount: out,
+		Route:     "noop",
+		ExpiresAt: time.Now().UTC().Add(30 * time.Second),
+	}, nil
+}
+
+func (v *SwapVenue) Swap(_ context.Context, q types.Quote, _ int) (types.TxHash, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.swaps = append(v.swaps, q)
+	return types.TxHash("noop-tx"), nil
+}
+
+func (v *SwapVenue) WaitConfirm(_ context.Context, tx types.TxHash) (types.SwapResult, error) {
+	return types.SwapResult{
+		TxHash:    tx,
+		Status:    types.SwapStatusConfirmed,
+		BlockTime: time.Now().UTC(),
+	}, nil
+}
+
+func (v *SwapVenue) Balance(_ context.Context, _ types.Asset) (decimal.Decimal, error) {
+	return decimal.Zero, nil
+}
+
+// Submitted returns the quotes recorded by Swap, in submission order.
+func (v *SwapVenue) Submitted() []types.Quote {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	out := make([]types.Quote, len(v.swaps))
+	copy(out, v.swaps)
+	return out
+}

--- a/internal/swap/swap.go
+++ b/internal/swap/swap.go
@@ -1,0 +1,52 @@
+// Package swap defines the SwapVenue contract: the on-chain DEX/aggregator
+// interface used to execute spot legs of basis positions.
+//
+// SwapVenue is deliberately not the same shape as exchange.Venue because
+// DEX trading is request-quote-execute-confirm rather than place-and-wait.
+// Concrete adapters (Jupiter on Solana, 0x on EVM) live in subpackages.
+package swap
+
+import (
+	"context"
+	"errors"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// SwapVenue executes swaps on a single chain via a single aggregator/DEX.
+type SwapVenue interface {
+	// Name is the adapter identifier (e.g. "jupiter").
+	Name() string
+
+	// Chain reports which chain this venue settles on.
+	Chain() types.ChainID
+
+	// Quote prices a swap. The returned Quote may carry opaque routing data
+	// in its Raw field; that data MUST be passed back unchanged to Swap.
+	Quote(ctx context.Context, req types.QuoteRequest) (types.Quote, error)
+
+	// Swap submits the trade for the given quote with the supplied slippage
+	// budget. It returns once the transaction has been broadcast; callers
+	// should call WaitConfirm to await on-chain confirmation.
+	Swap(ctx context.Context, q types.Quote, slippageBps int) (types.TxHash, error)
+
+	// WaitConfirm blocks until the transaction is confirmed or the context
+	// is cancelled. Implementations SHOULD return SwapStatusFailed promptly
+	// when the chain reports a definitive failure (rather than waiting for
+	// the context deadline).
+	WaitConfirm(ctx context.Context, tx types.TxHash) (types.SwapResult, error)
+
+	// Balance reports the wallet balance of the given asset for the venue's
+	// configured signing address.
+	Balance(ctx context.Context, asset types.Asset) (decimal.Decimal, error)
+}
+
+// ErrQuoteExpired is returned by Swap when the supplied Quote is past its
+// ExpiresAt; the caller should re-quote.
+var ErrQuoteExpired = errors.New("swap: quote expired")
+
+// ErrInsufficientBalance is returned by Quote/Swap when the configured
+// wallet does not hold enough of the input asset.
+var ErrInsufficientBalance = errors.New("swap: insufficient balance")

--- a/internal/swap/swap_test.go
+++ b/internal/swap/swap_test.go
@@ -1,0 +1,47 @@
+package swap_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/swap/noop"
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+func TestNoopSwapVenue(t *testing.T) {
+	v := noop.New()
+	ctx := context.Background()
+
+	in := types.Asset{Symbol: "USDC", Chain: types.ChainSolana, Mint: "USDCmint"}
+	out := types.Asset{Symbol: "WIF", Chain: types.ChainSolana, Mint: "WIFmint"}
+
+	q, err := v.Quote(ctx, types.QuoteRequest{
+		InToken: in,
+		OutToken: out,
+		Amount:   decimal.NewFromInt(100),
+		Mode:     types.QuoteExactIn,
+	})
+	if err != nil {
+		t.Fatalf("Quote: %v", err)
+	}
+	if !q.InAmount.Equal(decimal.NewFromInt(100)) {
+		t.Errorf("InAmount: got %s", q.InAmount)
+	}
+
+	tx, err := v.Swap(ctx, q, 50)
+	if err != nil {
+		t.Fatalf("Swap: %v", err)
+	}
+	res, err := v.WaitConfirm(ctx, tx)
+	if err != nil {
+		t.Fatalf("WaitConfirm: %v", err)
+	}
+	if res.Status != types.SwapStatusConfirmed {
+		t.Errorf("Status: got %q", res.Status)
+	}
+	if len(v.Submitted()) != 1 {
+		t.Errorf("Submitted: got %d", len(v.Submitted()))
+	}
+}

--- a/internal/types/asset.go
+++ b/internal/types/asset.go
@@ -1,0 +1,38 @@
+// Package types holds the shared trading-domain types used across packages
+// (strategy, exchange, swap, risk). Types here must be free of import cycles:
+// they may not import any internal package other than each other.
+package types
+
+import "fmt"
+
+// ChainID identifies a settlement venue or chain.
+type ChainID string
+
+const (
+	ChainHyperliquid ChainID = "hyperliquid"
+	ChainSolana      ChainID = "solana"
+)
+
+// Asset is a chain-bound token. For perpetual symbols traded on Hyperliquid,
+// Mint holds the perp symbol (e.g. "WIF-PERP") and Decimals holds the on-venue
+// quote decimals.
+type Asset struct {
+	Symbol   string  `json:"symbol"`   // human-readable: USDC, WIF, BONK
+	Chain    ChainID `json:"chain"`    // settlement venue
+	Mint     string  `json:"mint"`     // chain-specific identifier (mint, contract, perp symbol)
+	Decimals int32   `json:"decimals"` // on-chain decimals
+}
+
+// String renders Asset as "<symbol>@<chain>".
+func (a Asset) String() string {
+	if a.Symbol == "" {
+		return fmt.Sprintf("?@%s", a.Chain)
+	}
+	return fmt.Sprintf("%s@%s", a.Symbol, a.Chain)
+}
+
+// Equal reports whether two assets refer to the same token on the same chain.
+// Symbol is informational; identity is determined by (Chain, Mint).
+func (a Asset) Equal(b Asset) bool {
+	return a.Chain == b.Chain && a.Mint == b.Mint
+}

--- a/internal/types/balance.go
+++ b/internal/types/balance.go
@@ -1,0 +1,29 @@
+package types
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// Balance is a free/locked breakdown of a single asset on a single venue.
+type Balance struct {
+	Asset  string          `json:"asset"`   // e.g. "USDC"
+	Venue  string          `json:"venue"`   // venue name (hyperliquid, solana, ...)
+	Free   decimal.Decimal `json:"free"`
+	Locked decimal.Decimal `json:"locked"`
+}
+
+// Total returns Free + Locked.
+func (b Balance) Total() decimal.Decimal { return b.Free.Add(b.Locked) }
+
+// WalletBalance is a chain-bound balance held in a self-custodied wallet.
+// Distinct from Balance because wallet balances have no concept of "locked"
+// in the orderbook sense; everything held is freely transferable.
+type WalletBalance struct {
+	Chain     ChainID         `json:"chain"`
+	Address   string          `json:"address"`
+	Asset     Asset           `json:"asset"`
+	Amount    decimal.Decimal `json:"amount"`
+	UpdatedAt time.Time       `json:"updated_at"`
+}

--- a/internal/types/funding.go
+++ b/internal/types/funding.go
@@ -1,0 +1,40 @@
+package types
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// FundingRate is a single funding observation for a perpetual symbol.
+//
+// Rate is the per-interval rate (NOT annualised). Annualise via:
+//   AnnualPct = Rate * (365*24h / Interval) * 100
+type FundingRate struct {
+	Time          time.Time       `json:"time"`
+	Venue         string          `json:"venue"`
+	Symbol        string          `json:"symbol"`
+	Rate          decimal.Decimal `json:"rate"`            // per Interval, fractional (0.0001 = 1bp)
+	Interval      time.Duration   `json:"interval"`        // typically 1h or 8h
+	PredictedNext decimal.Decimal `json:"predicted_next"`  // venue-published forecast for next interval
+}
+
+// Annualised returns the funding rate scaled to one year. Returns zero if
+// Interval is not positive.
+func (f FundingRate) Annualised() decimal.Decimal {
+	if f.Interval <= 0 {
+		return decimal.Zero
+	}
+	year := decimal.NewFromInt(int64(time.Hour * 24 * 365))
+	intvl := decimal.NewFromInt(int64(f.Interval))
+	return f.Rate.Mul(year.Div(intvl))
+}
+
+// FundingPayment is a realised funding settlement for an open perp position.
+type FundingPayment struct {
+	Time   time.Time       `json:"time"`
+	Venue  string          `json:"venue"`
+	Symbol string          `json:"symbol"`
+	Amount decimal.Decimal `json:"amount"` // signed: positive = received, negative = paid
+	Rate   decimal.Decimal `json:"rate"`
+}

--- a/internal/types/market.go
+++ b/internal/types/market.go
@@ -1,0 +1,84 @@
+package types
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// Tick is a top-of-book quote.
+type Tick struct {
+	Time   time.Time       `json:"time"`
+	Venue  string          `json:"venue"`
+	Symbol string          `json:"symbol"`
+	Bid    decimal.Decimal `json:"bid"`
+	Ask    decimal.Decimal `json:"ask"`
+	Last   decimal.Decimal `json:"last"`
+	Volume decimal.Decimal `json:"volume"` // 24h
+}
+
+// Mid returns (Bid+Ask)/2 when both are set, else Last.
+func (t Tick) Mid() decimal.Decimal {
+	if !t.Bid.IsZero() && !t.Ask.IsZero() {
+		return t.Bid.Add(t.Ask).Div(decimal.NewFromInt(2))
+	}
+	return t.Last
+}
+
+// BookLevel is a single price level in an orderbook side.
+type BookLevel struct {
+	Price decimal.Decimal `json:"price"`
+	Size  decimal.Decimal `json:"size"`
+}
+
+// BookSnapshot captures aggregated bids and asks for a symbol.
+type BookSnapshot struct {
+	Time   time.Time   `json:"time"`
+	Venue  string      `json:"venue"`
+	Symbol string      `json:"symbol"`
+	Bids   []BookLevel `json:"bids"` // sorted descending by price
+	Asks   []BookLevel `json:"asks"` // sorted ascending by price
+}
+
+// MarketEventKind tags the union members of MarketEvent.
+type MarketEventKind string
+
+const (
+	EventTick    MarketEventKind = "tick"
+	EventBook    MarketEventKind = "book"
+	EventTrade   MarketEventKind = "trade"
+	EventFunding MarketEventKind = "funding"
+)
+
+// Trade is a public trade print.
+type Trade struct {
+	Time   time.Time       `json:"time"`
+	Venue  string          `json:"venue"`
+	Symbol string          `json:"symbol"`
+	Price  decimal.Decimal `json:"price"`
+	Size   decimal.Decimal `json:"size"`
+	Side   Side            `json:"side"` // taker side
+}
+
+// MarketEvent is a typed envelope sent on the venue subscription channel.
+// Exactly one of Tick/Book/Trade/Funding will be populated based on Kind.
+type MarketEvent struct {
+	Kind    MarketEventKind `json:"kind"`
+	Tick    *Tick           `json:"tick,omitempty"`
+	Book    *BookSnapshot   `json:"book,omitempty"`
+	Trade   *Trade          `json:"trade,omitempty"`
+	Funding *FundingRate    `json:"funding,omitempty"`
+}
+
+// MarketSnapshot is the consolidated view of one symbol at decision time.
+type MarketSnapshot struct {
+	Time     time.Time              `json:"time"`
+	Symbols  map[string]SymbolSnap  `json:"symbols"` // keyed by symbol
+}
+
+// SymbolSnap collects everything a strategy needs to know about one symbol.
+type SymbolSnap struct {
+	Tick    Tick         `json:"tick"`
+	Book    BookSnapshot `json:"book"`
+	Funding FundingRate  `json:"funding"`
+}

--- a/internal/types/order.go
+++ b/internal/types/order.go
@@ -1,0 +1,112 @@
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// OrderID is a venue-assigned identifier for a placed order.
+type OrderID string
+
+// ClientOrderID is a deterministic identifier supplied by the framework.
+// Its value uniquely identifies an order intent for idempotent retries.
+type ClientOrderID string
+
+// Side is the buy/sell direction of an order.
+type Side string
+
+const (
+	SideBuy  Side = "buy"
+	SideSell Side = "sell"
+)
+
+// OrderType captures the order's posting style.
+type OrderType string
+
+const (
+	OrderTypeLimit  OrderType = "limit"
+	OrderTypeMarket OrderType = "market"
+)
+
+// TimeInForce controls how long a resting order remains active.
+type TimeInForce string
+
+const (
+	TIFGTC TimeInForce = "gtc"  // good-til-cancelled
+	TIFIOC TimeInForce = "ioc"  // immediate-or-cancel
+	TIFFOK TimeInForce = "fok"  // fill-or-kill
+	TIFALO TimeInForce = "alo"  // add-liquidity-only (post-only)
+)
+
+// OrderIntent is what a Strategy proposes. The agent runtime is responsible
+// for stamping ClientID (deterministic), validating with Risk, and submitting
+// to the Venue.
+type OrderIntent struct {
+	Venue       string          `json:"venue"`
+	Symbol      string          `json:"symbol"`
+	Side        Side            `json:"side"`
+	Type        OrderType       `json:"type"`
+	Price       decimal.Decimal `json:"price"`            // ignored for market orders
+	Size        decimal.Decimal `json:"size"`             // base-asset units
+	TIF         TimeInForce     `json:"tif"`
+	ReduceOnly  bool            `json:"reduce_only"`
+	ClientID    ClientOrderID   `json:"client_id"`        // set by runtime if empty
+	PositionID  string          `json:"position_id"`      // links order to a strategy_position
+	DecisionID  string          `json:"decision_id"`      // links order to an agent_decision
+	Slot        int             `json:"slot"`             // ordinal within a decision
+	Tag         string          `json:"tag,omitempty"`    // strategy-defined annotation
+}
+
+// Notional returns the absolute notional value (price * size). For market
+// orders Price will typically be zero and Notional reports zero.
+func (o OrderIntent) Notional() decimal.Decimal {
+	return o.Price.Mul(o.Size).Abs()
+}
+
+// OrderAck is what a Venue returns after accepting an order.
+type OrderAck struct {
+	ID         OrderID       `json:"id"`
+	ClientID   ClientOrderID `json:"client_id"`
+	AcceptedAt time.Time     `json:"accepted_at"`
+	Status     OrderStatus   `json:"status"`
+	Filled     decimal.Decimal `json:"filled"`
+	Remaining  decimal.Decimal `json:"remaining"`
+	AvgPrice   decimal.Decimal `json:"avg_price"`
+}
+
+// OrderStatus is the lifecycle state of an order.
+type OrderStatus string
+
+const (
+	OrderStatusOpen      OrderStatus = "open"
+	OrderStatusPartial   OrderStatus = "partial"
+	OrderStatusFilled    OrderStatus = "filled"
+	OrderStatusCancelled OrderStatus = "cancelled"
+	OrderStatusRejected  OrderStatus = "rejected"
+)
+
+// Fill is a single execution against an order.
+type Fill struct {
+	OrderID  OrderID         `json:"order_id"`
+	Time     time.Time       `json:"time"`
+	Price    decimal.Decimal `json:"price"`
+	Size     decimal.Decimal `json:"size"`
+	Fee      decimal.Decimal `json:"fee"`
+	FeeAsset string          `json:"fee_asset"`
+}
+
+// DeriveClientID computes the deterministic client_id used for idempotent
+// order placement. The output is a stable function of (agentID, decisionID,
+// slot, venue, symbol, side, size). Strategies should normally leave
+// OrderIntent.ClientID blank and let the runtime stamp it; this helper is
+// exported for tests and adapters that need to reproduce IDs.
+func DeriveClientID(agentID, decisionID string, slot int, venue, symbol string, side Side, size decimal.Decimal) ClientOrderID {
+	h := sha256.New()
+	fmt.Fprintf(h, "%s|%s|%d|%s|%s|%s|%s",
+		agentID, decisionID, slot, venue, symbol, side, size.String())
+	return ClientOrderID("pf_" + hex.EncodeToString(h.Sum(nil))[:24])
+}

--- a/internal/types/position.go
+++ b/internal/types/position.go
@@ -1,0 +1,85 @@
+package types
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// Position is a per-symbol position on a single venue (typically Hyperliquid).
+type Position struct {
+	Venue        string          `json:"venue"`
+	Symbol       string          `json:"symbol"`
+	Qty          decimal.Decimal `json:"qty"`            // signed: positive = long, negative = short
+	EntryPrice   decimal.Decimal `json:"entry_price"`    // VWAP entry
+	MarkPrice    decimal.Decimal `json:"mark_price"`
+	LiqPrice     decimal.Decimal `json:"liq_price"`
+	Leverage     decimal.Decimal `json:"leverage"`
+	Margin       decimal.Decimal `json:"margin"`
+	UnrealizedPx decimal.Decimal `json:"upnl"`
+	RealizedPx   decimal.Decimal `json:"rpnl"`
+	UpdatedAt    time.Time       `json:"updated_at"`
+}
+
+// IsLong reports whether the position is net long.
+func (p Position) IsLong() bool { return p.Qty.IsPositive() }
+
+// IsShort reports whether the position is net short.
+func (p Position) IsShort() bool { return p.Qty.IsNegative() }
+
+// IsFlat reports whether the position is closed.
+func (p Position) IsFlat() bool { return p.Qty.IsZero() }
+
+// BasisPositionState models the lifecycle of a paired (spot + perp) position.
+type BasisPositionState string
+
+const (
+	BasisStateOpening BasisPositionState = "opening"
+	BasisStateOpen    BasisPositionState = "open"
+	BasisStateClosing BasisPositionState = "closing"
+	BasisStateBroken  BasisPositionState = "broken"
+	BasisStateClosed  BasisPositionState = "closed"
+)
+
+// BasisLeg is one side of a basis position. Kind disambiguates spot vs perp.
+type BasisLeg struct {
+	Kind     BasisLegKind    `json:"kind"`
+	Asset    Asset           `json:"asset"`
+	Symbol   string          `json:"symbol"`              // perp symbol (perp leg) or "" (spot leg)
+	Qty      decimal.Decimal `json:"qty"`                 // base-asset units, unsigned
+	AvgPrice decimal.Decimal `json:"avg_price"`           // entry VWAP in USDC
+}
+
+// BasisLegKind labels a leg as spot (long, on-chain) or perp (short, venue).
+type BasisLegKind string
+
+const (
+	BasisLegSpot BasisLegKind = "spot"
+	BasisLegPerp BasisLegKind = "perp"
+)
+
+// BasisPosition is a logical paired position spanning two symbols.
+// PnL only makes sense at the pair level. The agent runtime persists these
+// to the strategy_positions table; per-leg detail lives in the orders, fills,
+// and swaps tables linked by PositionID.
+type BasisPosition struct {
+	ID               string             `json:"id"`
+	AgentID          string             `json:"agent_id"`
+	Underlying       string             `json:"underlying"`        // canonical symbol, e.g. "WIF"
+	State            BasisPositionState `json:"state"`
+	Legs             []BasisLeg         `json:"legs"`
+	OpenedAt         time.Time          `json:"opened_at"`
+	ClosedAt         *time.Time         `json:"closed_at,omitempty"`
+	RealizedFunding  decimal.Decimal    `json:"realized_funding"`
+	RealizedBasisPnL decimal.Decimal    `json:"realized_basis_pnl"`
+	RealizedFees     decimal.Decimal    `json:"realized_fees"`
+	RealizedGas      decimal.Decimal    `json:"realized_gas"`
+}
+
+// NetPnL returns realized funding minus fees and gas plus realized basis PnL.
+func (b BasisPosition) NetPnL() decimal.Decimal {
+	return b.RealizedFunding.
+		Add(b.RealizedBasisPnL).
+		Sub(b.RealizedFees).
+		Sub(b.RealizedGas)
+}

--- a/internal/types/risk.go
+++ b/internal/types/risk.go
@@ -1,0 +1,67 @@
+package types
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// RiskLimits captures the hard limits applied to a single agent. All values
+// are evaluated in USDC unless noted.
+type RiskLimits struct {
+	MaxNotionalPerLeg       decimal.Decimal `json:"max_notional_per_leg"`
+	MaxTotalBasisExposure   decimal.Decimal `json:"max_total_basis_exposure"`
+	MaxSwapsPerMin          int             `json:"max_swaps_per_min"`
+	MaxOrdersPerMin         int             `json:"max_orders_per_min"`
+	MaxDailyLoss            decimal.Decimal `json:"max_daily_loss"`
+	MaxSpotSlippageBps      int             `json:"max_spot_slippage_bps"`
+	MaxEntryBasisBps        int             `json:"max_entry_basis_bps"`
+	MaxConcurrentPositions  int             `json:"max_concurrent_positions"`
+}
+
+// VerdictKind is the outcome of a risk check.
+type VerdictKind string
+
+const (
+	VerdictAllow VerdictKind = "allow"
+	VerdictWarn  VerdictKind = "warn"
+	VerdictBlock VerdictKind = "block"
+)
+
+// Verdict is what the risk engine returns for a check. Reason is a short
+// machine-friendly tag (e.g. "max_notional"); Detail is for humans/logs.
+type Verdict struct {
+	Kind   VerdictKind `json:"kind"`
+	Reason string      `json:"reason,omitempty"`
+	Detail string      `json:"detail,omitempty"`
+}
+
+// IsBlock reports whether this verdict prohibits the action.
+func (v Verdict) IsBlock() bool { return v.Kind == VerdictBlock }
+
+// PortfolioSnapshot is the consolidated view passed to risk checks.
+type PortfolioSnapshot struct {
+	Time           time.Time
+	NAV            decimal.Decimal
+	HighWaterMark  decimal.Decimal
+	DailyPnL       decimal.Decimal
+	OpenBasis      []BasisPosition
+	PerpPositions  []Position
+	WalletBalances []WalletBalance
+	VenueBalances  []Balance
+}
+
+// TotalBasisExposure sums |notional| across open basis positions, valued at
+// each position's perp leg avg-entry. Returns USDC.
+func (s PortfolioSnapshot) TotalBasisExposure() decimal.Decimal {
+	total := decimal.Zero
+	for _, p := range s.OpenBasis {
+		for _, leg := range p.Legs {
+			if leg.Kind == BasisLegPerp {
+				total = total.Add(leg.AvgPrice.Mul(leg.Qty).Abs())
+				break
+			}
+		}
+	}
+	return total
+}

--- a/internal/types/swap.go
+++ b/internal/types/swap.go
@@ -1,0 +1,81 @@
+package types
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// QuoteMode controls whether a quote fixes the input or output amount.
+type QuoteMode string
+
+const (
+	QuoteExactIn  QuoteMode = "exact_in"
+	QuoteExactOut QuoteMode = "exact_out"
+)
+
+// QuoteRequest asks a SwapVenue to price a swap.
+type QuoteRequest struct {
+	InToken  Asset
+	OutToken Asset
+	Amount   decimal.Decimal
+	Mode     QuoteMode
+}
+
+// Quote is the venue's response to a QuoteRequest. Implementations may
+// include opaque routing data in Raw which must be passed back unchanged
+// when calling Swap.
+type Quote struct {
+	InToken      Asset           `json:"in_token"`
+	OutToken     Asset           `json:"out_token"`
+	InAmount     decimal.Decimal `json:"in_amount"`
+	OutAmount    decimal.Decimal `json:"out_amount"`     // expected, before slippage
+	PriceImpact  decimal.Decimal `json:"price_impact"`   // 0..1 fraction
+	Route        string          `json:"route"`          // e.g. "Raydium → Orca"
+	ExpiresAt    time.Time       `json:"expires_at"`
+	Raw          []byte          `json:"raw,omitempty"`  // opaque payload returned to Swap
+}
+
+// SwapIntent is a Strategy-issued instruction to acquire or dispose of an
+// on-chain asset. The agent runtime requests a Quote, validates it against
+// risk, then submits the Swap and waits for confirmation. ClientID is set by
+// the runtime for idempotency.
+type SwapIntent struct {
+	Chain        ChainID         `json:"chain"`
+	InToken      Asset           `json:"in_token"`
+	OutToken     Asset           `json:"out_token"`
+	InAmount     decimal.Decimal `json:"in_amount"`
+	MinOutAmount decimal.Decimal `json:"min_out_amount"`  // hard slippage floor
+	SlippageBps  int             `json:"slippage_bps"`    // soft target slippage
+	ClientID     string          `json:"client_id"`
+	PositionID   string          `json:"position_id"`
+	DecisionID   string          `json:"decision_id"`
+	Slot         int             `json:"slot"`
+	Tag          string          `json:"tag,omitempty"`
+}
+
+// TxHash is a chain-specific transaction identifier (signature on Solana,
+// hex on EVM). Stored as string for cross-chain ergonomics.
+type TxHash string
+
+// SwapStatus is the lifecycle state of a submitted swap.
+type SwapStatus string
+
+const (
+	SwapStatusPending   SwapStatus = "pending"
+	SwapStatusConfirmed SwapStatus = "confirmed"
+	SwapStatusFailed    SwapStatus = "failed"
+)
+
+// SwapResult reports the on-chain outcome of a submitted Swap.
+type SwapResult struct {
+	TxHash       TxHash          `json:"tx_hash"`
+	Status       SwapStatus      `json:"status"`
+	Slot         uint64          `json:"slot,omitempty"`     // Solana slot, if applicable
+	BlockTime    time.Time       `json:"block_time"`
+	InAmount     decimal.Decimal `json:"in_amount"`
+	OutAmount    decimal.Decimal `json:"out_amount"`         // actual received
+	GasNative    decimal.Decimal `json:"gas_native"`         // native units (lamports/wei)
+	GasUSD       decimal.Decimal `json:"gas_usd"`            // priced at submission time
+	Error        string          `json:"error,omitempty"`
+}

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -1,0 +1,126 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+func d(s string) decimal.Decimal { return decimal.RequireFromString(s) }
+
+func TestAssetEqual(t *testing.T) {
+	a := Asset{Symbol: "USDC", Chain: ChainSolana, Mint: "ABC"}
+	b := Asset{Symbol: "USD-Coin", Chain: ChainSolana, Mint: "ABC"} // different symbol, same identity
+	c := Asset{Symbol: "USDC", Chain: ChainSolana, Mint: "DEF"}
+
+	if !a.Equal(b) {
+		t.Errorf("Equal: identity should be (chain, mint) not symbol")
+	}
+	if a.Equal(c) {
+		t.Errorf("Equal: different mint should be unequal")
+	}
+}
+
+func TestOrderIntentNotional(t *testing.T) {
+	o := OrderIntent{Price: d("100.5"), Size: d("2")}
+	if got := o.Notional(); !got.Equal(d("201")) {
+		t.Errorf("Notional: got %s want 201", got)
+	}
+	o.Price = d("0")
+	if got := o.Notional(); !got.IsZero() {
+		t.Errorf("Notional with zero price: got %s", got)
+	}
+}
+
+func TestDeriveClientID_Deterministic(t *testing.T) {
+	a := DeriveClientID("agent1", "dec1", 0, "hyperliquid", "WIF-PERP", SideSell, d("100"))
+	b := DeriveClientID("agent1", "dec1", 0, "hyperliquid", "WIF-PERP", SideSell, d("100"))
+	if a != b {
+		t.Errorf("DeriveClientID should be deterministic, got %q vs %q", a, b)
+	}
+}
+
+func TestDeriveClientID_DiffersOnSlot(t *testing.T) {
+	a := DeriveClientID("a", "d", 0, "v", "s", SideBuy, d("1"))
+	b := DeriveClientID("a", "d", 1, "v", "s", SideBuy, d("1"))
+	if a == b {
+		t.Errorf("DeriveClientID should change with slot, got %q", a)
+	}
+}
+
+func TestPositionFlags(t *testing.T) {
+	if !(Position{Qty: d("1")}).IsLong() {
+		t.Error("IsLong: positive qty")
+	}
+	if !(Position{Qty: d("-1")}).IsShort() {
+		t.Error("IsShort: negative qty")
+	}
+	if !(Position{Qty: d("0")}).IsFlat() {
+		t.Error("IsFlat: zero qty")
+	}
+}
+
+func TestBalanceTotal(t *testing.T) {
+	b := Balance{Free: d("3"), Locked: d("2")}
+	if got := b.Total(); !got.Equal(d("5")) {
+		t.Errorf("Total: got %s want 5", got)
+	}
+}
+
+func TestTickMid(t *testing.T) {
+	if got := (Tick{Bid: d("100"), Ask: d("102")}).Mid(); !got.Equal(d("101")) {
+		t.Errorf("Mid: got %s want 101", got)
+	}
+	if got := (Tick{Last: d("99")}).Mid(); !got.Equal(d("99")) {
+		t.Errorf("Mid: empty book should fall back to last, got %s", got)
+	}
+}
+
+func TestFundingAnnualised(t *testing.T) {
+	// 0.0001 (1bp) per hour = 1bp * 24 * 365 = 87600bp = 8.76 (876%) annualised
+	f := FundingRate{Rate: d("0.0001"), Interval: time.Hour}
+	got := f.Annualised()
+	want := d("0.876")
+	if !got.Equal(want) {
+		t.Errorf("Annualised: got %s want %s", got, want)
+	}
+}
+
+func TestFundingAnnualised_ZeroInterval(t *testing.T) {
+	f := FundingRate{Rate: d("0.0001"), Interval: 0}
+	if !f.Annualised().IsZero() {
+		t.Errorf("Annualised with 0 interval should be 0")
+	}
+}
+
+func TestBasisPositionNetPnL(t *testing.T) {
+	bp := BasisPosition{
+		RealizedFunding:  d("100"),
+		RealizedBasisPnL: d("10"),
+		RealizedFees:     d("5"),
+		RealizedGas:      d("1"),
+	}
+	if got := bp.NetPnL(); !got.Equal(d("104")) {
+		t.Errorf("NetPnL: got %s want 104", got)
+	}
+}
+
+func TestPortfolioTotalBasisExposure(t *testing.T) {
+	snap := PortfolioSnapshot{
+		OpenBasis: []BasisPosition{
+			{Legs: []BasisLeg{
+				{Kind: BasisLegSpot, Qty: d("10"), AvgPrice: d("100")},
+				{Kind: BasisLegPerp, Qty: d("10"), AvgPrice: d("101")},
+			}},
+			{Legs: []BasisLeg{
+				{Kind: BasisLegPerp, Qty: d("5"), AvgPrice: d("200")},
+			}},
+		},
+	}
+	got := snap.TotalBasisExposure()
+	want := d("2010") // 10*101 + 5*200
+	if !got.Equal(want) {
+		t.Errorf("TotalBasisExposure: got %s want %s", got, want)
+	}
+}

--- a/internal/wallet/noop/noop.go
+++ b/internal/wallet/noop/noop.go
@@ -1,0 +1,69 @@
+// Package noop provides a Signer/Keystore that returns deterministic dummy
+// values. For tests only — never use against real funds.
+package noop
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/teslashibe/permafrost/internal/types"
+	"github.com/teslashibe/permafrost/internal/wallet"
+)
+
+// Signer is a deterministic stub.
+type Signer struct {
+	chain types.ChainID
+	addr  string
+}
+
+// NewSigner constructs a stub for the given chain. The address is a stable
+// hash so tests can pin against it.
+func NewSigner(chain types.ChainID) *Signer {
+	h := sha256.Sum256([]byte("noop-signer:" + string(chain)))
+	return &Signer{chain: chain, addr: "noop_" + hex.EncodeToString(h[:8])}
+}
+
+func (s *Signer) Address() string                                  { return s.addr }
+func (s *Signer) Chain() types.ChainID                             { return s.chain }
+func (s *Signer) Sign(_ context.Context, payload []byte) ([]byte, error) {
+	h := sha256.Sum256(append([]byte(s.addr+":"), payload...))
+	return h[:], nil
+}
+
+// Keystore is a chain → Signer map.
+type Keystore struct {
+	signers map[types.ChainID]wallet.Signer
+}
+
+// NewKeystore constructs a Keystore preloaded with stub signers for the
+// supplied chains.
+func NewKeystore(chains ...types.ChainID) *Keystore {
+	ks := &Keystore{signers: make(map[types.ChainID]wallet.Signer, len(chains))}
+	for _, c := range chains {
+		ks.signers[c] = NewSigner(c)
+	}
+	return ks
+}
+
+func (k *Keystore) Signer(chain types.ChainID) (wallet.Signer, error) {
+	s, ok := k.signers[chain]
+	if !ok {
+		return nil, fmt.Errorf("no signer for chain %q", chain)
+	}
+	return s, nil
+}
+
+func (k *Keystore) Chains() []types.ChainID {
+	out := make([]types.ChainID, 0, len(k.signers))
+	for c := range k.signers {
+		out = append(out, c)
+	}
+	return out
+}
+
+var (
+	_ wallet.Signer   = (*Signer)(nil)
+	_ wallet.Keystore = (*Keystore)(nil)
+)

--- a/internal/wallet/wallet.go
+++ b/internal/wallet/wallet.go
@@ -1,0 +1,41 @@
+// Package wallet defines the Signer contract used for chain-specific signing
+// operations. Concrete signers and the local encrypted keystore are added in
+// the M4 milestone PR.
+//
+// Design rule: this package is the only one in the repo that holds raw key
+// bytes. Everything else operates on Signer.
+package wallet
+
+import (
+	"context"
+
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// Signer signs payloads for a specific chain. Implementations MUST be safe
+// for concurrent use.
+type Signer interface {
+	// Address is the public address derived from the underlying private key,
+	// rendered in the chain's canonical encoding (base58 for Solana, 0x-hex
+	// for EVM, etc.).
+	Address() string
+
+	// Chain identifies which chain this signer is bound to.
+	Chain() types.ChainID
+
+	// Sign produces a signature over the supplied payload. The exact bytes
+	// signed are chain-specific; see chain-specific implementations for
+	// details (e.g. transaction wire bytes for Solana).
+	Sign(ctx context.Context, payload []byte) ([]byte, error)
+}
+
+// Keystore is the lookup interface used by the agent runtime to obtain a
+// Signer for a configured chain. Implementations are added in M4.
+type Keystore interface {
+	// Signer returns the signer registered for the given chain or an error
+	// if no key is configured.
+	Signer(chain types.ChainID) (Signer, error)
+
+	// Chains returns the chains for which signers are configured.
+	Chains() []types.ChainID
+}

--- a/internal/wallet/wallet_test.go
+++ b/internal/wallet/wallet_test.go
@@ -1,0 +1,49 @@
+package wallet_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/teslashibe/permafrost/internal/types"
+	"github.com/teslashibe/permafrost/internal/wallet/noop"
+)
+
+func TestNoopSigner(t *testing.T) {
+	s := noop.NewSigner(types.ChainSolana)
+	if s.Chain() != types.ChainSolana {
+		t.Errorf("Chain: got %q", s.Chain())
+	}
+	if !strings.HasPrefix(s.Address(), "noop_") {
+		t.Errorf("Address: got %q", s.Address())
+	}
+
+	sig1, err := s.Sign(context.Background(), []byte("hello"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig2, _ := s.Sign(context.Background(), []byte("hello"))
+	if string(sig1) != string(sig2) {
+		t.Errorf("Sign should be deterministic")
+	}
+	sig3, _ := s.Sign(context.Background(), []byte("world"))
+	if string(sig1) == string(sig3) {
+		t.Errorf("Sign should depend on payload")
+	}
+}
+
+func TestNoopKeystore(t *testing.T) {
+	ks := noop.NewKeystore(types.ChainSolana, types.ChainHyperliquid)
+
+	if _, err := ks.Signer(types.ChainSolana); err != nil {
+		t.Errorf("Signer(solana): %v", err)
+	}
+	if _, err := ks.Signer("ethereum"); err == nil {
+		t.Errorf("Signer(unknown): expected error")
+	}
+
+	chains := ks.Chains()
+	if len(chains) != 2 {
+		t.Errorf("Chains: got %d want 2", len(chains))
+	}
+}


### PR DESCRIPTION
## Milestone
**M1 — Core interfaces.** Defines every framework contract called for in [SCOPE.md §4](../blob/m1-interfaces/SCOPE.md#4-core-interfaces) plus the shared trading-domain types they reference, with no-op implementations and tests for each.

> Stacked on top of #1 (M0). Diff against \`main\` will shrink to just M1 once #1 merges.

## Shared types (\`internal/types\`)
| File | Contents |
|---|---|
| \`asset.go\` | \`Asset\`, \`ChainID\` |
| \`order.go\` | \`OrderID\`, \`ClientOrderID\`, \`Side\`, \`OrderType\`, \`TIF\`, \`OrderIntent\`, \`OrderAck\`, \`OrderStatus\`, \`Fill\`, \`DeriveClientID\` |
| \`position.go\` | \`Position\`, \`BasisLeg\`, \`BasisPosition\`, \`BasisPositionState\`, \`NetPnL\` helper |
| \`balance.go\` | \`Balance\`, \`WalletBalance\` |
| \`market.go\` | \`Tick\`, \`BookSnapshot\`, \`Trade\`, \`MarketEvent\`, \`MarketSnapshot\`, \`SymbolSnap\` |
| \`funding.go\` | \`FundingRate\` (with \`Annualised\`), \`FundingPayment\` |
| \`swap.go\` | \`QuoteRequest\`/\`Quote\`/\`QuoteMode\`, \`SwapIntent\`, \`SwapResult\`, \`TxHash\`, \`SwapStatus\` |
| \`risk.go\` | \`RiskLimits\`, \`Verdict\`, \`PortfolioSnapshot\` |

## Interfaces
- \`strategy.Strategy\` — \`Name\`, \`Warmup\`, \`Decide\`. Decision returns \`Orders\` + \`Swaps\` + \`Cancels\`; runtime executes \`Swaps\` before \`Orders\` to enforce the spot-first invariant.
- \`strategy.Registry\` — name → constructor map; the \`noop\` strategy auto-registers in \`init()\`.
- \`exchange.Venue\` — orderbook venue (\`Subscribe\`/\`Place\`/\`Cancel\`/\`Positions\`/\`Balances\`/\`FundingRates\`).
- \`swap.SwapVenue\` — DEX/aggregator (\`Quote\`/\`Swap\`/\`WaitConfirm\`/\`Balance\`) with \`ErrQuoteExpired\` / \`ErrInsufficientBalance\` sentinels.
- \`inference.Provider\` — single OpenAI-compatible chat-completion contract (\`Complete\` + \`Embed\`). \`ErrUnsupportedFeature\` and \`ErrRateLimited\` sentinels let strategies degrade gracefully.
- \`wallet.Signer\` + \`wallet.Keystore\` — chain-bound signers; only this package will ever hold raw key bytes (real keystore lands in M4).
- \`risk.Engine\` — \`PreTrade(intent any)\` for \`OrderIntent\` or \`SwapIntent\`, plus \`Portfolio\` for periodic snapshots.

## No-op implementations
\`strategy/noop\`, \`exchange/noop\`, \`swap/noop\`, \`inference/mock\`, \`wallet/noop\`, \`risk/noop\`. Each is sufficient to drive the agent runtime in tests and serves as a reference implementation of the contract.

## Tests
Type helpers (Asset.Equal, Notional, deterministic ClientID, position flags, funding annualisation, basis NetPnL, portfolio basis exposure rollup); strategy registry round-trip; noop venues' record-and-return semantics; mock inference static/queue/exhaustion; signer determinism + payload sensitivity; verdict matrix.

## Verify locally
\`\`\`
go build ./...
go test ./... -race -count=1
\`\`\`

## Out of scope (next PRs)
- Real Hyperliquid adapter → **PR #3 (M2)**
- OpenAI-compatible HTTP client → **PR #4 (M3)**
- Local encrypted keystore → **PR #5 (M4)**
- Jupiter SwapVenue → **PR #6 (M5)**