### PR TITLE
feat(m3): inference — openai-compatible client, registry, CLI

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,3 +16,21 @@ database:
   url: postgres://permafrost:permafrost@localhost:5432/permafrost?sslmode=disable
   max_conns: 16
   min_conns: 2
+
+inference:
+  # Single OpenAI-compatible client. Each entry below points at a different
+  # base_url so providers can be swapped via config. Add your own here.
+  default: openrouter
+  providers:
+    openai:
+      base_url: https://api.openai.com/v1
+      api_key_env: OPENAI_API_KEY
+    openrouter:
+      base_url: https://openrouter.ai/api/v1
+      api_key_env: OPENROUTER_API_KEY
+    groq:
+      base_url: https://api.groq.com/openai/v1
+      api_key_env: GROQ_API_KEY
+    ollama:
+      base_url: http://localhost:11434/v1
+      api_key_env: ""        # not required for local Ollama

--- a/internal/cli/inference.go
+++ b/internal/cli/inference.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/teslashibe/permafrost/internal/inference"
+	"github.com/teslashibe/permafrost/internal/inference/openai"
+)
+
+func init() { addCommandFactory(newInferenceCmd) }
+
+func newInferenceCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "inference",
+		Short: "Inference provider utilities",
+	}
+	cmd.AddCommand(newInferenceTestCmd(), newInferenceListCmd())
+	return cmd
+}
+
+func newInferenceTestCmd() *cobra.Command {
+	var (
+		providerName string
+		model        string
+		prompt       string
+	)
+	cmd := &cobra.Command{
+		Use:   "test",
+		Short: "Send a one-shot completion to a configured provider",
+		RunE: func(c *cobra.Command, _ []string) error {
+			g := FromContext(c.Context())
+			if g == nil {
+				return errors.New("globals not initialised")
+			}
+			reg, err := inference.NewRegistry(g.Config.Inference, openai.NewProvider)
+			if err != nil {
+				return err
+			}
+			var p inference.Provider
+			if providerName == "" {
+				p, err = reg.Default()
+			} else {
+				p, err = reg.Get(providerName)
+			}
+			if err != nil {
+				return err
+			}
+			resp, err := p.Complete(c.Context(), inference.Request{
+				Model: model,
+				Messages: []inference.Message{
+					{Role: inference.RoleUser, Content: prompt},
+				},
+				MaxTokens: 200,
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Printf("provider:    %s\nmodel:       %s\nfinish:      %s\nlatency_ms:  %d\ntokens_in:   %d\ntokens_out:  %d\ncost_usd:    %.6f\n\n%s\n",
+				resp.Provider, resp.Model, resp.FinishReason, resp.LatencyMS,
+				resp.TokensIn, resp.TokensOut, resp.CostUSD, resp.Content)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&providerName, "provider", "", "provider name (defaults to inference.default)")
+	cmd.Flags().StringVar(&model, "model", "", "model identifier (provider-specific)")
+	cmd.Flags().StringVar(&prompt, "prompt", "Say hello in exactly five words.", "prompt to send")
+	_ = cmd.MarkFlagRequired("model")
+	return cmd
+}
+
+func newInferenceListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List configured inference providers",
+		RunE: func(c *cobra.Command, _ []string) error {
+			g := FromContext(c.Context())
+			if g == nil {
+				return errors.New("globals not initialised")
+			}
+			reg, err := inference.NewRegistry(g.Config.Inference, openai.NewProvider)
+			if err != nil {
+				return err
+			}
+			defName := reg.DefaultName()
+			for _, n := range reg.Names() {
+				marker := " "
+				if n == defName {
+					marker = "*"
+				}
+				fmt.Printf("%s %s\n", marker, n)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -54,7 +54,20 @@ func NewRootCmd(ctx context.Context) *cobra.Command {
 		newDBCmd(),
 		newVersionCmd(),
 	)
+	for _, f := range commandFactories {
+		cmd.AddCommand(f())
+	}
 	return cmd
+}
+
+// commandFactories is a registration table populated via init() functions
+// in sibling files. This lets each milestone PR add its own CLI subcommand
+// without editing root.go (which would create constant merge conflicts).
+var commandFactories []func() *cobra.Command
+
+// addCommandFactory registers a command constructor. Call from init().
+func addCommandFactory(f func() *cobra.Command) {
+	commandFactories = append(commandFactories, f)
 }
 
 type globalsKey struct{}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,10 +22,11 @@ const (
 )
 
 type Config struct {
-	Env      Env            `mapstructure:"env"`
-	Server   ServerConfig   `mapstructure:"server"`
-	Logging  LoggingConfig  `mapstructure:"logging"`
-	Database DatabaseConfig `mapstructure:"database"`
+	Env       Env             `mapstructure:"env"`
+	Server    ServerConfig    `mapstructure:"server"`
+	Logging   LoggingConfig   `mapstructure:"logging"`
+	Database  DatabaseConfig  `mapstructure:"database"`
+	Inference InferenceConfig `mapstructure:"inference"`
 }
 
 type ServerConfig struct {
@@ -42,6 +43,23 @@ type DatabaseConfig struct {
 	URL      string `mapstructure:"url"`
 	MaxConns int32  `mapstructure:"max_conns"`
 	MinConns int32  `mapstructure:"min_conns"`
+}
+
+// InferenceConfig holds the named OpenAI-compatible providers and the default
+// provider used when one is not specified.
+type InferenceConfig struct {
+	Default   string                            `mapstructure:"default"`
+	Providers map[string]InferenceProviderConfig `mapstructure:"providers"`
+}
+
+// InferenceProviderConfig is one named provider entry. APIKeyEnv is the name
+// of an environment variable holding the API key (empty for no-auth providers
+// like Ollama). RequestTimeoutSecs is optional (default 60).
+type InferenceProviderConfig struct {
+	BaseURL            string `mapstructure:"base_url"`
+	APIKeyEnv          string `mapstructure:"api_key_env"`
+	APIKey             string `mapstructure:"api_key"` // direct value (use sparingly)
+	RequestTimeoutSecs int    `mapstructure:"request_timeout_secs"`
 }
 
 // Load reads configuration from the given path (optional) and environment.

--- a/internal/inference/factory.go
+++ b/internal/inference/factory.go
@@ -1,0 +1,131 @@
+package inference
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/teslashibe/permafrost/internal/config"
+)
+
+// Registry holds the configured Provider set, keyed by name. Construct one
+// with NewRegistry. The registry is safe for concurrent use.
+type Registry struct {
+	mu       sync.RWMutex
+	def      string
+	provs    map[string]Provider
+}
+
+// NewRegistry builds a Registry from configuration. It instantiates one
+// OpenAI-compatible Client per named provider entry. The factory parameter
+// is the constructor for an OpenAI-compatible client; it is supplied so this
+// package does not import internal/inference/openai (avoiding an import
+// cycle when the openai package imports this).
+//
+// In practice callers use:
+//
+//	import "github.com/teslashibe/permafrost/internal/inference/openai"
+//	reg, err := inference.NewRegistry(cfg.Inference, openai.NewProvider)
+func NewRegistry(cfg config.InferenceConfig, factory ProviderFactory) (*Registry, error) {
+	r := &Registry{
+		def:   cfg.Default,
+		provs: make(map[string]Provider, len(cfg.Providers)),
+	}
+	if len(cfg.Providers) == 0 {
+		return r, nil
+	}
+
+	for name, pcfg := range cfg.Providers {
+		if pcfg.BaseURL == "" {
+			return nil, fmt.Errorf("inference provider %q: base_url is required", name)
+		}
+		key := pcfg.APIKey
+		if key == "" && pcfg.APIKeyEnv != "" {
+			key = os.Getenv(pcfg.APIKeyEnv)
+		}
+		timeout := time.Duration(pcfg.RequestTimeoutSecs) * time.Second
+		if timeout == 0 {
+			timeout = 60 * time.Second
+		}
+		p, err := factory(ProviderConfig{
+			Name:    name,
+			BaseURL: pcfg.BaseURL,
+			APIKey:  key,
+			Timeout: timeout,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("inference provider %q: %w", name, err)
+		}
+		r.provs[name] = p
+	}
+
+	if r.def == "" {
+		// pick a deterministic default if none specified (alphabetical)
+		names := r.Names()
+		if len(names) > 0 {
+			r.def = names[0]
+		}
+	}
+	if _, ok := r.provs[r.def]; r.def != "" && !ok {
+		return nil, fmt.Errorf("inference default %q not in providers", r.def)
+	}
+	return r, nil
+}
+
+// ProviderConfig is the input to a ProviderFactory.
+type ProviderConfig struct {
+	Name    string
+	BaseURL string
+	APIKey  string
+	Timeout time.Duration
+}
+
+// ProviderFactory constructs a Provider. It is supplied by client packages
+// (e.g. internal/inference/openai) to avoid cycles.
+type ProviderFactory func(ProviderConfig) (Provider, error)
+
+// Default returns the default Provider, or an error if none is registered.
+func (r *Registry) Default() (Provider, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.def == "" {
+		return nil, fmt.Errorf("inference: no default provider configured")
+	}
+	p, ok := r.provs[r.def]
+	if !ok {
+		return nil, fmt.Errorf("inference: default %q missing", r.def)
+	}
+	return p, nil
+}
+
+// Get returns the Provider registered under name.
+func (r *Registry) Get(name string) (Provider, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.provs[name]
+	if !ok {
+		return nil, fmt.Errorf("inference: provider %q not registered", name)
+	}
+	return p, nil
+}
+
+// Names returns all registered provider names in sorted order.
+func (r *Registry) Names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]string, 0, len(r.provs))
+	for n := range r.provs {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// DefaultName returns the configured default provider name (or "").
+func (r *Registry) DefaultName() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.def
+}

--- a/internal/inference/factory_test.go
+++ b/internal/inference/factory_test.go
@@ -1,0 +1,145 @@
+package inference_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/teslashibe/permafrost/internal/config"
+	"github.com/teslashibe/permafrost/internal/inference"
+)
+
+// stubProvider records calls and lets tests assert on construction args.
+type stubProvider struct {
+	cfg inference.ProviderConfig
+}
+
+func (p *stubProvider) Name() string { return p.cfg.Name }
+func (p *stubProvider) Complete(_ context.Context, _ inference.Request) (inference.Response, error) {
+	return inference.Response{Provider: p.cfg.Name}, nil
+}
+func (p *stubProvider) Embed(_ context.Context, _ inference.EmbedRequest) (inference.EmbedResponse, error) {
+	return inference.EmbedResponse{Provider: p.cfg.Name}, nil
+}
+
+func stubFactory(cfg inference.ProviderConfig) (inference.Provider, error) {
+	return &stubProvider{cfg: cfg}, nil
+}
+
+func TestRegistry_Build(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-from-env")
+	cfg := config.InferenceConfig{
+		Default: "openai",
+		Providers: map[string]config.InferenceProviderConfig{
+			"openai":  {BaseURL: "https://api.openai.com/v1", APIKeyEnv: "OPENAI_API_KEY"},
+			"openrouter": {BaseURL: "https://openrouter.ai/api/v1", APIKey: "sk-direct"},
+			"ollama":  {BaseURL: "http://localhost:11434/v1"},
+		},
+	}
+	r, err := inference.NewRegistry(cfg, stubFactory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := r.Names()
+	if len(names) != 3 {
+		t.Errorf("Names: got %v", names)
+	}
+
+	def, err := r.Default()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if def.Name() != "openai" {
+		t.Errorf("Default: %q", def.Name())
+	}
+	defStub, ok := def.(*stubProvider)
+	if !ok || defStub.cfg.APIKey != "sk-from-env" {
+		t.Errorf("openai apikey from env: got %+v", defStub.cfg)
+	}
+
+	or, _ := r.Get("openrouter")
+	if or.(*stubProvider).cfg.APIKey != "sk-direct" {
+		t.Errorf("openrouter apikey direct: got %+v", or.(*stubProvider).cfg)
+	}
+
+	ollama, _ := r.Get("ollama")
+	if ollama.(*stubProvider).cfg.APIKey != "" {
+		t.Errorf("ollama apikey should be empty: got %+v", ollama.(*stubProvider).cfg)
+	}
+	if ollama.(*stubProvider).cfg.Timeout == 0 {
+		t.Errorf("Timeout default should be applied")
+	}
+}
+
+func TestRegistry_DefaultMissing(t *testing.T) {
+	cfg := config.InferenceConfig{
+		Default: "nope",
+		Providers: map[string]config.InferenceProviderConfig{
+			"openai": {BaseURL: "x"},
+		},
+	}
+	_, err := inference.NewRegistry(cfg, stubFactory)
+	if err == nil {
+		t.Fatal("expected error for missing default")
+	}
+}
+
+func TestRegistry_NoProviders(t *testing.T) {
+	r, err := inference.NewRegistry(config.InferenceConfig{}, stubFactory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Default(); err == nil {
+		t.Fatal("Default with no providers should error")
+	}
+	if _, err := r.Get("anything"); err == nil {
+		t.Fatal("Get with no providers should error")
+	}
+}
+
+func TestRegistry_MissingBaseURL(t *testing.T) {
+	cfg := config.InferenceConfig{
+		Providers: map[string]config.InferenceProviderConfig{
+			"x": {APIKey: "k"},
+		},
+	}
+	_, err := inference.NewRegistry(cfg, stubFactory)
+	if err == nil {
+		t.Fatal("expected error for missing base_url")
+	}
+}
+
+func TestRegistry_FactoryError(t *testing.T) {
+	bad := errors.New("boom")
+	failing := func(_ inference.ProviderConfig) (inference.Provider, error) { return nil, bad }
+	cfg := config.InferenceConfig{
+		Providers: map[string]config.InferenceProviderConfig{
+			"x": {BaseURL: "y"},
+		},
+	}
+	_, err := inference.NewRegistry(cfg, failing)
+	if !errors.Is(err, bad) {
+		t.Fatalf("expected %v, got %v", bad, err)
+	}
+}
+
+func TestProviderConfig_TimeoutDefault(t *testing.T) {
+	captured := make(chan inference.ProviderConfig, 1)
+	cfg := config.InferenceConfig{
+		Providers: map[string]config.InferenceProviderConfig{
+			"x": {BaseURL: "y", RequestTimeoutSecs: 30},
+		},
+	}
+	_, err := inference.NewRegistry(cfg, func(c inference.ProviderConfig) (inference.Provider, error) {
+		captured <- c
+		return &stubProvider{cfg: c}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := <-captured
+	if got.Timeout != 30*time.Second {
+		t.Errorf("Timeout: got %v want 30s", got.Timeout)
+	}
+}

--- a/internal/inference/openai/api.go
+++ b/internal/inference/openai/api.go
@@ -1,0 +1,108 @@
+// Package openai implements an OpenAI-compatible chat-completions client.
+//
+// The same client serves OpenAI, OpenRouter, Groq, Together, Fireworks, vLLM,
+// Ollama, LM Studio, and any other provider that exposes the OpenAI Chat
+// Completions schema at /chat/completions and embeddings at /embeddings.
+//
+// Provider selection is done via base_url; this package contains zero
+// per-provider branching.
+package openai
+
+import "encoding/json"
+
+// chatRequest is the JSON body sent to /chat/completions.
+type chatRequest struct {
+	Model          string         `json:"model"`
+	Messages       []chatMessage  `json:"messages"`
+	Temperature    *float64       `json:"temperature,omitempty"`
+	TopP           *float64       `json:"top_p,omitempty"`
+	MaxTokens      *int           `json:"max_tokens,omitempty"`
+	Stop           []string       `json:"stop,omitempty"`
+	User           string         `json:"user,omitempty"`
+	Tools          []chatTool     `json:"tools,omitempty"`
+	ResponseFormat *responseFmt   `json:"response_format,omitempty"`
+}
+
+type chatMessage struct {
+	Role       string         `json:"role"`
+	Content    string         `json:"content,omitempty"`
+	Name       string         `json:"name,omitempty"`
+	ToolCalls  []chatToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string         `json:"tool_call_id,omitempty"`
+}
+
+type chatTool struct {
+	Type     string       `json:"type"` // always "function"
+	Function chatToolFunc `json:"function"`
+}
+
+type chatToolFunc struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters"`
+}
+
+type chatToolCall struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+type responseFmt struct {
+	Type       string             `json:"type"` // "json_schema" | "json_object"
+	JSONSchema *responseFmtSchema `json:"json_schema,omitempty"`
+}
+
+type responseFmtSchema struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Schema      json.RawMessage `json:"schema"`
+	Strict      bool            `json:"strict,omitempty"`
+}
+
+// chatResponse is the JSON body returned by /chat/completions.
+type chatResponse struct {
+	ID      string `json:"id"`
+	Model   string `json:"model"`
+	Created int64  `json:"created"`
+	Choices []struct {
+		Index        int         `json:"index"`
+		Message      chatMessage `json:"message"`
+		FinishReason string      `json:"finish_reason"`
+	} `json:"choices"`
+	Usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+	} `json:"usage"`
+	Error *apiError `json:"error,omitempty"`
+}
+
+type apiError struct {
+	Message string      `json:"message"`
+	Type    string      `json:"type"`
+	Code    interface{} `json:"code"` // string or int depending on provider
+}
+
+// embedRequest is the JSON body sent to /embeddings.
+type embedRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+// embedResponse is the JSON body returned by /embeddings.
+type embedResponse struct {
+	Model string `json:"model"`
+	Data  []struct {
+		Embedding []float32 `json:"embedding"`
+		Index     int       `json:"index"`
+	} `json:"data"`
+	Usage struct {
+		PromptTokens int `json:"prompt_tokens"`
+		TotalTokens  int `json:"total_tokens"`
+	} `json:"usage"`
+	Error *apiError `json:"error,omitempty"`
+}

--- a/internal/inference/openai/client.go
+++ b/internal/inference/openai/client.go
@@ -1,0 +1,246 @@
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/teslashibe/permafrost/internal/inference"
+)
+
+// Client implements inference.Provider against any OpenAI-compatible HTTP API.
+type Client struct {
+	name    string
+	baseURL string
+	apiKey  string
+	http    *http.Client
+}
+
+// Config configures a Client.
+type Config struct {
+	Name    string        // identifier returned by Name(); e.g. "openrouter"
+	BaseURL string        // e.g. "https://api.openai.com/v1"
+	APIKey  string        // bearer token (may be empty for local providers)
+	Timeout time.Duration // request timeout (default 60s)
+}
+
+// New constructs a Client. BaseURL must be set. If APIKey is empty, no
+// Authorization header is sent.
+func New(cfg Config) (*Client, error) {
+	if cfg.BaseURL == "" {
+		return nil, errors.New("openai: BaseURL is required")
+	}
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 60 * time.Second
+	}
+	return &Client{
+		name:    cfg.Name,
+		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
+		apiKey:  cfg.APIKey,
+		http:    &http.Client{Timeout: cfg.Timeout},
+	}, nil
+}
+
+// Compile-time check.
+var _ inference.Provider = (*Client)(nil)
+
+func (c *Client) Name() string { return c.name }
+
+// Complete sends a chat-completions request and returns the parsed response.
+func (c *Client) Complete(ctx context.Context, req inference.Request) (inference.Response, error) {
+	body, err := buildChatRequest(req)
+	if err != nil {
+		return inference.Response{}, err
+	}
+
+	start := time.Now()
+	var raw chatResponse
+	rawBytes, err := c.post(ctx, "/chat/completions", body, &raw)
+	if err != nil {
+		return inference.Response{}, err
+	}
+	if raw.Error != nil {
+		return inference.Response{}, fmt.Errorf("%s: %s", c.name, raw.Error.Message)
+	}
+	if len(raw.Choices) == 0 {
+		return inference.Response{}, errors.New("openai: empty choices")
+	}
+
+	choice := raw.Choices[0]
+	resp := inference.Response{
+		Content:      choice.Message.Content,
+		FinishReason: choice.FinishReason,
+		TokensIn:     raw.Usage.PromptTokens,
+		TokensOut:    raw.Usage.CompletionTokens,
+		Model:        raw.Model,
+		Provider:     c.name,
+		LatencyMS:    time.Since(start).Milliseconds(),
+		CostUSD:      estimateCost(raw.Model, raw.Usage.PromptTokens, raw.Usage.CompletionTokens),
+		Raw:          rawBytes,
+	}
+	if len(choice.Message.ToolCalls) > 0 {
+		resp.ToolCalls = make([]inference.ToolCall, len(choice.Message.ToolCalls))
+		for i, tc := range choice.Message.ToolCalls {
+			resp.ToolCalls[i] = inference.ToolCall{
+				ID:        tc.ID,
+				Name:      tc.Function.Name,
+				Arguments: tc.Function.Arguments,
+			}
+		}
+	}
+	return resp, nil
+}
+
+// Embed sends an embeddings request and returns the parsed response.
+func (c *Client) Embed(ctx context.Context, req inference.EmbedRequest) (inference.EmbedResponse, error) {
+	body := embedRequest{Model: req.Model, Input: req.Input}
+	var raw embedResponse
+	if _, err := c.post(ctx, "/embeddings", body, &raw); err != nil {
+		return inference.EmbedResponse{}, err
+	}
+	if raw.Error != nil {
+		return inference.EmbedResponse{}, fmt.Errorf("%s: %s", c.name, raw.Error.Message)
+	}
+	out := inference.EmbedResponse{
+		Vectors:  make([][]float32, len(raw.Data)),
+		TokensIn: raw.Usage.PromptTokens,
+		Model:    raw.Model,
+		Provider: c.name,
+		CostUSD:  estimateCost(raw.Model, raw.Usage.PromptTokens, 0),
+	}
+	for i, d := range raw.Data {
+		out.Vectors[i] = d.Embedding
+	}
+	return out, nil
+}
+
+// post issues a POST with a JSON body and decodes into out. The raw response
+// bytes are also returned so callers can persist them for audit.
+func (c *Client) post(ctx context.Context, path string, body any, out any) ([]byte, error) {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("openai: marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(b))
+	if err != nil {
+		return nil, fmt.Errorf("openai: new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("openai: do: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return raw, fmt.Errorf("%w (status=%d body=%s)", inference.ErrRateLimited, resp.StatusCode, string(truncate(raw)))
+	}
+	if resp.StatusCode/100 != 2 {
+		return raw, fmt.Errorf("openai: %s -> %d: %s", path, resp.StatusCode, string(truncate(raw)))
+	}
+	if out != nil {
+		if err := json.Unmarshal(raw, out); err != nil {
+			return raw, fmt.Errorf("openai: decode: %w", err)
+		}
+	}
+	return raw, nil
+}
+
+func truncate(b []byte) []byte {
+	if len(b) > 1024 {
+		return append(b[:1024:1024], []byte("...")...)
+	}
+	return b
+}
+
+// buildChatRequest converts an inference.Request into the wire shape.
+func buildChatRequest(in inference.Request) (chatRequest, error) {
+	out := chatRequest{
+		Model: in.Model,
+		Stop:  in.Stop,
+		User:  in.User,
+	}
+	if in.Temperature != 0 {
+		t := in.Temperature
+		out.Temperature = &t
+	}
+	if in.TopP != 0 {
+		p := in.TopP
+		out.TopP = &p
+	}
+	if in.MaxTokens != 0 {
+		mt := in.MaxTokens
+		out.MaxTokens = &mt
+	}
+
+	if in.System != "" {
+		out.Messages = append(out.Messages, chatMessage{Role: "system", Content: in.System})
+	}
+	for _, m := range in.Messages {
+		out.Messages = append(out.Messages, convertMessage(m))
+	}
+	if len(out.Messages) == 0 {
+		return chatRequest{}, errors.New("openai: at least one message (or System) is required")
+	}
+
+	for _, t := range in.Tools {
+		if !json.Valid(t.Schema) {
+			return chatRequest{}, fmt.Errorf("openai: tool %q: invalid JSON schema", t.Name)
+		}
+		out.Tools = append(out.Tools, chatTool{
+			Type: "function",
+			Function: chatToolFunc{
+				Name:        t.Name,
+				Description: t.Description,
+				Parameters:  json.RawMessage(t.Schema),
+			},
+		})
+	}
+
+	if in.JSONSchema != nil {
+		if !json.Valid(in.JSONSchema.JSON) {
+			return chatRequest{}, errors.New("openai: JSONSchema.JSON is not valid JSON")
+		}
+		out.ResponseFormat = &responseFmt{
+			Type: "json_schema",
+			JSONSchema: &responseFmtSchema{
+				Name:        in.JSONSchema.Name,
+				Description: in.JSONSchema.Description,
+				Schema:      json.RawMessage(in.JSONSchema.JSON),
+				Strict:      in.JSONSchema.Strict,
+			},
+		}
+	}
+	return out, nil
+}
+
+func convertMessage(m inference.Message) chatMessage {
+	out := chatMessage{
+		Role:       string(m.Role),
+		Content:    m.Content,
+		Name:       m.Name,
+		ToolCallID: m.ToolCallID,
+	}
+	for _, tc := range m.ToolCalls {
+		out.ToolCalls = append(out.ToolCalls, chatToolCall{
+			ID:   tc.ID,
+			Type: "function",
+			Function: struct {
+				Name      string `json:"name"`
+				Arguments string `json:"arguments"`
+			}{Name: tc.Name, Arguments: tc.Arguments},
+		})
+	}
+	return out
+}

--- a/internal/inference/openai/client_test.go
+++ b/internal/inference/openai/client_test.go
@@ -1,0 +1,207 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/teslashibe/permafrost/internal/inference"
+)
+
+func newServer(t *testing.T, h http.HandlerFunc) (*httptest.Server, *Client) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	c, err := New(Config{Name: "test", BaseURL: srv.URL, APIKey: "sk-test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv, c
+}
+
+func TestComplete_HappyPath(t *testing.T) {
+	_, c := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer sk-test" {
+			t.Errorf("auth: %s", got)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var got chatRequest
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("decode: %v body=%s", err, body)
+		}
+		if got.Model != "gpt-4o" {
+			t.Errorf("model: %s", got.Model)
+		}
+		if len(got.Messages) != 2 {
+			t.Errorf("messages: %d", len(got.Messages))
+		}
+		if got.Messages[0].Role != "system" || got.Messages[1].Role != "user" {
+			t.Errorf("roles: %+v", got.Messages)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":      "chatcmpl-1",
+			"model":   "gpt-4o",
+			"created": 0,
+			"choices": []map[string]any{{
+				"index": 0,
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": "hi there",
+				},
+				"finish_reason": "stop",
+			}},
+			"usage": map[string]any{
+				"prompt_tokens":     10,
+				"completion_tokens": 5,
+				"total_tokens":      15,
+			},
+		})
+	})
+
+	resp, err := c.Complete(context.Background(), inference.Request{
+		Model:  "gpt-4o",
+		System: "you are helpful",
+		Messages: []inference.Message{
+			{Role: inference.RoleUser, Content: "hello"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Content != "hi there" {
+		t.Errorf("Content: %q", resp.Content)
+	}
+	if resp.TokensIn != 10 || resp.TokensOut != 5 {
+		t.Errorf("tokens: in=%d out=%d", resp.TokensIn, resp.TokensOut)
+	}
+	if resp.Provider != "test" {
+		t.Errorf("Provider: %q", resp.Provider)
+	}
+	if resp.CostUSD == 0 {
+		t.Errorf("CostUSD: gpt-4o should have a non-zero estimate, got %f", resp.CostUSD)
+	}
+	if len(resp.Raw) == 0 {
+		t.Errorf("Raw should be populated")
+	}
+}
+
+func TestComplete_ToolCalls(t *testing.T) {
+	_, c := newServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"model": "gpt-4o",
+			"choices": []map[string]any{{
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": "",
+					"tool_calls": []map[string]any{{
+						"id":   "call_1",
+						"type": "function",
+						"function": map[string]any{
+							"name":      "get_funding",
+							"arguments": `{"coin":"WIF"}`,
+						},
+					}},
+				},
+				"finish_reason": "tool_calls",
+			}},
+		})
+	})
+	resp, err := c.Complete(context.Background(), inference.Request{
+		Model: "gpt-4o", Messages: []inference.Message{{Role: inference.RoleUser, Content: "x"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.ToolCalls) != 1 || resp.ToolCalls[0].Name != "get_funding" {
+		t.Errorf("ToolCalls: %+v", resp.ToolCalls)
+	}
+	if resp.FinishReason != "tool_calls" {
+		t.Errorf("FinishReason: %q", resp.FinishReason)
+	}
+}
+
+func TestComplete_RateLimited(t *testing.T) {
+	_, c := newServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"slow down"}}`))
+	})
+	_, err := c.Complete(context.Background(), inference.Request{
+		Model: "gpt-4o", System: "x",
+	})
+	if !errors.Is(err, inference.ErrRateLimited) {
+		t.Fatalf("expected ErrRateLimited, got %v", err)
+	}
+}
+
+func TestComplete_APIError(t *testing.T) {
+	_, c := newServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"message": "model not found"},
+		})
+	})
+	_, err := c.Complete(context.Background(), inference.Request{
+		Model: "gpt-4o", System: "x",
+	})
+	if err == nil || !strings.Contains(err.Error(), "model not found") {
+		t.Fatalf("expected error with API message, got %v", err)
+	}
+}
+
+func TestComplete_RequiresMessage(t *testing.T) {
+	c, _ := New(Config{BaseURL: "http://localhost"})
+	_, err := c.Complete(context.Background(), inference.Request{Model: "x"})
+	if err == nil {
+		t.Fatal("expected error for empty messages")
+	}
+}
+
+func TestEmbed_HappyPath(t *testing.T) {
+	_, c := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/embeddings" {
+			t.Errorf("path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"model": "text-embedding-3-small",
+			"data": []map[string]any{
+				{"embedding": []float32{0.1, 0.2}, "index": 0},
+				{"embedding": []float32{0.3, 0.4}, "index": 1},
+			},
+			"usage": map[string]any{"prompt_tokens": 4, "total_tokens": 4},
+		})
+	})
+	resp, err := c.Embed(context.Background(), inference.EmbedRequest{
+		Model: "text-embedding-3-small",
+		Input: []string{"a", "b"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Vectors) != 2 || resp.Vectors[0][0] != 0.1 {
+		t.Errorf("vectors: %+v", resp.Vectors)
+	}
+	if resp.TokensIn != 4 {
+		t.Errorf("TokensIn: %d", resp.TokensIn)
+	}
+}
+
+func TestPricing_KnownAndUnknown(t *testing.T) {
+	if got := estimateCost("gpt-4o", 1_000_000, 1_000_000); got <= 0 {
+		t.Errorf("known model should cost > 0, got %f", got)
+	}
+	if got := estimateCost("anthropic/claude-sonnet-4.5", 1_000_000, 0); got != 3.0 {
+		t.Errorf("suffix match should cost 3.0, got %f", got)
+	}
+	if got := estimateCost("totally-made-up-model", 100, 100); got != 0 {
+		t.Errorf("unknown model should cost 0, got %f", got)
+	}
+}

--- a/internal/inference/openai/factory.go
+++ b/internal/inference/openai/factory.go
@@ -1,0 +1,14 @@
+package openai
+
+import "github.com/teslashibe/permafrost/internal/inference"
+
+// NewProvider adapts Client to the inference.ProviderFactory signature so it
+// can be passed to inference.NewRegistry without creating an import cycle.
+func NewProvider(cfg inference.ProviderConfig) (inference.Provider, error) {
+	return New(Config{
+		Name:    cfg.Name,
+		BaseURL: cfg.BaseURL,
+		APIKey:  cfg.APIKey,
+		Timeout: cfg.Timeout,
+	})
+}

--- a/internal/inference/openai/pricing.go
+++ b/internal/inference/openai/pricing.go
@@ -1,0 +1,66 @@
+package openai
+
+import "strings"
+
+// modelPrice describes per-million-token pricing in USD.
+type modelPrice struct {
+	InputPerM  float64
+	OutputPerM float64
+}
+
+// pricing is a best-effort lookup table for common models. Unknown models
+// return (0, 0) and CostUSD will be reported as 0.
+//
+// Provider-specific routing (e.g. OpenRouter) often passes through the
+// upstream model name; we match on the most-specific suffix first. Numbers
+// are illustrative defaults; operators should override via their own
+// pricing source for accurate accounting.
+var pricing = map[string]modelPrice{
+	// OpenAI
+	"gpt-5":              {InputPerM: 5.00, OutputPerM: 15.00},
+	"gpt-5-mini":         {InputPerM: 0.25, OutputPerM: 1.00},
+	"gpt-4o":             {InputPerM: 2.50, OutputPerM: 10.00},
+	"gpt-4o-mini":        {InputPerM: 0.15, OutputPerM: 0.60},
+	"o3":                 {InputPerM: 2.00, OutputPerM: 8.00},
+	"o3-mini":            {InputPerM: 1.10, OutputPerM: 4.40},
+	"text-embedding-3-small": {InputPerM: 0.02},
+	"text-embedding-3-large": {InputPerM: 0.13},
+
+	// Anthropic via OpenRouter / native
+	"claude-sonnet-4.5":     {InputPerM: 3.00, OutputPerM: 15.00},
+	"claude-opus-4.1":       {InputPerM: 15.00, OutputPerM: 75.00},
+	"claude-3.7-sonnet":     {InputPerM: 3.00, OutputPerM: 15.00},
+	"claude-3.5-sonnet":     {InputPerM: 3.00, OutputPerM: 15.00},
+	"claude-3.5-haiku":      {InputPerM: 0.80, OutputPerM: 4.00},
+
+	// Google
+	"gemini-2.5-pro":  {InputPerM: 1.25, OutputPerM: 10.00},
+	"gemini-2.5-flash": {InputPerM: 0.30, OutputPerM: 2.50},
+
+	// Open / hosted-OSS (typical Groq/Together pricing)
+	"llama-3.1-70b": {InputPerM: 0.59, OutputPerM: 0.79},
+	"llama-3.1-8b":  {InputPerM: 0.05, OutputPerM: 0.08},
+	"deepseek-chat": {InputPerM: 0.27, OutputPerM: 1.10},
+
+	// Local (Ollama, vLLM, LM Studio): zero by definition
+	"local": {InputPerM: 0, OutputPerM: 0},
+}
+
+// estimateCost computes a USD cost from token usage and a model name.
+// Returns 0 if the model is unknown. Matching is suffix-based to handle
+// provider prefixes like "anthropic/claude-sonnet-4.5".
+func estimateCost(model string, in, out int) float64 {
+	if p, ok := pricing[model]; ok {
+		return cost(p, in, out)
+	}
+	for k, p := range pricing {
+		if strings.HasSuffix(model, k) {
+			return cost(p, in, out)
+		}
+	}
+	return 0
+}
+
+func cost(p modelPrice, in, out int) float64 {
+	return float64(in)/1_000_000*p.InputPerM + float64(out)/1_000_000*p.OutputPerM
+}


### PR DESCRIPTION
## Milestone
**M3 — Inference.** Single OpenAI-compatible client. One implementation serves OpenAI, OpenRouter, Groq, Together, Fireworks, vLLM, Ollama, LM Studio — anything that speaks the OpenAI Chat Completions schema.

> Stacked on top of #3 (M2). Diff against \`main\` will shrink to just M3 once #1, #2, and #3 merge.

## What's in
**Config**
- \`InferenceConfig\` — \`default\` + \`providers: { name -> { base_url, api_key/api_key_env, request_timeout_secs } }\`.
- \`config.example.yaml\` updated with openai/openrouter/groq/ollama entries.

**Library**
- \`inference.NewRegistry(cfg, factory)\` — builds a Provider map from config using a caller-supplied \`ProviderFactory\`. Avoids an import cycle while keeping the openai package importable from CLI.
- \`internal/inference/openai/client.go\` — \`Complete\` + \`Embed\` against \`/chat/completions\` and \`/embeddings\`. Bearer auth, JSON-schema response_format, function tools, \`ErrRateLimited\` mapping for HTTP 429, latency capture, raw-body preservation for audit.
- \`internal/inference/openai/pricing.go\` — best-effort per-million-token costing with suffix matching for provider-prefixed model names (e.g. \`anthropic/claude-sonnet-4.5\`). Unknown models cost \`0\`.

**CLI**
- \`permafrost inference list\` — configured providers (default marked).
- \`permafrost inference test --model X [--provider Y] [--prompt ...]\` — one-shot completion; prints provider, model, finish reason, latency, tokens, cost, content.
- \`root.go\` exposes \`addCommandFactory\` so each milestone's CLI file self-registers without editing root.

## Tests
- **openai**: happy path with auth header, request shape, response decoding, tool-call extraction; 429 → \`ErrRateLimited\`; error envelope; missing-message validation; embed round-trip; pricing estimator (known, suffix, unknown-zero).
- **registry**: env-backed and direct API keys, default selection, missing-default error, missing-base_url error, factory error propagation, timeout default applied.

## Verify locally
\`\`\`
go test ./internal/inference/... -race -count=1 -v
go run ./cmd/permafrost --help     # 'inference' subcommand visible
\`\`\`

## Out of scope (next PRs)
- Encrypted local keystore + Solana/HL signers → **PR #5 (M4)**
- Wiring inference cost into the \`inference_calls\` hypertable → comes with M8 (agent runtime persistence)