### PR TITLE
feat(m6): asset registry — curated YAML, embedded loader, DB sync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,4 +63,5 @@ require (
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/assets/embed.go
+++ b/internal/assets/embed.go
@@ -1,0 +1,25 @@
+package assets
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+)
+
+//go:embed registry.yaml
+var embeddedYAML []byte
+
+// EmbeddedYAML returns the raw bytes of the embedded registry.
+func EmbeddedYAML() []byte {
+	out := make([]byte, len(embeddedYAML))
+	copy(out, embeddedYAML)
+	return out
+}
+
+func mustEmbed() Registry {
+	r, err := Parse(bytes.NewReader(embeddedYAML))
+	if err != nil {
+		panic(fmt.Errorf("permafrost: embedded asset registry is invalid: %w", err))
+	}
+	return r
+}

--- a/internal/assets/registry.go
+++ b/internal/assets/registry.go
@@ -1,0 +1,217 @@
+// Package assets owns the curated asset registry that maps a token to its
+// Hyperliquid perp symbol and Solana spot mint. It is the source of truth
+// for what funding-arb strategies may trade.
+//
+// The registry lives in registry.yaml. It is embedded into the binary so a
+// fresh deployment can boot without an external file; operators may also
+// supply a custom path via Load(path).
+package assets
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// Asset is one fully-resolved registry entry.
+type Asset struct {
+	Symbol     string
+	Perp       *PerpRef
+	Spot       SpotRef
+	HedgeRatio float64
+	Notes      string
+}
+
+// PerpRef points at a Hyperliquid perp symbol. nil for assets that are
+// quote-only (e.g. USDC).
+type PerpRef struct {
+	Venue  string
+	Symbol string
+}
+
+// SpotRef points at a chain-bound mint.
+type SpotRef struct {
+	Chain    types.ChainID
+	Mint     string
+	Decimals int32
+}
+
+// Tradable reports whether the asset has both legs (perp + spot) configured
+// and is therefore eligible for basis trading.
+func (a Asset) Tradable() bool {
+	return a.Perp != nil && a.Spot.Mint != ""
+}
+
+// AsAsset returns the Spot leg as a types.Asset for use with SwapVenue.
+func (a Asset) AsAsset() types.Asset {
+	return types.Asset{
+		Symbol:   a.Symbol,
+		Chain:    a.Spot.Chain,
+		Mint:     a.Spot.Mint,
+		Decimals: a.Spot.Decimals,
+	}
+}
+
+// Registry holds the parsed asset list. Safe to share by value (read-only).
+type Registry struct {
+	Version int
+	Defaults Defaults
+	Assets  []Asset
+
+	bySymbol map[string]Asset
+}
+
+// Defaults are global defaults applied when an asset entry omits a field.
+type Defaults struct {
+	HedgeRatio float64
+}
+
+// Get returns the asset for a symbol, or false if not present.
+func (r Registry) Get(symbol string) (Asset, bool) {
+	a, ok := r.bySymbol[strings.ToUpper(symbol)]
+	return a, ok
+}
+
+// Tradable returns the subset of assets that have both perp and spot legs
+// configured (the universe a funding-arb strategy may consider).
+func (r Registry) Tradable() []Asset {
+	out := make([]Asset, 0, len(r.Assets))
+	for _, a := range r.Assets {
+		if a.Tradable() {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+// Symbols returns all symbols (sorted).
+func (r Registry) Symbols() []string {
+	out := make([]string, 0, len(r.Assets))
+	for _, a := range r.Assets {
+		out = append(out, a.Symbol)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ─── loading ────────────────────────────────────────────────────────────────
+
+// rawFile mirrors the YAML schema 1:1.
+type rawFile struct {
+	Version  int      `yaml:"version"`
+	Defaults rawDefaults `yaml:"defaults"`
+	Assets   []rawAsset  `yaml:"assets"`
+}
+
+type rawDefaults struct {
+	HedgeRatio float64 `yaml:"hedge_ratio"`
+}
+
+type rawAsset struct {
+	Symbol     string  `yaml:"symbol"`
+	HedgeRatio float64 `yaml:"hedge_ratio"`
+	Notes      string  `yaml:"notes"`
+	Perp       *struct {
+		Venue  string `yaml:"venue"`
+		Symbol string `yaml:"symbol"`
+	} `yaml:"perp,omitempty"`
+	Spot struct {
+		Chain    string `yaml:"chain"`
+		Mint     string `yaml:"mint"`
+		Decimals int32  `yaml:"decimals"`
+	} `yaml:"spot"`
+}
+
+// Embedded copy of the curated registry shipped with the binary.
+//
+//go:generate go run ./internal/assets/cmd/embed
+//
+//revive:disable-next-line:line-length-limit
+var Embedded = mustEmbed()
+
+// LoadEmbedded returns the embedded registry.
+func LoadEmbedded() (Registry, error) { return Embedded, nil }
+
+// Load reads a registry from the given filesystem path.
+func Load(path string) (Registry, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return Registry{}, fmt.Errorf("assets: open %s: %w", path, err)
+	}
+	defer f.Close()
+	return Parse(f)
+}
+
+// Parse reads a registry from any YAML reader.
+func Parse(r io.Reader) (Registry, error) {
+	var raw rawFile
+	dec := yaml.NewDecoder(r)
+	dec.KnownFields(true)
+	if err := dec.Decode(&raw); err != nil {
+		return Registry{}, fmt.Errorf("assets: parse: %w", err)
+	}
+	return validate(raw)
+}
+
+func validate(raw rawFile) (Registry, error) {
+	if raw.Version != 1 {
+		return Registry{}, fmt.Errorf("assets: unsupported version %d (want 1)", raw.Version)
+	}
+	out := Registry{
+		Version: raw.Version,
+		Defaults: Defaults{HedgeRatio: raw.Defaults.HedgeRatio},
+		bySymbol: make(map[string]Asset, len(raw.Assets)),
+	}
+	if out.Defaults.HedgeRatio == 0 {
+		out.Defaults.HedgeRatio = 1.0
+	}
+	for i, ra := range raw.Assets {
+		if ra.Symbol == "" {
+			return Registry{}, fmt.Errorf("assets[%d]: missing symbol", i)
+		}
+		key := strings.ToUpper(ra.Symbol)
+		if _, dup := out.bySymbol[key]; dup {
+			return Registry{}, fmt.Errorf("assets[%d]: duplicate symbol %q", i, ra.Symbol)
+		}
+		if ra.Spot.Mint == "" {
+			return Registry{}, fmt.Errorf("assets[%s]: missing spot.mint", ra.Symbol)
+		}
+		if ra.Spot.Chain == "" {
+			return Registry{}, fmt.Errorf("assets[%s]: missing spot.chain", ra.Symbol)
+		}
+		if ra.Spot.Decimals < 0 || ra.Spot.Decimals > 30 {
+			return Registry{}, fmt.Errorf("assets[%s]: spot.decimals out of range: %d", ra.Symbol, ra.Spot.Decimals)
+		}
+		hr := ra.HedgeRatio
+		if hr == 0 {
+			hr = out.Defaults.HedgeRatio
+		}
+		var perp *PerpRef
+		if ra.Perp != nil {
+			if ra.Perp.Venue == "" || ra.Perp.Symbol == "" {
+				return Registry{}, fmt.Errorf("assets[%s]: perp requires venue + symbol", ra.Symbol)
+			}
+			perp = &PerpRef{Venue: ra.Perp.Venue, Symbol: ra.Perp.Symbol}
+		}
+		a := Asset{
+			Symbol:     ra.Symbol,
+			Perp:       perp,
+			Spot:       SpotRef{Chain: types.ChainID(ra.Spot.Chain), Mint: ra.Spot.Mint, Decimals: ra.Spot.Decimals},
+			HedgeRatio: hr,
+			Notes:      ra.Notes,
+		}
+		out.Assets = append(out.Assets, a)
+		out.bySymbol[key] = a
+	}
+	if len(out.Assets) == 0 {
+		return Registry{}, errors.New("assets: registry is empty")
+	}
+	return out, nil
+}

--- a/internal/assets/registry.yaml
+++ b/internal/assets/registry.yaml
@@ -1,0 +1,104 @@
+# Permafrost asset registry — curated mapping between Hyperliquid perp
+# symbols and Solana spot mints used by funding-arb strategies.
+#
+# Entries here are the SOURCE OF TRUTH for what `funding_arb_basic` may
+# trade. Adding an entry here makes that token tradable; removing it stops
+# new positions (existing positions still unwind normally).
+#
+# Operators MUST verify each spot.mint against on-chain records (Solscan,
+# Jupiter token list) before going live. A wrong mint will result in trading
+# the wrong token. The mints below are the publicly-known production mints
+# at the time of writing; they do not change, but verify before trusting.
+
+version: 1
+defaults:
+  hedge_ratio: 1.0       # 1:1 notional matching by default
+
+assets:
+  # Quote currency. No perp; included so the loader knows about its decimals.
+  - symbol: USDC
+    spot:
+      chain: solana
+      mint: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+      decimals: 6
+    notes: Quote currency. Native USDC on Solana.
+
+  - symbol: WIF
+    perp:
+      venue: hyperliquid
+      symbol: WIF
+    spot:
+      chain: solana
+      mint: EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYLDKSHhX2P
+      decimals: 6
+    notes: dogwifhat. Solana native; deep liquidity on Raydium + Orca.
+
+  - symbol: BONK
+    perp:
+      venue: hyperliquid
+      symbol: BONK
+    spot:
+      chain: solana
+      mint: DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263
+      decimals: 5
+    notes: BONK. High velocity, frequent funding spikes.
+
+  - symbol: POPCAT
+    perp:
+      venue: hyperliquid
+      symbol: POPCAT
+    spot:
+      chain: solana
+      mint: 7GCihgDB8fe6KNjn2MYtkzZcRjQy3t9GHdC8uHYmW2hr
+      decimals: 9
+    notes: POPCAT (SOL).
+
+  - symbol: PNUT
+    perp:
+      venue: hyperliquid
+      symbol: PNUT
+    spot:
+      chain: solana
+      mint: 2qEHjDLDLbuBgRYvsxhc5D6uDWAivNFZGan56P1tpump
+      decimals: 6
+    notes: Peanut the Squirrel.
+
+  - symbol: GOAT
+    perp:
+      venue: hyperliquid
+      symbol: GOAT
+    spot:
+      chain: solana
+      mint: CzLSujWBLFsSjncfkh59rUFqvafWcY5tzedWJSuypump
+      decimals: 6
+    notes: Goatseus Maximus.
+
+  - symbol: FARTCOIN
+    perp:
+      venue: hyperliquid
+      symbol: FARTCOIN
+    spot:
+      chain: solana
+      mint: 9BB6NFEcjBCtnNLFko2FqVQBq8HHM13kCyYcdQbgpump
+      decimals: 6
+    notes: Fartcoin.
+
+  - symbol: MOODENG
+    perp:
+      venue: hyperliquid
+      symbol: MOODENG
+    spot:
+      chain: solana
+      mint: ED5nyyWEzpPPiWimP8vYm7sD7TD3LAt3Q3gRTWHzPJBY
+      decimals: 6
+    notes: Moo Deng (the hippo).
+
+  - symbol: CHILLGUY
+    perp:
+      venue: hyperliquid
+      symbol: CHILLGUY
+    spot:
+      chain: solana
+      mint: Df6yfrKC8kZE3KNkrHERKzAetSxbrWeniQfyJY4Jpump
+      decimals: 6
+    notes: Just a chill guy.

--- a/internal/assets/registry_test.go
+++ b/internal/assets/registry_test.go
@@ -1,0 +1,166 @@
+package assets
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+func TestEmbedded_Loads(t *testing.T) {
+	r, err := LoadEmbedded()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Assets) == 0 {
+		t.Fatal("embedded registry is empty")
+	}
+	if got, _ := r.Get("USDC"); got.Symbol != "USDC" {
+		t.Errorf("USDC missing or mis-loaded: %+v", got)
+	}
+	wif, ok := r.Get("WIF")
+	if !ok || wif.Perp == nil || wif.Perp.Symbol != "WIF" {
+		t.Errorf("WIF missing or perp not populated: %+v", wif)
+	}
+	if !wif.Tradable() {
+		t.Errorf("WIF should be tradable")
+	}
+	usdc, _ := r.Get("USDC")
+	if usdc.Tradable() {
+		t.Errorf("USDC should not be tradable (no perp)")
+	}
+}
+
+func TestEmbedded_TradableList(t *testing.T) {
+	r, _ := LoadEmbedded()
+	got := r.Tradable()
+	if len(got) < 5 {
+		t.Errorf("expected at least 5 tradable assets, got %d", len(got))
+	}
+	for _, a := range got {
+		if a.Perp == nil || a.Spot.Mint == "" {
+			t.Errorf("Tradable returned non-tradable: %+v", a)
+		}
+	}
+}
+
+func TestEmbedded_AsAsset(t *testing.T) {
+	r, _ := LoadEmbedded()
+	wif, _ := r.Get("WIF")
+	a := wif.AsAsset()
+	if a.Chain != types.ChainSolana {
+		t.Errorf("AsAsset chain: %q", a.Chain)
+	}
+	if a.Mint == "" || a.Decimals == 0 {
+		t.Errorf("AsAsset incomplete: %+v", a)
+	}
+}
+
+func TestParse_Validations(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			"version unsupported",
+			`version: 99
+defaults: {}
+assets: []`,
+			"unsupported version",
+		},
+		{
+			"missing symbol",
+			`version: 1
+assets:
+  - spot: {chain: solana, mint: x, decimals: 6}`,
+			"missing symbol",
+		},
+		{
+			"missing mint",
+			`version: 1
+assets:
+  - symbol: WIF
+    spot: {chain: solana, mint: "", decimals: 6}`,
+			"spot.mint",
+		},
+		{
+			"missing chain",
+			`version: 1
+assets:
+  - symbol: WIF
+    spot: {chain: "", mint: x, decimals: 6}`,
+			"spot.chain",
+		},
+		{
+			"decimals out of range",
+			`version: 1
+assets:
+  - symbol: WIF
+    spot: {chain: solana, mint: x, decimals: 99}`,
+			"out of range",
+		},
+		{
+			"perp missing parts",
+			`version: 1
+assets:
+  - symbol: WIF
+    perp: {venue: hyperliquid, symbol: ""}
+    spot: {chain: solana, mint: x, decimals: 6}`,
+			"perp requires",
+		},
+		{
+			"empty registry",
+			`version: 1
+defaults: {}
+assets: []`,
+			"empty",
+		},
+		{
+			"duplicate symbol",
+			`version: 1
+assets:
+  - symbol: WIF
+    spot: {chain: solana, mint: a, decimals: 6}
+  - symbol: wif
+    spot: {chain: solana, mint: b, decimals: 6}`,
+			"duplicate",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse(strings.NewReader(tc.yaml))
+			if err == nil {
+				t.Fatalf("expected error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestParse_HedgeRatioDefault(t *testing.T) {
+	r, err := Parse(strings.NewReader(`version: 1
+defaults:
+  hedge_ratio: 1.25
+assets:
+  - symbol: WIF
+    perp: {venue: hyperliquid, symbol: WIF}
+    spot: {chain: solana, mint: x, decimals: 6}
+  - symbol: BONK
+    hedge_ratio: 0.5
+    spot: {chain: solana, mint: y, decimals: 5}
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wif, _ := r.Get("WIF")
+	if wif.HedgeRatio != 1.25 {
+		t.Errorf("WIF hedge_ratio default: %v", wif.HedgeRatio)
+	}
+	bonk, _ := r.Get("BONK")
+	if bonk.HedgeRatio != 0.5 {
+		t.Errorf("BONK hedge_ratio override: %v", bonk.HedgeRatio)
+	}
+}

--- a/internal/assets/sync.go
+++ b/internal/assets/sync.go
@@ -1,0 +1,56 @@
+package assets
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Sync reconciles the assets table with the supplied Registry. It performs
+// an upsert per row (no deletes), since removing an entry from registry.yaml
+// while live positions reference it would orphan accounting.
+//
+// Returns the number of rows inserted/updated.
+func Sync(ctx context.Context, pool *pgxpool.Pool, r Registry) (int, error) {
+	tx, err := pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return 0, fmt.Errorf("assets: begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // best-effort cleanup
+
+	const stmt = `
+INSERT INTO assets (symbol, perp_venue, perp_symbol, spot_chain, spot_mint, spot_decimals, hedge_ratio, notes, updated_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now())
+ON CONFLICT (symbol) DO UPDATE
+SET perp_venue    = EXCLUDED.perp_venue,
+    perp_symbol   = EXCLUDED.perp_symbol,
+    spot_chain    = EXCLUDED.spot_chain,
+    spot_mint     = EXCLUDED.spot_mint,
+    spot_decimals = EXCLUDED.spot_decimals,
+    hedge_ratio   = EXCLUDED.hedge_ratio,
+    notes         = EXCLUDED.notes,
+    updated_at    = now();
+`
+	count := 0
+	for _, a := range r.Assets {
+		var perpVenue, perpSymbol any
+		if a.Perp != nil {
+			perpVenue = a.Perp.Venue
+			perpSymbol = a.Perp.Symbol
+		}
+		if _, err := tx.Exec(ctx, stmt,
+			a.Symbol, perpVenue, perpSymbol,
+			string(a.Spot.Chain), a.Spot.Mint, a.Spot.Decimals,
+			a.HedgeRatio, a.Notes,
+		); err != nil {
+			return 0, fmt.Errorf("assets: upsert %s: %w", a.Symbol, err)
+		}
+		count++
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("assets: commit: %w", err)
+	}
+	return count, nil
+}

--- a/internal/cli/assets.go
+++ b/internal/cli/assets.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/teslashibe/permafrost/internal/assets"
+	"github.com/teslashibe/permafrost/internal/store"
+)
+
+func init() { addCommandFactory(newAssetsCmd) }
+
+func newAssetsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "assets",
+		Short: "Inspect and synchronise the asset registry",
+	}
+	cmd.AddCommand(newAssetsListCmd(), newAssetsSyncCmd())
+	return cmd
+}
+
+func newAssetsListCmd() *cobra.Command {
+	var path string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Print all entries in the curated asset registry",
+		RunE: func(c *cobra.Command, _ []string) error {
+			r, err := loadRegistry(path)
+			if err != nil {
+				return err
+			}
+			tw := tabwriter.NewWriter(cmdOut(c), 0, 0, 2, ' ', 0)
+			fmt.Fprintln(tw, "SYMBOL\tPERP\tCHAIN\tMINT\tDECIMALS\tTRADABLE")
+			for _, a := range r.Assets {
+				perp := "-"
+				if a.Perp != nil {
+					perp = a.Perp.Venue + ":" + a.Perp.Symbol
+				}
+				tradable := "no"
+				if a.Tradable() {
+					tradable = "yes"
+				}
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%s\n",
+					a.Symbol, perp, a.Spot.Chain, truncMint(a.Spot.Mint), a.Spot.Decimals, tradable)
+			}
+			return tw.Flush()
+		},
+	}
+	cmd.Flags().StringVar(&path, "file", "", "registry YAML path (default: embedded)")
+	return cmd
+}
+
+func newAssetsSyncCmd() *cobra.Command {
+	var path string
+	cmd := &cobra.Command{
+		Use:   "sync",
+		Short: "Upsert the asset registry into the database",
+		RunE: func(c *cobra.Command, _ []string) error {
+			g := FromContext(c.Context())
+			if g == nil {
+				return errors.New("globals not initialised")
+			}
+			r, err := loadRegistry(path)
+			if err != nil {
+				return err
+			}
+			db, err := store.Open(c.Context(), g.Config.Database)
+			if err != nil {
+				return fmt.Errorf("open db: %w", err)
+			}
+			defer db.Close()
+			n, err := assets.Sync(c.Context(), db.Pool, r)
+			if err != nil {
+				return err
+			}
+			g.Log.Info("assets synced", "rows", n)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&path, "file", "", "registry YAML path (default: embedded)")
+	return cmd
+}
+
+func loadRegistry(path string) (assets.Registry, error) {
+	if path == "" {
+		return assets.LoadEmbedded()
+	}
+	return assets.Load(path)
+}
+
+func truncMint(s string) string {
+	if len(s) <= 14 {
+		return s
+	}
+	return s[:6] + "…" + s[len(s)-4:]
+}
+
+// cmdOut returns the cobra command's stdout (or os.Stdout). Split out so
+// future tests can capture output by injecting a buffer.
+func cmdOut(c *cobra.Command) (out interface {
+	Write(p []byte) (n int, err error)
+}) {
+	return c.OutOrStdout()
+}

--- a/internal/store/migrations/0002_assets_and_wallets.sql
+++ b/internal/store/migrations/0002_assets_and_wallets.sql
@@ -1,0 +1,39 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Assets — synced from internal/assets/registry.yaml on startup or via
+-- `permafrost assets sync`. Symbol is the canonical name (e.g. "WIF").
+CREATE TABLE IF NOT EXISTS assets (
+    symbol            text PRIMARY KEY,
+    perp_venue        text,                         -- NULL if quote-only (e.g. USDC)
+    perp_symbol       text,
+    spot_chain        text NOT NULL,
+    spot_mint         text NOT NULL,
+    spot_decimals     int  NOT NULL CHECK (spot_decimals >= 0 AND spot_decimals <= 30),
+    hedge_ratio       numeric(10,4) NOT NULL DEFAULT 1.0,
+    notes             text,
+    updated_at        timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (spot_chain, spot_mint)
+);
+
+CREATE INDEX IF NOT EXISTS assets_perp_idx ON assets (perp_venue, perp_symbol)
+    WHERE perp_venue IS NOT NULL;
+
+-- Wallets — operator-controlled signing addresses, populated by the wallet
+-- package. Address book; NEVER stores keys.
+CREATE TABLE IF NOT EXISTS wallets (
+    id          bigserial PRIMARY KEY,
+    chain       text NOT NULL,
+    address     text NOT NULL,
+    label       text,
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (chain, address)
+);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS wallets;
+DROP TABLE IF EXISTS assets;
+-- +goose StatementEnd


### PR DESCRIPTION
## Milestone
**M6 — Asset registry.** The source-of-truth mapping from a token to its Hyperliquid perp symbol and its Solana spot mint. Strategies consult the registry to know what they may trade and how to execute the spot leg.

> Stacked on top of #6 (M5).

## What's in
**Registry**
- \`internal/assets/registry.yaml\` — curated entries for **USDC, WIF, BONK, POPCAT, PNUT, GOAT, FARTCOIN, MOODENG, CHILLGUY**. Documented operator responsibility to verify mints before live trading.
- \`internal/assets/embed.go\` — \`go:embed\`s the YAML; exposes \`EmbeddedYAML()\` and a parsed \`Embedded\` (validated at init).
- \`internal/assets/registry.go\` — \`Asset\` / \`PerpRef\` / \`SpotRef\` / \`Defaults\` / \`Registry\`. Loader supports embedded or external YAML with strict \`KnownFields\` parsing.
- \`internal/assets/sync.go\` — \`Sync(ctx, pool, registry)\` upserts every entry inside one transaction. **No deletes** — removing an entry while live positions reference it would orphan accounting.

**DB** (\`migrations/0002_assets_and_wallets.sql\`)
- \`assets(symbol PK, perp_venue/symbol, spot_chain/mint/decimals, hedge_ratio, notes, updated_at)\` with \`UNIQUE (spot_chain, spot_mint)\` and a partial index on \`(perp_venue, perp_symbol)\`.
- \`wallets(id, chain, address, label, created_at)\` — operator address book, populated by the wallet package; never holds keys.

**CLI**
- \`permafrost assets list [--file PATH]\` — table of symbol / perp / chain / mint (truncated) / decimals / tradable.
- \`permafrost assets sync [--file PATH]\` — applies the registry to the database via \`Sync\`.

## Validations
\`Parse\` rejects: unsupported version, missing symbol, missing mint, missing chain, decimals out of range (0..30), perp leg partial (venue without symbol or vice versa), empty registry, duplicate symbol (case-insensitive).

## Tests
Embedded loads + USDC quote-only + WIF tradable; \`Tradable()\` filters; \`AsAsset()\` returns valid \`types.Asset\`; the full validation matrix; \`HedgeRatio\` default + per-row override.

## Verify locally
\`\`\`
go test ./internal/assets/... -race -count=1 -v
go run ./cmd/permafrost assets list
\`\`\`

## Out of scope (next PRs)
- Vault accounting → **PR #8 (M7)**
- Agent runtime that consumes the registry to size positions → **PR #9 (M8)**