### PR TITLE
feat(m7): vault — accounting, NAV, lockups, allocator

### DIFF
--- a/internal/cli/vault.go
+++ b/internal/cli/vault.go
@@ -1,0 +1,259 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/spf13/cobra"
+
+	"github.com/teslashibe/permafrost/internal/store"
+	"github.com/teslashibe/permafrost/internal/vault"
+)
+
+const defaultVaultName = "permafrost"
+const vaultAsset = "USDC"
+
+func init() { addCommandFactory(newVaultCmd) }
+
+func newVaultCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vault",
+		Short: "Vault accounting (deposits, withdrawals, NAV)",
+	}
+	cmd.AddCommand(
+		newVaultInitCmd(),
+		newVaultDepositCmd(),
+		newVaultWithdrawCmd(),
+		newVaultLockupCmd(),
+		newVaultStatusCmd(),
+		newVaultRecordNAVCmd(),
+		newVaultNAVHistoryCmd(),
+	)
+	return cmd
+}
+
+func openVaultService(c *cobra.Command) (*vault.Service, *store.DB, vault.Vault, error) {
+	g := FromContext(c.Context())
+	if g == nil {
+		return nil, nil, vault.Vault{}, errors.New("globals not initialised")
+	}
+	db, err := store.Open(c.Context(), g.Config.Database)
+	if err != nil {
+		return nil, nil, vault.Vault{}, fmt.Errorf("open db: %w", err)
+	}
+	svc := vault.NewService(db.Pool)
+	v, err := svc.Init(c.Context(), defaultVaultName, vaultAsset)
+	if err != nil {
+		db.Close()
+		return nil, nil, vault.Vault{}, err
+	}
+	return svc, db, v, nil
+}
+
+func newVaultInitCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "init",
+		Short: "Create the default vault if it does not exist",
+		RunE: func(c *cobra.Command, _ []string) error {
+			svc, db, v, err := openVaultService(c)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			_ = svc
+			fmt.Printf("vault id=%d name=%s asset=%s\n", v.ID, v.Name, v.Asset)
+			return nil
+		},
+	}
+}
+
+func newVaultDepositCmd() *cobra.Command {
+	var amount, source, note string
+	cmd := &cobra.Command{
+		Use:   "deposit",
+		Short: "Record a deposit into the vault",
+		RunE: func(c *cobra.Command, _ []string) error {
+			svc, db, v, err := openVaultService(c)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			amt, err := decimal.NewFromString(amount)
+			if err != nil {
+				return fmt.Errorf("amount: %w", err)
+			}
+			d, err := svc.Deposit(c.Context(), v.ID, amt, source, note)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("deposit id=%d amount=%s source=%s\n", d.ID, d.Amount, d.Source)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&amount, "amount", "", "USDC amount (e.g. 10000)")
+	cmd.Flags().StringVar(&source, "source", "manual", "source label")
+	cmd.Flags().StringVar(&note, "note", "", "freeform note")
+	_ = cmd.MarkFlagRequired("amount")
+	return cmd
+}
+
+func newVaultWithdrawCmd() *cobra.Command {
+	var amount, dest, note string
+	cmd := &cobra.Command{
+		Use:   "withdraw",
+		Short: "Record a withdrawal from the vault",
+		RunE: func(c *cobra.Command, _ []string) error {
+			svc, db, v, err := openVaultService(c)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			amt, err := decimal.NewFromString(amount)
+			if err != nil {
+				return err
+			}
+			w, err := svc.Withdraw(c.Context(), v.ID, amt, dest, note)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("withdrawal id=%d amount=%s dest=%s\n", w.ID, w.Amount, w.Destination)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&amount, "amount", "", "USDC amount")
+	cmd.Flags().StringVar(&dest, "dest", "manual", "destination label")
+	cmd.Flags().StringVar(&note, "note", "", "freeform note")
+	_ = cmd.MarkFlagRequired("amount")
+	return cmd
+}
+
+func newVaultLockupCmd() *cobra.Command {
+	var amount, until, note string
+	cmd := &cobra.Command{
+		Use:   "lockup",
+		Short: "Add a time-based lockup against vault capital",
+		RunE: func(c *cobra.Command, _ []string) error {
+			svc, db, v, err := openVaultService(c)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			amt, err := decimal.NewFromString(amount)
+			if err != nil {
+				return err
+			}
+			ts, err := time.Parse(time.RFC3339, until)
+			if err != nil {
+				return fmt.Errorf("--until must be RFC3339 (e.g. 2027-01-01T00:00:00Z): %w", err)
+			}
+			l, err := svc.AddLockup(c.Context(), v.ID, amt, ts, note)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("lockup id=%d amount=%s unlock_at=%s\n", l.ID, l.Amount, l.UnlockAt.Format(time.RFC3339))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&amount, "amount", "", "USDC amount")
+	cmd.Flags().StringVar(&until, "until", "", "unlock time (RFC3339)")
+	cmd.Flags().StringVar(&note, "note", "", "freeform note")
+	_ = cmd.MarkFlagRequired("amount")
+	_ = cmd.MarkFlagRequired("until")
+	return cmd
+}
+
+func newVaultStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show vault summary (deposits, withdrawals, latest NAV)",
+		RunE: func(c *cobra.Command, _ []string) error {
+			svc, db, v, err := openVaultService(c)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			dep, wit, err := svc.LedgerTotals(c.Context(), v.ID)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("vault:        %s (%s)\n", v.Name, v.Asset)
+			fmt.Printf("deposits:     %s\n", dep)
+			fmt.Printf("withdrawals:  %s\n", wit)
+			fmt.Printf("net contrib:  %s\n", dep.Sub(wit))
+			snap, err := svc.LatestNAV(c.Context(), v.ID)
+			if err != nil {
+				fmt.Println("nav:          (no snapshots yet — run `permafrost vault record-nav`)")
+				return nil
+			}
+			fmt.Printf("nav:          %s (cash=%s positions=%s)\n", snap.NAV, snap.Cash, snap.PositionsValue)
+			fmt.Printf("hwm:          %s\n", snap.HighWaterMark)
+			fmt.Printf("return:       %s\n", vault.SimpleReturn(snap))
+			return nil
+		},
+	}
+}
+
+func newVaultRecordNAVCmd() *cobra.Command {
+	var cash, positions string
+	cmd := &cobra.Command{
+		Use:   "record-nav",
+		Short: "Persist a NAV snapshot from supplied cash + positions",
+		Long:  "v1 takes cash and positions value as arguments. The agent runtime will populate these automatically in M8.",
+		RunE: func(c *cobra.Command, _ []string) error {
+			svc, db, v, err := openVaultService(c)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			cv, err := decimal.NewFromString(cash)
+			if err != nil {
+				return fmt.Errorf("cash: %w", err)
+			}
+			pv, err := decimal.NewFromString(positions)
+			if err != nil {
+				return fmt.Errorf("positions: %w", err)
+			}
+			snap, err := svc.RecordNAV(c.Context(), v.ID, cv, pv)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("nav=%s cash=%s pos=%s hwm=%s\n", snap.NAV, snap.Cash, snap.PositionsValue, snap.HighWaterMark)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&cash, "cash", "0", "current cash balance")
+	cmd.Flags().StringVar(&positions, "positions", "0", "current positions value")
+	return cmd
+}
+
+func newVaultNAVHistoryCmd() *cobra.Command {
+	var since string
+	cmd := &cobra.Command{
+		Use:   "nav",
+		Short: "Print recent NAV snapshots",
+		RunE: func(c *cobra.Command, _ []string) error {
+			svc, db, v, err := openVaultService(c)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			dur, err := time.ParseDuration(since)
+			if err != nil {
+				return fmt.Errorf("--since must be a duration (e.g. 24h): %w", err)
+			}
+			rows, err := svc.NAVHistory(c.Context(), v.ID, time.Now().Add(-dur))
+			if err != nil {
+				return err
+			}
+			for _, r := range rows {
+				fmt.Printf("%s  nav=%s  cash=%s  pos=%s\n",
+					r.Time.Format(time.RFC3339), r.NAV, r.Cash, r.PositionsValue)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&since, "since", "168h", "lookback duration (e.g. 24h, 7d→168h)")
+	return cmd
+}

--- a/internal/store/migrations/0003_vault.sql
+++ b/internal/store/migrations/0003_vault.sql
@@ -1,0 +1,70 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Vaults — single-operator MVP normally has exactly one row.
+CREATE TABLE IF NOT EXISTS vaults (
+    id          bigserial PRIMARY KEY,
+    name        text NOT NULL UNIQUE,
+    asset       text NOT NULL,                       -- accounting unit, USDC for v1
+    created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+-- Deposits / Withdrawals are append-only ledger entries.
+CREATE TABLE IF NOT EXISTS deposits (
+    id          bigserial PRIMARY KEY,
+    vault_id    bigint NOT NULL REFERENCES vaults(id),
+    amount      numeric(38,9) NOT NULL CHECK (amount > 0),
+    source      text NOT NULL DEFAULT 'manual',
+    note        text,
+    created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS withdrawals (
+    id          bigserial PRIMARY KEY,
+    vault_id    bigint NOT NULL REFERENCES vaults(id),
+    amount      numeric(38,9) NOT NULL CHECK (amount > 0),
+    destination text NOT NULL DEFAULT 'manual',
+    note        text,
+    created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+-- Lockups freeze a portion of vault capital until unlock_at.
+CREATE TABLE IF NOT EXISTS lockups (
+    id          bigserial PRIMARY KEY,
+    vault_id    bigint NOT NULL REFERENCES vaults(id),
+    amount      numeric(38,9) NOT NULL CHECK (amount > 0),
+    unlock_at   timestamptz NOT NULL,
+    note        text,
+    created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS lockups_vault_unlock_idx ON lockups (vault_id, unlock_at);
+
+-- NAV snapshots — Timescale hypertable, partitioned on time.
+CREATE TABLE IF NOT EXISTS nav_snapshots (
+    time             timestamptz NOT NULL,
+    vault_id         bigint      NOT NULL REFERENCES vaults(id),
+    nav              numeric(38,9) NOT NULL,
+    cash             numeric(38,9) NOT NULL,
+    positions_value  numeric(38,9) NOT NULL,
+    high_water_mark  numeric(38,9) NOT NULL,
+    deposit_total    numeric(38,9) NOT NULL,
+    withdrawal_total numeric(38,9) NOT NULL,
+    PRIMARY KEY (vault_id, time)
+);
+
+SELECT create_hypertable('nav_snapshots', 'time', if_not_exists => TRUE);
+
+CREATE INDEX IF NOT EXISTS nav_snapshots_vault_time_desc_idx
+    ON nav_snapshots (vault_id, time DESC);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS nav_snapshots;
+DROP TABLE IF EXISTS lockups;
+DROP TABLE IF EXISTS withdrawals;
+DROP TABLE IF EXISTS deposits;
+DROP TABLE IF EXISTS vaults;
+-- +goose StatementEnd

--- a/internal/vault/allocator.go
+++ b/internal/vault/allocator.go
@@ -1,0 +1,56 @@
+package vault
+
+import (
+	"errors"
+	"sort"
+
+	"github.com/shopspring/decimal"
+)
+
+// AgentAllocation is one agent's share of vault capital.
+type AgentAllocation struct {
+	AgentID string
+	Weight  decimal.Decimal // 0..1
+	Amount  decimal.Decimal // resolved capital
+}
+
+// AllocatorPolicy decides how to split AvailableCapital across agents.
+type AllocatorPolicy interface {
+	Allocate(available decimal.Decimal, weights map[string]decimal.Decimal) ([]AgentAllocation, error)
+}
+
+// ProportionalPolicy splits available capital pro-rata to weights. Weights
+// are normalised so they sum to 1; an agent with weight 0 gets nothing.
+type ProportionalPolicy struct{}
+
+// Allocate implements AllocatorPolicy.
+func (ProportionalPolicy) Allocate(available decimal.Decimal, weights map[string]decimal.Decimal) ([]AgentAllocation, error) {
+	if available.IsNegative() {
+		return nil, errors.New("vault: available capital is negative")
+	}
+	total := decimal.Zero
+	for _, w := range weights {
+		if w.IsNegative() {
+			return nil, errors.New("vault: negative weight")
+		}
+		total = total.Add(w)
+	}
+	out := make([]AgentAllocation, 0, len(weights))
+	for id, w := range weights {
+		out = append(out, AgentAllocation{
+			AgentID: id,
+			Weight:  w,
+			Amount:  decimal.Zero, // filled below
+		})
+	}
+	// sort for determinism
+	sort.Slice(out, func(i, j int) bool { return out[i].AgentID < out[j].AgentID })
+
+	if total.IsZero() || available.IsZero() {
+		return out, nil
+	}
+	for i := range out {
+		out[i].Amount = available.Mul(out[i].Weight).Div(total)
+	}
+	return out, nil
+}

--- a/internal/vault/allocator_test.go
+++ b/internal/vault/allocator_test.go
@@ -1,0 +1,63 @@
+package vault
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestProportional_BasicSplit(t *testing.T) {
+	p := ProportionalPolicy{}
+	allocs, err := p.Allocate(d("1000"), map[string]decimal.Decimal{
+		"a": d("1"), "b": d("1"), "c": d("2"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(allocs) != 3 {
+		t.Fatalf("got %d allocations", len(allocs))
+	}
+	got := map[string]decimal.Decimal{}
+	for _, a := range allocs {
+		got[a.AgentID] = a.Amount
+	}
+	want := map[string]string{"a": "250", "b": "250", "c": "500"}
+	for k, v := range want {
+		if !got[k].Equal(d(v)) {
+			t.Errorf("%s: got %s want %s", k, got[k], v)
+		}
+	}
+}
+
+func TestProportional_ZeroAvailable(t *testing.T) {
+	p := ProportionalPolicy{}
+	allocs, err := p.Allocate(d("0"), map[string]decimal.Decimal{"a": d("1")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !allocs[0].Amount.IsZero() {
+		t.Errorf("expected zero amount, got %s", allocs[0].Amount)
+	}
+}
+
+func TestProportional_RejectsNegative(t *testing.T) {
+	p := ProportionalPolicy{}
+	if _, err := p.Allocate(d("-1"), map[string]decimal.Decimal{"a": d("1")}); err == nil {
+		t.Error("expected error for negative available")
+	}
+	if _, err := p.Allocate(d("1"), map[string]decimal.Decimal{"a": d("-1")}); err == nil {
+		t.Error("expected error for negative weight")
+	}
+}
+
+func TestProportional_DeterministicOrder(t *testing.T) {
+	p := ProportionalPolicy{}
+	allocs, _ := p.Allocate(d("100"), map[string]decimal.Decimal{
+		"zeta": d("1"), "alpha": d("1"), "mu": d("1"),
+	})
+	for i, want := range []string{"alpha", "mu", "zeta"} {
+		if allocs[i].AgentID != want {
+			t.Errorf("position %d: got %s want %s", i, allocs[i].AgentID, want)
+		}
+	}
+}

--- a/internal/vault/nav.go
+++ b/internal/vault/nav.go
@@ -1,0 +1,60 @@
+package vault
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// ComputeNAV produces a NAVSnapshot from the supplied inputs. NAV is simply
+// cash + positions value; the high-water mark is the running maximum.
+//
+// This function is pure and stateless to keep tests trivial; the database
+// layer in service.go wraps it.
+func ComputeNAV(now time.Time, vaultID int64, in NAVInputs) NAVSnapshot {
+	nav := in.Cash.Add(in.PositionsValue)
+	hwm := in.PrevHWM
+	if nav.GreaterThan(hwm) {
+		hwm = nav
+	}
+	return NAVSnapshot{
+		Time:            now,
+		VaultID:         vaultID,
+		NAV:             nav,
+		Cash:            in.Cash,
+		PositionsValue:  in.PositionsValue,
+		HighWaterMark:   hwm,
+		DepositTotal:    in.DepositTotal,
+		WithdrawalTotal: in.WithdrawalTotal,
+	}
+}
+
+// AvailableCapital returns the cash that is not currently locked.
+//
+// Lockups are applied by amount: if total lockups exceed cash, the excess is
+// considered to be locked in positions and is not available for new
+// allocations.
+func AvailableCapital(cash decimal.Decimal, lockups []Lockup, now time.Time) decimal.Decimal {
+	locked := decimal.Zero
+	for _, l := range lockups {
+		if l.IsActive(now) {
+			locked = locked.Add(l.Amount)
+		}
+	}
+	available := cash.Sub(locked)
+	if available.IsNegative() {
+		return decimal.Zero
+	}
+	return available
+}
+
+// SimpleReturn returns NAV / (deposits - withdrawals) - 1 — the all-time
+// total return on net contributed capital. Returns zero if no capital was
+// contributed.
+func SimpleReturn(s NAVSnapshot) decimal.Decimal {
+	contributed := s.DepositTotal.Sub(s.WithdrawalTotal)
+	if contributed.IsZero() || contributed.IsNegative() {
+		return decimal.Zero
+	}
+	return s.NAV.Div(contributed).Sub(decimal.NewFromInt(1))
+}

--- a/internal/vault/nav_test.go
+++ b/internal/vault/nav_test.go
@@ -1,0 +1,109 @@
+package vault
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+func d(s string) decimal.Decimal { return decimal.RequireFromString(s) }
+
+func TestComputeNAV_HWMTakesMax(t *testing.T) {
+	t0 := time.Now()
+	cases := []struct {
+		name    string
+		in      NAVInputs
+		wantNAV string
+		wantHWM string
+	}{
+		{
+			"new high",
+			NAVInputs{Cash: d("1000"), PositionsValue: d("100"), PrevHWM: d("900")},
+			"1100", "1100",
+		},
+		{
+			"under high",
+			NAVInputs{Cash: d("800"), PositionsValue: d("100"), PrevHWM: d("1100")},
+			"900", "1100",
+		},
+		{
+			"first ever",
+			NAVInputs{Cash: d("500"), PositionsValue: d("0"), PrevHWM: d("0")},
+			"500", "500",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ComputeNAV(t0, 1, c.in)
+			if !got.NAV.Equal(d(c.wantNAV)) {
+				t.Errorf("NAV: got %s want %s", got.NAV, c.wantNAV)
+			}
+			if !got.HighWaterMark.Equal(d(c.wantHWM)) {
+				t.Errorf("HWM: got %s want %s", got.HighWaterMark, c.wantHWM)
+			}
+		})
+	}
+}
+
+func TestAvailableCapital(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name    string
+		cash    string
+		lockups []Lockup
+		want    string
+	}{
+		{"no lockups", "1000", nil, "1000"},
+		{
+			"single active lockup",
+			"1000",
+			[]Lockup{{Amount: d("300"), UnlockAt: now.Add(time.Hour)}},
+			"700",
+		},
+		{
+			"expired lockup ignored",
+			"1000",
+			[]Lockup{{Amount: d("400"), UnlockAt: now.Add(-time.Hour)}},
+			"1000",
+		},
+		{
+			"oversubscribed clamps to zero",
+			"1000",
+			[]Lockup{
+				{Amount: d("700"), UnlockAt: now.Add(time.Hour)},
+				{Amount: d("500"), UnlockAt: now.Add(2 * time.Hour)},
+			},
+			"0",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := AvailableCapital(d(c.cash), c.lockups, now)
+			if !got.Equal(d(c.want)) {
+				t.Errorf("got %s want %s", got, c.want)
+			}
+		})
+	}
+}
+
+func TestSimpleReturn(t *testing.T) {
+	cases := []struct {
+		nav, dep, wit, want string
+	}{
+		{"1100", "1000", "0", "0.1"},     // +10%
+		{"900", "1000", "0", "-0.1"},     // -10%
+		{"1000", "0", "0", "0"},          // no contributions → 0
+		{"500", "1000", "500", "0"},      // contributed 500, NAV=500 → 0% return
+	}
+	for _, c := range cases {
+		got := SimpleReturn(NAVSnapshot{
+			NAV:             d(c.nav),
+			DepositTotal:    d(c.dep),
+			WithdrawalTotal: d(c.wit),
+		})
+		if !got.Equal(d(c.want)) {
+			t.Errorf("nav=%s dep=%s wit=%s: got %s want %s", c.nav, c.dep, c.wit, got, c.want)
+		}
+	}
+}

--- a/internal/vault/service.go
+++ b/internal/vault/service.go
@@ -1,0 +1,200 @@
+package vault
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// Service wraps DB access for the vault accounting layer.
+type Service struct {
+	pool *pgxpool.Pool
+}
+
+// NewService constructs a Service.
+func NewService(pool *pgxpool.Pool) *Service { return &Service{pool: pool} }
+
+// ─── vaults ─────────────────────────────────────────────────────────────────
+
+// Init creates a vault if it does not already exist and returns it. v1 uses
+// a single canonical vault per deployment.
+func (s *Service) Init(ctx context.Context, name, asset string) (Vault, error) {
+	if name == "" || asset == "" {
+		return Vault{}, errors.New("vault: name and asset required")
+	}
+	const q = `
+INSERT INTO vaults (name, asset)
+VALUES ($1, $2)
+ON CONFLICT (name) DO UPDATE SET asset = vaults.asset
+RETURNING id, name, asset, created_at;`
+	var v Vault
+	if err := s.pool.QueryRow(ctx, q, name, asset).
+		Scan(&v.ID, &v.Name, &v.Asset, &v.CreatedAt); err != nil {
+		return Vault{}, fmt.Errorf("vault: init: %w", err)
+	}
+	return v, nil
+}
+
+// Get returns the vault by name.
+func (s *Service) Get(ctx context.Context, name string) (Vault, error) {
+	const q = `SELECT id, name, asset, created_at FROM vaults WHERE name = $1`
+	var v Vault
+	if err := s.pool.QueryRow(ctx, q, name).Scan(&v.ID, &v.Name, &v.Asset, &v.CreatedAt); err != nil {
+		return Vault{}, fmt.Errorf("vault: get: %w", err)
+	}
+	return v, nil
+}
+
+// ─── ledger ─────────────────────────────────────────────────────────────────
+
+// Deposit appends a deposit entry.
+func (s *Service) Deposit(ctx context.Context, vaultID int64, amount decimal.Decimal, source, note string) (Deposit, error) {
+	if !amount.IsPositive() {
+		return Deposit{}, errors.New("vault: deposit amount must be positive")
+	}
+	const q = `INSERT INTO deposits (vault_id, amount, source, note)
+VALUES ($1, $2, $3, $4) RETURNING id, created_at;`
+	var d = Deposit{VaultID: vaultID, Amount: amount, Source: source, Note: note}
+	if err := s.pool.QueryRow(ctx, q, vaultID, amount, source, note).Scan(&d.ID, &d.CreatedAt); err != nil {
+		return Deposit{}, fmt.Errorf("vault: deposit: %w", err)
+	}
+	return d, nil
+}
+
+// Withdraw appends a withdrawal entry. Does NOT enforce against current NAV;
+// risk + balance checks are the agent runtime's job.
+func (s *Service) Withdraw(ctx context.Context, vaultID int64, amount decimal.Decimal, dest, note string) (Withdrawal, error) {
+	if !amount.IsPositive() {
+		return Withdrawal{}, errors.New("vault: withdrawal amount must be positive")
+	}
+	const q = `INSERT INTO withdrawals (vault_id, amount, destination, note)
+VALUES ($1, $2, $3, $4) RETURNING id, created_at;`
+	w := Withdrawal{VaultID: vaultID, Amount: amount, Destination: dest, Note: note}
+	if err := s.pool.QueryRow(ctx, q, vaultID, amount, dest, note).Scan(&w.ID, &w.CreatedAt); err != nil {
+		return Withdrawal{}, fmt.Errorf("vault: withdraw: %w", err)
+	}
+	return w, nil
+}
+
+// AddLockup records a time-based lockup against vault capital.
+func (s *Service) AddLockup(ctx context.Context, vaultID int64, amount decimal.Decimal, until time.Time, note string) (Lockup, error) {
+	if !amount.IsPositive() {
+		return Lockup{}, errors.New("vault: lockup amount must be positive")
+	}
+	if !until.After(time.Now()) {
+		return Lockup{}, errors.New("vault: unlock time must be in the future")
+	}
+	const q = `INSERT INTO lockups (vault_id, amount, unlock_at, note)
+VALUES ($1, $2, $3, $4) RETURNING id, created_at;`
+	l := Lockup{VaultID: vaultID, Amount: amount, UnlockAt: until, Note: note}
+	if err := s.pool.QueryRow(ctx, q, vaultID, amount, until, note).Scan(&l.ID, &l.CreatedAt); err != nil {
+		return Lockup{}, fmt.Errorf("vault: lockup: %w", err)
+	}
+	return l, nil
+}
+
+// ActiveLockups returns lockups still in force at t.
+func (s *Service) ActiveLockups(ctx context.Context, vaultID int64, t time.Time) ([]Lockup, error) {
+	const q = `SELECT id, vault_id, amount, unlock_at, COALESCE(note,''), created_at
+FROM lockups WHERE vault_id = $1 AND unlock_at > $2 ORDER BY unlock_at`
+	rows, err := s.pool.Query(ctx, q, vaultID, t)
+	if err != nil {
+		return nil, fmt.Errorf("vault: lockups: %w", err)
+	}
+	defer rows.Close()
+	out := make([]Lockup, 0)
+	for rows.Next() {
+		var l Lockup
+		if err := rows.Scan(&l.ID, &l.VaultID, &l.Amount, &l.UnlockAt, &l.Note, &l.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, l)
+	}
+	return out, rows.Err()
+}
+
+// LedgerTotals returns cumulative deposits and withdrawals for the vault.
+func (s *Service) LedgerTotals(ctx context.Context, vaultID int64) (depositTotal, withdrawalTotal decimal.Decimal, err error) {
+	row := s.pool.QueryRow(ctx, `
+SELECT
+  COALESCE((SELECT SUM(amount) FROM deposits     WHERE vault_id = $1), 0),
+  COALESCE((SELECT SUM(amount) FROM withdrawals  WHERE vault_id = $1), 0)`, vaultID)
+	if err = row.Scan(&depositTotal, &withdrawalTotal); err != nil {
+		return decimal.Zero, decimal.Zero, fmt.Errorf("vault: totals: %w", err)
+	}
+	return
+}
+
+// ─── NAV ────────────────────────────────────────────────────────────────────
+
+// LatestNAV returns the most recent NAV snapshot for a vault, or
+// pgx.ErrNoRows if none exists.
+func (s *Service) LatestNAV(ctx context.Context, vaultID int64) (NAVSnapshot, error) {
+	const q = `SELECT time, vault_id, nav, cash, positions_value, high_water_mark, deposit_total, withdrawal_total
+FROM nav_snapshots WHERE vault_id = $1 ORDER BY time DESC LIMIT 1`
+	var s2 NAVSnapshot
+	if err := s.pool.QueryRow(ctx, q, vaultID).Scan(
+		&s2.Time, &s2.VaultID, &s2.NAV, &s2.Cash, &s2.PositionsValue,
+		&s2.HighWaterMark, &s2.DepositTotal, &s2.WithdrawalTotal,
+	); err != nil {
+		return NAVSnapshot{}, err
+	}
+	return s2, nil
+}
+
+// RecordNAV computes a NAV snapshot from current cash + positions value and
+// persists it. The previous HWM is read from latest_nav (or zero).
+func (s *Service) RecordNAV(ctx context.Context, vaultID int64, cash, positionsValue decimal.Decimal) (NAVSnapshot, error) {
+	depositTotal, withdrawalTotal, err := s.LedgerTotals(ctx, vaultID)
+	if err != nil {
+		return NAVSnapshot{}, err
+	}
+	prevHWM := decimal.Zero
+	if prev, err := s.LatestNAV(ctx, vaultID); err == nil {
+		prevHWM = prev.HighWaterMark
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		return NAVSnapshot{}, err
+	}
+	snap := ComputeNAV(time.Now().UTC(), vaultID, NAVInputs{
+		Cash:            cash,
+		PositionsValue:  positionsValue,
+		DepositTotal:    depositTotal,
+		WithdrawalTotal: withdrawalTotal,
+		PrevHWM:         prevHWM,
+	})
+	const ins = `INSERT INTO nav_snapshots (time, vault_id, nav, cash, positions_value, high_water_mark, deposit_total, withdrawal_total)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8) ON CONFLICT (vault_id, time) DO NOTHING;`
+	if _, err := s.pool.Exec(ctx, ins,
+		snap.Time, snap.VaultID, snap.NAV, snap.Cash, snap.PositionsValue,
+		snap.HighWaterMark, snap.DepositTotal, snap.WithdrawalTotal,
+	); err != nil {
+		return NAVSnapshot{}, fmt.Errorf("vault: record nav: %w", err)
+	}
+	return snap, nil
+}
+
+// NAVHistory returns NAV snapshots since the given time, oldest first.
+func (s *Service) NAVHistory(ctx context.Context, vaultID int64, since time.Time) ([]NAVSnapshot, error) {
+	const q = `SELECT time, vault_id, nav, cash, positions_value, high_water_mark, deposit_total, withdrawal_total
+FROM nav_snapshots WHERE vault_id = $1 AND time >= $2 ORDER BY time ASC`
+	rows, err := s.pool.Query(ctx, q, vaultID, since)
+	if err != nil {
+		return nil, fmt.Errorf("vault: nav history: %w", err)
+	}
+	defer rows.Close()
+	out := make([]NAVSnapshot, 0)
+	for rows.Next() {
+		var s2 NAVSnapshot
+		if err := rows.Scan(&s2.Time, &s2.VaultID, &s2.NAV, &s2.Cash, &s2.PositionsValue,
+			&s2.HighWaterMark, &s2.DepositTotal, &s2.WithdrawalTotal); err != nil {
+			return nil, err
+		}
+		out = append(out, s2)
+	}
+	return out, rows.Err()
+}

--- a/internal/vault/types.go
+++ b/internal/vault/types.go
@@ -1,0 +1,73 @@
+// Package vault models the off-chain accounting layer: deposits,
+// withdrawals, lockups, and NAV snapshots. v1 is single-asset (USDC) and
+// single-vault per deployment; the multi-asset / multi-tenant story is v2
+// (see SCOPE.md §15).
+package vault
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// Vault is a row in the vaults table.
+type Vault struct {
+	ID        int64
+	Name      string
+	Asset     string // accounting unit, e.g. "USDC"
+	CreatedAt time.Time
+}
+
+// Deposit is one ledger entry into the vault.
+type Deposit struct {
+	ID        int64
+	VaultID   int64
+	Amount    decimal.Decimal
+	Source    string
+	Note      string
+	CreatedAt time.Time
+}
+
+// Withdrawal is one ledger entry out of the vault.
+type Withdrawal struct {
+	ID          int64
+	VaultID     int64
+	Amount      decimal.Decimal
+	Destination string
+	Note        string
+	CreatedAt   time.Time
+}
+
+// Lockup freezes a portion of vault capital until UnlockAt.
+type Lockup struct {
+	ID        int64
+	VaultID   int64
+	Amount    decimal.Decimal
+	UnlockAt  time.Time
+	Note      string
+	CreatedAt time.Time
+}
+
+// IsActive reports whether the lockup is still in force at t.
+func (l Lockup) IsActive(t time.Time) bool { return t.Before(l.UnlockAt) }
+
+// NAVSnapshot is one observation of vault state.
+type NAVSnapshot struct {
+	Time            time.Time
+	VaultID         int64
+	NAV             decimal.Decimal // cash + positions_value
+	Cash            decimal.Decimal
+	PositionsValue  decimal.Decimal
+	HighWaterMark   decimal.Decimal
+	DepositTotal    decimal.Decimal // cumulative deposits
+	WithdrawalTotal decimal.Decimal // cumulative withdrawals
+}
+
+// Inputs to ComputeNAV (see nav.go).
+type NAVInputs struct {
+	Cash            decimal.Decimal
+	PositionsValue  decimal.Decimal
+	DepositTotal    decimal.Decimal
+	WithdrawalTotal decimal.Decimal
+	PrevHWM         decimal.Decimal
+}


### PR DESCRIPTION
## Milestone
**M7 — Vault & accounting.** Off-chain vault and accounting layer per [SCOPE.md M7](../blob/m7-vault/SCOPE.md#13-build-milestones). USDC-only, single-vault-per-deployment for v1.

> Stacked on top of #7 (M6).

## DB (\`migrations/0003_vault.sql\`)
| Table | Purpose |
|---|---|
| \`vaults\` | Single canonical row per deployment |
| \`deposits\` | Append-only ledger |
| \`withdrawals\` | Append-only ledger |
| \`lockups\` | Time-based capital freezes |
| \`nav_snapshots\` | Timescale hypertable, indexed by \`(vault_id, time DESC)\` |

## Library (\`internal/vault\`)
- \`types.go\` — Vault, Deposit, Withdrawal, Lockup, NAVSnapshot, NAVInputs.
- \`nav.go\` — **pure** \`ComputeNAV\` (HWM is running max), \`AvailableCapital\` (cash minus active lockups, clamped to zero), \`SimpleReturn\`.
- \`allocator.go\` — \`AllocatorPolicy\` interface + \`ProportionalPolicy\` that normalises weights and produces deterministic allocations.
- \`service.go\` — pgx-backed Service: \`Init\`, \`Get\`, \`Deposit\`, \`Withdraw\`, \`AddLockup\`, \`ActiveLockups\`, \`LedgerTotals\`, \`RecordNAV\` (reads prev HWM → computes → persists), \`LatestNAV\`, \`NAVHistory\`.

## CLI
\`\`\`
permafrost vault init
permafrost vault deposit  --amount 10000
permafrost vault withdraw --amount 1000  --dest ramp
permafrost vault lockup   --amount 5000  --until 2027-01-01T00:00:00Z
permafrost vault status
permafrost vault record-nav --cash 9000 --positions 1100   # manual; agent runtime will populate in M8
permafrost vault nav        --since 24h
\`\`\`

## Tests (pure logic, no DB required)
- **ComputeNAV** — HWM updates on a new high, holds on a dip, sets initial.
- **AvailableCapital** — no lockups passes through, single active subtracts, expired ignored, oversubscription clamps to zero.
- **SimpleReturn** — gain, loss, zero contributions returns 0, contributed-and-recovered returns 0.
- **ProportionalPolicy** — pro-rata split (\`{a:1, b:1, c:2}\` of 1000 → 250/250/500), zero available, negative-input rejection, deterministic ordering by AgentID.

## Verify locally
\`\`\`
go test ./internal/vault/... -race -count=1 -v
docker compose -f deploy/compose/docker-compose.yml up -d   # for DB-backed CLI
go run ./cmd/permafrost vault init
\`\`\`

## Out of scope (next PRs)
- Agent runtime that writes NAV automatically → **PR #9 (M8)**
- Performance fees (HWM-based) → out of v1 scope