### PR TITLE
feat(m8): agent runtime — scheduler, paired execution, paper mode, persistence

### DIFF
--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -1,0 +1,353 @@
+package agent
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/exchange"
+	"github.com/teslashibe/permafrost/internal/inference"
+	"github.com/teslashibe/permafrost/internal/risk"
+	"github.com/teslashibe/permafrost/internal/strategy"
+	"github.com/teslashibe/permafrost/internal/swap"
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// Deps bundles the dependencies a Runtime needs to execute one Agent.
+// The intention is one Runtime per Agent; the Supervisor builds Deps from
+// the global registries (venues, inference, etc.).
+type Deps struct {
+	Strategy   strategy.Strategy
+	Perp       exchange.Venue
+	Swap       swap.SwapVenue
+	Inference  inference.Provider
+	Risk       risk.Engine
+	Store      *Store
+	Logger     *slog.Logger
+}
+
+// Runtime drives the tick loop for one Agent.
+type Runtime struct {
+	agent Agent
+	deps  Deps
+	now   func() time.Time
+
+	mu      sync.Mutex
+	running bool
+	cancel  context.CancelFunc
+}
+
+// NewRuntime constructs a Runtime.
+func NewRuntime(a Agent, d Deps) *Runtime {
+	if d.Logger == nil {
+		d.Logger = slog.Default()
+	}
+	return &Runtime{
+		agent: a,
+		deps:  d,
+		now:   func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// SetClock overrides the runtime's clock function. For tests only.
+func (r *Runtime) SetClock(fn func() time.Time) { r.now = fn }
+
+// IsRunning reports whether the tick loop is active.
+func (r *Runtime) IsRunning() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.running
+}
+
+// Start launches the tick loop and returns immediately. The supplied parent
+// context controls overall lifetime. Use Stop() for graceful shutdown.
+func (r *Runtime) Start(parent context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.running {
+		return errors.New("runtime: already running")
+	}
+	ctx, cancel := context.WithCancel(parent)
+	r.cancel = cancel
+	r.running = true
+
+	if r.deps.Store != nil {
+		_ = r.deps.Store.SetStatus(parent, r.agent.ID, StatusRunning)
+	}
+
+	go r.loop(ctx)
+	return nil
+}
+
+// Stop gracefully halts the tick loop and waits for the current tick to
+// complete (best-effort within ctx).
+func (r *Runtime) Stop(ctx context.Context, reason string) error {
+	r.mu.Lock()
+	if !r.running {
+		r.mu.Unlock()
+		return nil
+	}
+	r.running = false
+	r.cancel()
+	r.mu.Unlock()
+
+	if r.deps.Store != nil {
+		_ = r.deps.Store.SetStatus(ctx, r.agent.ID, StatusStopped)
+	}
+	r.deps.Logger.Info("agent stopped", "agent_id", r.agent.ID, "reason", reason)
+	return nil
+}
+
+func (r *Runtime) loop(ctx context.Context) {
+	tick := time.NewTicker(r.agent.Interval())
+	defer tick.Stop()
+
+	// run an immediate tick on start
+	r.tickOnce(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+			r.tickOnce(ctx)
+		}
+	}
+}
+
+// TickOnce executes a single decision tick. Exported for tests and for
+// "permafrost agent tick" debugging.
+func (r *Runtime) TickOnce(ctx context.Context) (strategy.Decision, error) {
+	return r.tickOnce(ctx)
+}
+
+func (r *Runtime) tickOnce(ctx context.Context) (strategy.Decision, error) {
+	now := r.now()
+	in, err := r.buildDecisionInput(ctx, now)
+	if err != nil {
+		r.deps.Logger.Error("agent input failed", "agent_id", r.agent.ID, "err", err)
+		return strategy.Decision{}, err
+	}
+
+	dec, err := r.deps.Strategy.Decide(ctx, in)
+	if err != nil {
+		r.deps.Logger.Error("agent decide failed", "agent_id", r.agent.ID, "err", err)
+		return strategy.Decision{}, err
+	}
+
+	decisionID := uuid.NewString()
+	r.persistDecision(ctx, now, decisionID, in, dec)
+
+	r.executeSwapsThenOrders(ctx, now, decisionID, in, dec)
+	return dec, nil
+}
+
+// buildDecisionInput pulls current state from venues + the configured
+// universe and bundles it for Strategy.Decide.
+func (r *Runtime) buildDecisionInput(ctx context.Context, now time.Time) (strategy.DecisionInput, error) {
+	in := strategy.DecisionInput{
+		AgentID: r.agent.ID,
+		Now:     now,
+		Cash:    map[string]types.Balance{},
+		Limits:  types.RiskLimits{},
+	}
+	if r.deps.Perp != nil {
+		if pos, err := r.deps.Perp.Positions(ctx); err == nil {
+			in.PerpPositions = pos
+		}
+		if bals, err := r.deps.Perp.Balances(ctx); err == nil {
+			for _, b := range bals {
+				in.Cash["hyperliquid"] = b
+			}
+		}
+		if rates, err := r.deps.Perp.FundingRates(ctx, r.agent.Universe); err == nil {
+			snap := types.MarketSnapshot{Time: now, Symbols: map[string]types.SymbolSnap{}}
+			for _, fr := range rates {
+				snap.Symbols[fr.Symbol] = types.SymbolSnap{Funding: fr}
+			}
+			in.Market = snap
+		}
+	}
+	return in, nil
+}
+
+func (r *Runtime) persistDecision(ctx context.Context, now time.Time, decisionID string, in strategy.DecisionInput, dec strategy.Decision) {
+	if r.deps.Store == nil {
+		return
+	}
+	hash := decisionInputHash(in)
+	if err := r.deps.Store.PersistDecision(ctx, PersistDecisionInput{
+		Time:       now,
+		AgentID:    r.agent.ID,
+		DecisionID: decisionID,
+		InputHash:  hash,
+		Decision:   dec,
+		Rationale:  dec.Notes,
+	}); err != nil {
+		r.deps.Logger.Warn("persist decision failed", "agent_id", r.agent.ID, "err", err)
+	}
+}
+
+// executeSwapsThenOrders runs swaps first (spot leg), then orders (perp leg)
+// — this is the spot-first invariant called for in SCOPE.md §11.
+func (r *Runtime) executeSwapsThenOrders(ctx context.Context, now time.Time, decisionID string, _ strategy.DecisionInput, dec strategy.Decision) {
+	for i, s := range dec.Swaps {
+		r.executeSwap(ctx, now, decisionID, i, s)
+	}
+	for i, o := range dec.Orders {
+		r.executeOrder(ctx, now, decisionID, i, o)
+	}
+	for _, c := range dec.Cancels {
+		r.executeCancel(ctx, c)
+	}
+}
+
+func (r *Runtime) executeSwap(ctx context.Context, now time.Time, decisionID string, slot int, s types.SwapIntent) {
+	if s.ClientID == "" {
+		s.ClientID = clientIDFromSwap(r.agent.ID, decisionID, slot, s)
+	}
+	if r.deps.Risk != nil {
+		v := r.deps.Risk.PreTrade(ctx, r.agent.ID, s, types.PortfolioSnapshot{})
+		if v.IsBlock() {
+			r.deps.Logger.Warn("swap blocked by risk", "agent_id", r.agent.ID, "reason", v.Reason)
+			return
+		}
+	}
+	if r.agent.Mode == ModePaper || r.deps.Swap == nil {
+		r.recordSwap(ctx, now, decisionID, s, "", types.SwapStatusConfirmed, true, s.InAmount, decimal.Zero)
+		return
+	}
+
+	q, err := r.deps.Swap.Quote(ctx, types.QuoteRequest{
+		InToken: s.InToken, OutToken: s.OutToken, Amount: s.InAmount, Mode: types.QuoteExactIn,
+	})
+	if err != nil {
+		r.deps.Logger.Error("swap quote failed", "err", err)
+		r.recordSwap(ctx, now, decisionID, s, "", types.SwapStatusFailed, false, decimal.Zero, decimal.Zero)
+		return
+	}
+	tx, err := r.deps.Swap.Swap(ctx, q, s.SlippageBps)
+	if err != nil {
+		r.deps.Logger.Error("swap submit failed", "err", err)
+		r.recordSwap(ctx, now, decisionID, s, "", types.SwapStatusFailed, false, decimal.Zero, decimal.Zero)
+		return
+	}
+	res, err := r.deps.Swap.WaitConfirm(ctx, tx)
+	if err != nil {
+		r.deps.Logger.Error("swap confirm failed", "err", err)
+		r.recordSwap(ctx, now, decisionID, s, string(tx), types.SwapStatusFailed, false, decimal.Zero, decimal.Zero)
+		return
+	}
+	r.recordSwap(ctx, now, decisionID, s, string(res.TxHash), res.Status, false, res.OutAmount, res.GasNative)
+}
+
+func (r *Runtime) executeOrder(ctx context.Context, now time.Time, decisionID string, slot int, o types.OrderIntent) {
+	if o.ClientID == "" {
+		o.ClientID = types.DeriveClientID(r.agent.ID, decisionID, slot, o.Venue, o.Symbol, o.Side, o.Size)
+	}
+	o.DecisionID = decisionID
+	o.Slot = slot
+	if r.deps.Risk != nil {
+		v := r.deps.Risk.PreTrade(ctx, r.agent.ID, o, types.PortfolioSnapshot{})
+		if v.IsBlock() {
+			r.deps.Logger.Warn("order blocked by risk", "agent_id", r.agent.ID, "reason", v.Reason)
+			return
+		}
+	}
+	if r.agent.Mode == ModePaper || r.deps.Perp == nil {
+		r.recordOrder(ctx, now, decisionID, o, "", string(types.OrderStatusOpen), true)
+		return
+	}
+	ack, err := r.deps.Perp.Place(ctx, o)
+	if err != nil {
+		r.deps.Logger.Error("order place failed", "err", err)
+		r.recordOrder(ctx, now, decisionID, o, "", string(types.OrderStatusRejected), false)
+		return
+	}
+	r.recordOrder(ctx, now, decisionID, o, string(ack.ID), string(ack.Status), false)
+}
+
+func (r *Runtime) executeCancel(ctx context.Context, id types.OrderID) {
+	if r.agent.Mode == ModePaper || r.deps.Perp == nil {
+		return
+	}
+	if err := r.deps.Perp.Cancel(ctx, id); err != nil {
+		r.deps.Logger.Error("order cancel failed", "id", id, "err", err)
+	}
+}
+
+func (r *Runtime) recordSwap(ctx context.Context, now time.Time, decisionID string, s types.SwapIntent, txHash string, status types.SwapStatus, paper bool, outAmt, gas decimal.Decimal) {
+	if r.deps.Store == nil {
+		return
+	}
+	dex := "noop"
+	if r.deps.Swap != nil {
+		dex = r.deps.Swap.Name()
+	}
+	if err := r.deps.Store.PersistSwap(ctx, PersistSwapInput{
+		Time:        now,
+		AgentID:     r.agent.ID,
+		DecisionID:  decisionID,
+		Chain:       string(s.Chain),
+		DEX:         dex,
+		InToken:     s.InToken.Symbol,
+		OutToken:    s.OutToken.Symbol,
+		InAmount:    s.InAmount,
+		OutAmount:   outAmt,
+		SlippageBps: s.SlippageBps,
+		GasPaid:     gas,
+		TxHash:      txHash,
+		Status:      string(status),
+		Paper:       paper,
+	}); err != nil {
+		r.deps.Logger.Warn("persist swap failed", "err", err)
+	}
+}
+
+func (r *Runtime) recordOrder(ctx context.Context, now time.Time, decisionID string, o types.OrderIntent, venueID, status string, paper bool) {
+	if r.deps.Store == nil {
+		return
+	}
+	if err := r.deps.Store.PersistOrder(ctx, PersistOrderInput{
+		Time:       now,
+		AgentID:    r.agent.ID,
+		DecisionID: decisionID,
+		Venue:      o.Venue,
+		Symbol:     o.Symbol,
+		Side:       string(o.Side),
+		Type:       string(o.Type),
+		Price:      o.Price,
+		Size:       o.Size,
+		TIF:        string(o.TIF),
+		ReduceOnly: o.ReduceOnly,
+		ClientID:   string(o.ClientID),
+		VenueID:    venueID,
+		Status:     status,
+		Paper:      paper,
+	}); err != nil {
+		r.deps.Logger.Warn("persist order failed", "err", err)
+	}
+}
+
+// decisionInputHash produces a short fingerprint of the input so an operator
+// can join orders/decisions to their input snapshot in audits.
+func decisionInputHash(in strategy.DecisionInput) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "%s|%d|%d|%d|%d", in.AgentID, in.Now.UnixNano(), len(in.PerpPositions), len(in.SpotBalances), len(in.BasisPositions))
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// clientIDFromSwap creates a deterministic client_id for a SwapIntent.
+func clientIDFromSwap(agentID, decisionID string, slot int, s types.SwapIntent) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "%s|%s|%d|%s|%s|%s",
+		agentID, decisionID, slot, s.Chain, s.InToken.Mint, s.OutToken.Mint)
+	return "sw_" + hex.EncodeToString(h.Sum(nil))[:24]
+}

--- a/internal/agent/runtime_test.go
+++ b/internal/agent/runtime_test.go
@@ -1,0 +1,131 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	exchangenoop "github.com/teslashibe/permafrost/internal/exchange/noop"
+	"github.com/teslashibe/permafrost/internal/strategy"
+	swapnoop "github.com/teslashibe/permafrost/internal/swap/noop"
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// scriptedStrategy returns the same Decision every tick.
+type scriptedStrategy struct {
+	name     string
+	decision strategy.Decision
+}
+
+func (s *scriptedStrategy) Name() string                                       { return s.name }
+func (s *scriptedStrategy) Warmup(_ context.Context, _ strategy.WarmupInput) error { return nil }
+func (s *scriptedStrategy) Decide(_ context.Context, _ strategy.DecisionInput) (strategy.Decision, error) {
+	return s.decision, nil
+}
+
+func TestTickOnce_PaperMode_RecordsButDoesNotCallVenues(t *testing.T) {
+	perp := exchangenoop.New()
+	swp := swapnoop.New()
+	strat := &scriptedStrategy{
+		name: "test",
+		decision: strategy.Decision{
+			Notes: "open WIF basis",
+			Swaps: []types.SwapIntent{{
+				Chain:    types.ChainSolana,
+				InToken:  types.Asset{Symbol: "USDC", Chain: types.ChainSolana, Mint: "USDCmint", Decimals: 6},
+				OutToken: types.Asset{Symbol: "WIF", Chain: types.ChainSolana, Mint: "WIFmint", Decimals: 6},
+				InAmount: decimal.NewFromInt(100),
+			}},
+			Orders: []types.OrderIntent{{
+				Venue: "hyperliquid", Symbol: "WIF", Side: types.SideSell,
+				Type: types.OrderTypeLimit, Price: decimal.NewFromInt(1), Size: decimal.NewFromInt(100),
+			}},
+		},
+	}
+	a := Agent{ID: "a1", Strategy: "test", Mode: ModePaper, PerpVenue: "hyperliquid", SpotVenue: "jupiter"}
+	r := NewRuntime(a, Deps{
+		Strategy: strat,
+		Perp:     perp,
+		Swap:     swp,
+	})
+	r.SetClock(func() time.Time { return time.Unix(1_700_000_000, 0).UTC() })
+
+	dec, err := r.TickOnce(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dec.Notes != "open WIF basis" {
+		t.Errorf("decision passed through: %+v", dec)
+	}
+	if got := perp.Placed(); len(got) != 0 {
+		t.Errorf("paper mode should not call venue Place, got %d", len(got))
+	}
+	if got := swp.Submitted(); len(got) != 0 {
+		t.Errorf("paper mode should not call swap Swap, got %d", len(got))
+	}
+}
+
+func TestTickOnce_LiveMode_CallsVenues(t *testing.T) {
+	perp := exchangenoop.New()
+	swp := swapnoop.New()
+	strat := &scriptedStrategy{
+		name: "test",
+		decision: strategy.Decision{
+			Swaps: []types.SwapIntent{{
+				Chain:    types.ChainSolana,
+				InToken:  types.Asset{Symbol: "USDC", Chain: types.ChainSolana, Mint: "USDCmint", Decimals: 6},
+				OutToken: types.Asset{Symbol: "WIF", Chain: types.ChainSolana, Mint: "WIFmint", Decimals: 6},
+				InAmount: decimal.NewFromInt(100),
+			}},
+			Orders: []types.OrderIntent{{
+				Venue: "hyperliquid", Symbol: "WIF", Side: types.SideSell,
+				Type: types.OrderTypeLimit, Price: decimal.NewFromInt(1), Size: decimal.NewFromInt(100),
+			}},
+		},
+	}
+	a := Agent{ID: "a1", Strategy: "test", Mode: ModeLive, PerpVenue: "hyperliquid", SpotVenue: "noop"}
+	r := NewRuntime(a, Deps{
+		Strategy: strat,
+		Perp:     perp,
+		Swap:     swp,
+	})
+
+	if _, err := r.TickOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := swp.Submitted(); len(got) != 1 {
+		t.Errorf("expected 1 swap submitted, got %d", len(got))
+	}
+	if got := perp.Placed(); len(got) != 1 {
+		t.Errorf("expected 1 order placed, got %d", len(got))
+	}
+}
+
+func TestRuntime_StartStop(t *testing.T) {
+	strat := &scriptedStrategy{name: "noop"}
+	a := Agent{ID: "a1", Strategy: "noop", Mode: ModePaper, TickSecs: 1}
+	r := NewRuntime(a, Deps{Strategy: strat})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := r.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if !r.IsRunning() {
+		t.Fatal("expected running")
+	}
+	if err := r.Start(ctx); err == nil {
+		t.Fatal("double-start should fail")
+	}
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), time.Second)
+	defer stopCancel()
+	if err := r.Stop(stopCtx, "test"); err != nil {
+		t.Fatal(err)
+	}
+	if r.IsRunning() {
+		t.Fatal("expected stopped")
+	}
+}

--- a/internal/agent/store.go
+++ b/internal/agent/store.go
@@ -1,0 +1,295 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// Store wraps DB access for agent lifecycle and the decision/order/swap
+// audit logs.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+// NewStore constructs a Store.
+func NewStore(pool *pgxpool.Pool) *Store { return &Store{pool: pool} }
+
+// Create inserts a new agent and returns it. ID must be non-empty.
+func (s *Store) Create(ctx context.Context, a Agent) (Agent, error) {
+	if a.ID == "" {
+		return Agent{}, errors.New("agent: id required")
+	}
+	if a.Strategy == "" {
+		return Agent{}, errors.New("agent: strategy required")
+	}
+	if a.Mode == "" {
+		a.Mode = ModePaper
+	}
+	if a.Status == "" {
+		a.Status = StatusStopped
+	}
+	cfgBytes, _ := json.Marshal(orZero(a.Config))
+	const q = `
+INSERT INTO agents (id, name, strategy, mode, perp_venue, spot_venue, inference, universe, allocation_usdc, tick_secs, status, config)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+RETURNING created_at, updated_at;`
+	if err := s.pool.QueryRow(ctx, q,
+		a.ID, a.Name, a.Strategy, string(a.Mode), a.PerpVenue, a.SpotVenue, a.Inference,
+		a.Universe, a.AllocationUSDC, a.TickSecs, string(a.Status), cfgBytes,
+	).Scan(&a.CreatedAt, &a.UpdatedAt); err != nil {
+		return Agent{}, fmt.Errorf("agent: create: %w", err)
+	}
+	return a, nil
+}
+
+// Get returns an agent by id.
+func (s *Store) Get(ctx context.Context, id string) (Agent, error) {
+	const q = `SELECT id, name, strategy, mode, perp_venue, spot_venue, inference, universe, allocation_usdc, tick_secs, status, config, created_at, updated_at
+FROM agents WHERE id = $1`
+	var (
+		a   Agent
+		cfg []byte
+	)
+	if err := s.pool.QueryRow(ctx, q, id).Scan(
+		&a.ID, &a.Name, &a.Strategy, (*string)(&a.Mode), &a.PerpVenue, &a.SpotVenue,
+		&a.Inference, &a.Universe, &a.AllocationUSDC, &a.TickSecs, (*string)(&a.Status),
+		&cfg, &a.CreatedAt, &a.UpdatedAt,
+	); err != nil {
+		return Agent{}, fmt.Errorf("agent: get: %w", err)
+	}
+	if len(cfg) > 0 {
+		_ = json.Unmarshal(cfg, &a.Config)
+	}
+	return a, nil
+}
+
+// List returns all agents (newest first).
+func (s *Store) List(ctx context.Context) ([]Agent, error) {
+	rows, err := s.pool.Query(ctx, `SELECT id, name, strategy, mode, status, allocation_usdc, created_at FROM agents ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]Agent, 0)
+	for rows.Next() {
+		var a Agent
+		if err := rows.Scan(&a.ID, &a.Name, &a.Strategy, (*string)(&a.Mode), (*string)(&a.Status), &a.AllocationUSDC, &a.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// SetStatus updates an agent's persisted lifecycle status.
+func (s *Store) SetStatus(ctx context.Context, id string, status Status) error {
+	if _, err := s.pool.Exec(ctx, `UPDATE agents SET status = $1, updated_at = now() WHERE id = $2`,
+		string(status), id); err != nil {
+		return fmt.Errorf("agent: set status: %w", err)
+	}
+	return nil
+}
+
+// StartRun records the start of an agent run.
+func (s *Store) StartRun(ctx context.Context, id string) (int64, error) {
+	var runID int64
+	if err := s.pool.QueryRow(ctx, `INSERT INTO agent_runs (agent_id) VALUES ($1) RETURNING id`, id).Scan(&runID); err != nil {
+		return 0, fmt.Errorf("agent: start run: %w", err)
+	}
+	return runID, nil
+}
+
+// EndRun records the end of an agent run with a freeform reason.
+func (s *Store) EndRun(ctx context.Context, runID int64, reason string) error {
+	if _, err := s.pool.Exec(ctx, `UPDATE agent_runs SET ended_at = now(), exit_reason = $2 WHERE id = $1`,
+		runID, reason); err != nil {
+		return fmt.Errorf("agent: end run: %w", err)
+	}
+	return nil
+}
+
+// ─── decision / order / swap persistence ────────────────────────────────────
+
+// PersistDecisionInput is the data set persisted per Decide() call.
+type PersistDecisionInput struct {
+	Time       time.Time
+	AgentID    string
+	DecisionID string
+	InputHash  string
+	Decision   any // serialised as JSONB
+	Rationale  string
+	Provider   string
+	Model      string
+	TokensIn   int
+	TokensOut  int
+	LatencyMS  int64
+	CostUSD    float64
+}
+
+// PersistDecision writes one row to agent_decisions.
+func (s *Store) PersistDecision(ctx context.Context, in PersistDecisionInput) error {
+	body, err := json.Marshal(in.Decision)
+	if err != nil {
+		return fmt.Errorf("agent: marshal decision: %w", err)
+	}
+	const q = `INSERT INTO agent_decisions
+(time, agent_id, decision_id, input_hash, decision, rationale, provider, model, tokens_in, tokens_out, latency_ms, cost_usd)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+ON CONFLICT (agent_id, time, decision_id) DO NOTHING;`
+	if _, err := s.pool.Exec(ctx, q,
+		in.Time.UTC(), in.AgentID, in.DecisionID, in.InputHash, body, in.Rationale,
+		nz(in.Provider), nz(in.Model), in.TokensIn, in.TokensOut, in.LatencyMS, in.CostUSD,
+	); err != nil {
+		return fmt.Errorf("agent: persist decision: %w", err)
+	}
+	return nil
+}
+
+// PersistOrderInput is the order ledger row.
+type PersistOrderInput struct {
+	Time       time.Time
+	AgentID    string
+	DecisionID string
+	Venue      string
+	Symbol     string
+	Side       string
+	Type       string
+	Price      decimal.Decimal
+	Size       decimal.Decimal
+	TIF        string
+	ReduceOnly bool
+	ClientID   string
+	VenueID    string
+	Status     string
+	Paper      bool
+}
+
+// PersistOrder appends a row to orders.
+func (s *Store) PersistOrder(ctx context.Context, in PersistOrderInput) error {
+	const q = `INSERT INTO orders
+(time, agent_id, decision_id, venue, symbol, side, type, price, size, tif, reduce_only, client_id, venue_id, status, paper)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+ON CONFLICT (agent_id, time, client_id) DO NOTHING;`
+	if _, err := s.pool.Exec(ctx, q,
+		in.Time.UTC(), in.AgentID, in.DecisionID, in.Venue, in.Symbol, in.Side, in.Type,
+		in.Price, in.Size, in.TIF, in.ReduceOnly, in.ClientID, nz(in.VenueID), in.Status, in.Paper,
+	); err != nil {
+		return fmt.Errorf("agent: persist order: %w", err)
+	}
+	return nil
+}
+
+// PersistSwapInput is the swap ledger row.
+type PersistSwapInput struct {
+	Time        time.Time
+	AgentID     string
+	DecisionID  string
+	Chain       string
+	DEX         string
+	InToken     string
+	OutToken    string
+	InAmount    decimal.Decimal
+	OutAmount   decimal.Decimal
+	SlippageBps int
+	GasPaid     decimal.Decimal
+	TxHash      string
+	Status      string
+	Paper       bool
+}
+
+// PersistSwap appends a row to swaps.
+func (s *Store) PersistSwap(ctx context.Context, in PersistSwapInput) error {
+	const q = `INSERT INTO swaps
+(time, agent_id, decision_id, chain, dex, in_token, out_token, in_amount, out_amount, slippage_bps, gas_paid, tx_hash, status, paper)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+ON CONFLICT (agent_id, time, in_token, out_token) DO NOTHING;`
+	if _, err := s.pool.Exec(ctx, q,
+		in.Time.UTC(), in.AgentID, in.DecisionID, in.Chain, in.DEX, in.InToken, in.OutToken,
+		in.InAmount, in.OutAmount, in.SlippageBps, in.GasPaid, nz(in.TxHash), in.Status, in.Paper,
+	); err != nil {
+		return fmt.Errorf("agent: persist swap: %w", err)
+	}
+	return nil
+}
+
+// PersistInferenceCallInput is the audit row for an LLM call.
+type PersistInferenceCallInput struct {
+	Time      time.Time
+	AgentID   string
+	Provider  string
+	Model     string
+	LatencyMS int64
+	TokensIn  int
+	TokensOut int
+	CostUSD   float64
+	Status    string
+}
+
+// PersistInferenceCall appends a row to inference_calls.
+func (s *Store) PersistInferenceCall(ctx context.Context, in PersistInferenceCallInput) error {
+	const q = `INSERT INTO inference_calls
+(time, agent_id, provider, model, latency_ms, tokens_in, tokens_out, cost_usd, status)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+ON CONFLICT (provider, time, model) DO NOTHING;`
+	if _, err := s.pool.Exec(ctx, q,
+		in.Time.UTC(), nz(in.AgentID), in.Provider, in.Model, in.LatencyMS,
+		in.TokensIn, in.TokensOut, in.CostUSD, in.Status,
+	); err != nil {
+		return fmt.Errorf("agent: persist inference call: %w", err)
+	}
+	return nil
+}
+
+// RecentDecisions returns the most recent decisions for an agent, oldest first.
+func (s *Store) RecentDecisions(ctx context.Context, agentID string, since time.Time, limit int) ([]DecisionRow, error) {
+	rows, err := s.pool.Query(ctx, `
+SELECT time, decision_id, COALESCE(rationale,''), COALESCE(provider,''), COALESCE(model,''), tokens_in, tokens_out, cost_usd
+FROM agent_decisions WHERE agent_id = $1 AND time >= $2 ORDER BY time DESC LIMIT $3`,
+		agentID, since, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]DecisionRow, 0)
+	for rows.Next() {
+		var r DecisionRow
+		if err := rows.Scan(&r.Time, &r.DecisionID, &r.Rationale, &r.Provider, &r.Model, &r.TokensIn, &r.TokensOut, &r.CostUSD); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// DecisionRow is a row-shaped subset of agent_decisions used by the CLI.
+type DecisionRow struct {
+	Time       time.Time
+	DecisionID string
+	Rationale  string
+	Provider   string
+	Model      string
+	TokensIn   int
+	TokensOut  int
+	CostUSD    float64
+}
+
+func orZero(m map[string]any) map[string]any {
+	if m == nil {
+		return map[string]any{}
+	}
+	return m
+}
+
+func nz(s string) any {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	return s
+}

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -1,0 +1,61 @@
+// Package agent contains the runtime that drives a Strategy: scheduling,
+// paired execution (spot-first), persistence, and lifecycle management.
+package agent
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// Mode controls whether decisions actually hit the venues.
+type Mode string
+
+const (
+	ModePaper Mode = "paper" // record decisions; no venue calls
+	ModeLive  Mode = "live"  // submit to venues
+)
+
+// Status is the persisted lifecycle state.
+type Status string
+
+const (
+	StatusStopped Status = "stopped"
+	StatusRunning Status = "running"
+	StatusHalted  Status = "halted" // tripped a circuit breaker
+)
+
+// Agent is the persisted definition.
+type Agent struct {
+	ID             string
+	Name           string
+	Strategy       string
+	Mode           Mode
+	PerpVenue      string
+	SpotVenue      string
+	Inference      string // "provider:model"
+	Universe       []string
+	AllocationUSDC decimal.Decimal
+	TickSecs       int
+	Status         Status
+	Config         map[string]any
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+// AgentRun is one invocation of the runtime for an Agent.
+type AgentRun struct {
+	ID         int64
+	AgentID    string
+	StartedAt  time.Time
+	EndedAt    *time.Time
+	ExitReason string
+}
+
+// Tick interval default.
+func (a Agent) Interval() time.Duration {
+	if a.TickSecs <= 0 {
+		return 60 * time.Second
+	}
+	return time.Duration(a.TickSecs) * time.Second
+}

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -1,0 +1,229 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/spf13/cobra"
+
+	"github.com/teslashibe/permafrost/internal/agent"
+	"github.com/teslashibe/permafrost/internal/store"
+)
+
+func init() { addCommandFactory(newAgentCmd) }
+
+func newAgentCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "agent",
+		Short: "Manage strategy agents",
+	}
+	cmd.AddCommand(
+		newAgentCreateCmd(),
+		newAgentListCmd(),
+		newAgentStatusCmd(),
+		newAgentDecisionsCmd(),
+		newAgentSetModeCmd(),
+	)
+	return cmd
+}
+
+func openAgentStore(c *cobra.Command) (*agent.Store, *store.DB, error) {
+	g := FromContext(c.Context())
+	if g == nil {
+		return nil, nil, errors.New("globals not initialised")
+	}
+	db, err := store.Open(c.Context(), g.Config.Database)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open db: %w", err)
+	}
+	return agent.NewStore(db.Pool), db, nil
+}
+
+func newAgentCreateCmd() *cobra.Command {
+	var (
+		id, name, strategy, perp, spot, inferenceRef, modeStr string
+		universeCSV                                            string
+		alloc                                                  string
+		tickSecs                                               int
+	)
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a strategy agent (paper mode by default)",
+		RunE: func(c *cobra.Command, _ []string) error {
+			s, db, err := openAgentStore(c)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			if id == "" {
+				id = "ag_" + uuid.NewString()[:8]
+			}
+			amt := decimal.Zero
+			if alloc != "" {
+				amt, err = decimal.NewFromString(alloc)
+				if err != nil {
+					return fmt.Errorf("alloc: %w", err)
+				}
+			}
+			universe := splitCSV(universeCSV)
+			a := agent.Agent{
+				ID:             id,
+				Name:           name,
+				Strategy:       strategy,
+				Mode:           agent.Mode(modeStr),
+				PerpVenue:      perp,
+				SpotVenue:      spot,
+				Inference:      inferenceRef,
+				Universe:       universe,
+				AllocationUSDC: amt,
+				TickSecs:       tickSecs,
+			}
+			out, err := s.Create(c.Context(), a)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("created agent id=%s name=%s strategy=%s mode=%s alloc=%s\n",
+				out.ID, out.Name, out.Strategy, out.Mode, out.AllocationUSDC)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&id, "id", "", "agent id (defaults to a generated value)")
+	cmd.Flags().StringVar(&name, "name", "", "human-readable label")
+	cmd.Flags().StringVar(&strategy, "strategy", "funding_arb_basic", "registered strategy name")
+	cmd.Flags().StringVar(&perp, "perp", "hyperliquid", "perp venue")
+	cmd.Flags().StringVar(&spot, "spot", "jupiter", "spot venue")
+	cmd.Flags().StringVar(&inferenceRef, "inference", "", "inference provider:model (e.g. openrouter:anthropic/claude-sonnet-4.5)")
+	cmd.Flags().StringVar(&modeStr, "mode", string(agent.ModePaper), "paper | live")
+	cmd.Flags().StringVar(&universeCSV, "universe", "", "comma-separated symbols (e.g. WIF,BONK,POPCAT)")
+	cmd.Flags().StringVar(&alloc, "alloc", "", "allocation in USDC")
+	cmd.Flags().IntVar(&tickSecs, "tick-secs", 60, "tick interval seconds")
+	return cmd
+}
+
+func newAgentListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List agents",
+		RunE: func(c *cobra.Command, _ []string) error {
+			s, db, err := openAgentStore(c)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			rows, err := s.List(c.Context())
+			if err != nil {
+				return err
+			}
+			for _, a := range rows {
+				fmt.Printf("%-12s  %-20s  %-20s  %-7s  %-7s  alloc=%s  created=%s\n",
+					a.ID, a.Name, a.Strategy, a.Mode, a.Status, a.AllocationUSDC, a.CreatedAt.Format(time.RFC3339))
+			}
+			return nil
+		},
+	}
+}
+
+func newAgentStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status <id>",
+		Short: "Show one agent's full state",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			s, db, err := openAgentStore(c)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			a, err := s.Get(c.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			fmt.Printf("id:         %s\nname:       %s\nstrategy:   %s\nmode:       %s\nstatus:     %s\nperp:       %s\nspot:       %s\ninference:  %s\nuniverse:   %s\nalloc:      %s\ntick_secs:  %d\ncreated:    %s\n",
+				a.ID, a.Name, a.Strategy, a.Mode, a.Status, a.PerpVenue, a.SpotVenue,
+				a.Inference, strings.Join(a.Universe, ","), a.AllocationUSDC, a.TickSecs, a.CreatedAt.Format(time.RFC3339))
+			return nil
+		},
+	}
+}
+
+func newAgentDecisionsCmd() *cobra.Command {
+	var since string
+	var limit int
+	cmd := &cobra.Command{
+		Use:   "decisions <id>",
+		Short: "Show recent decisions for an agent",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			s, db, err := openAgentStore(c)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			dur, err := time.ParseDuration(since)
+			if err != nil {
+				return fmt.Errorf("--since: %w", err)
+			}
+			rows, err := s.RecentDecisions(c.Context(), args[0], time.Now().Add(-dur), limit)
+			if err != nil {
+				return err
+			}
+			for _, r := range rows {
+				fmt.Printf("%s  %s  cost=$%.4f  tokens(in/out)=%d/%d  %s\n",
+					r.Time.Format(time.RFC3339), r.Model, r.CostUSD, r.TokensIn, r.TokensOut, r.Rationale)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&since, "since", "1h", "lookback duration")
+	cmd.Flags().IntVar(&limit, "limit", 100, "max rows")
+	return cmd
+}
+
+func newAgentSetModeCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set-mode <id> <paper|live>",
+		Short: "Switch an agent between paper and live mode",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(c *cobra.Command, args []string) error {
+			_, db, err := openAgentStore(c)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			mode := agent.Mode(args[1])
+			if mode != agent.ModePaper && mode != agent.ModeLive {
+				return fmt.Errorf("mode must be paper or live")
+			}
+			res, err := db.Pool.Exec(c.Context(),
+				`UPDATE agents SET mode = $1, updated_at = now() WHERE id = $2`,
+				string(mode), args[0])
+			if err != nil {
+				return err
+			}
+			if res.RowsAffected() == 0 {
+				return fmt.Errorf("agent %q not found", args[0])
+			}
+			fmt.Printf("agent %s mode -> %s\n", args[0], mode)
+			return nil
+		},
+	}
+}
+
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/store/migrations/0004_agents_and_decisions.sql
+++ b/internal/store/migrations/0004_agents_and_decisions.sql
@@ -1,0 +1,126 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Agents — one row per configured strategy instance.
+CREATE TABLE IF NOT EXISTS agents (
+    id              text PRIMARY KEY,                  -- caller-supplied or generated uuid
+    name            text NOT NULL,
+    strategy        text NOT NULL,                     -- registered strategy name
+    mode            text NOT NULL DEFAULT 'paper',     -- 'paper' | 'live'
+    perp_venue      text NOT NULL,                     -- e.g. 'hyperliquid'
+    spot_venue      text NOT NULL DEFAULT 'jupiter',
+    inference       text NOT NULL,                     -- provider:model
+    universe        text[] NOT NULL DEFAULT ARRAY[]::text[],
+    allocation_usdc numeric(38,9) NOT NULL DEFAULT 0,
+    tick_secs       int NOT NULL DEFAULT 60,
+    status          text NOT NULL DEFAULT 'stopped',   -- 'stopped' | 'running' | 'halted'
+    config          jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS agents_status_idx ON agents (status);
+
+-- agent_runs — supervisor lifecycle ledger.
+CREATE TABLE IF NOT EXISTS agent_runs (
+    id          bigserial PRIMARY KEY,
+    agent_id    text NOT NULL REFERENCES agents(id),
+    started_at  timestamptz NOT NULL DEFAULT now(),
+    ended_at    timestamptz,
+    exit_reason text
+);
+
+CREATE INDEX IF NOT EXISTS agent_runs_agent_idx ON agent_runs (agent_id, started_at DESC);
+
+-- agent_decisions — every Strategy.Decide invocation, with the resulting
+-- decision as JSONB and any LLM provenance.
+CREATE TABLE IF NOT EXISTS agent_decisions (
+    time         timestamptz NOT NULL,
+    agent_id     text NOT NULL,
+    decision_id  text NOT NULL,
+    input_hash   text NOT NULL,
+    decision     jsonb NOT NULL,
+    rationale    text,
+    model        text,
+    provider     text,
+    tokens_in    int,
+    tokens_out   int,
+    latency_ms   int,
+    cost_usd     numeric(12,6),
+    PRIMARY KEY (agent_id, time, decision_id)
+);
+
+SELECT create_hypertable('agent_decisions', 'time', if_not_exists => TRUE);
+
+-- orders — all order intents the runtime submitted (or paper-recorded).
+CREATE TABLE IF NOT EXISTS orders (
+    time         timestamptz NOT NULL,
+    agent_id     text NOT NULL,
+    decision_id  text,
+    venue        text NOT NULL,
+    symbol       text NOT NULL,
+    side         text NOT NULL,
+    type         text NOT NULL,
+    price        numeric(38,9),
+    size         numeric(38,9) NOT NULL,
+    tif          text,
+    reduce_only  boolean NOT NULL DEFAULT false,
+    client_id    text NOT NULL,
+    venue_id     text,
+    status       text NOT NULL,
+    paper        boolean NOT NULL DEFAULT false,
+    PRIMARY KEY (agent_id, time, client_id)
+);
+
+SELECT create_hypertable('orders', 'time', if_not_exists => TRUE);
+CREATE INDEX IF NOT EXISTS orders_decision_idx ON orders (decision_id);
+
+-- swaps — all swap intents the runtime submitted.
+CREATE TABLE IF NOT EXISTS swaps (
+    time         timestamptz NOT NULL,
+    agent_id     text NOT NULL,
+    decision_id  text,
+    chain        text NOT NULL,
+    dex          text NOT NULL,
+    in_token     text NOT NULL,
+    out_token    text NOT NULL,
+    in_amount    numeric(38,9) NOT NULL,
+    out_amount   numeric(38,9) NOT NULL DEFAULT 0,
+    slippage_bps int,
+    gas_paid     numeric(38,9) NOT NULL DEFAULT 0,
+    tx_hash      text,
+    status       text NOT NULL,
+    paper        boolean NOT NULL DEFAULT false,
+    PRIMARY KEY (agent_id, time, in_token, out_token)
+);
+
+SELECT create_hypertable('swaps', 'time', if_not_exists => TRUE);
+CREATE INDEX IF NOT EXISTS swaps_decision_idx ON swaps (decision_id);
+
+-- inference_calls — LLM call audit log.
+CREATE TABLE IF NOT EXISTS inference_calls (
+    time        timestamptz NOT NULL,
+    agent_id    text,
+    provider    text NOT NULL,
+    model       text NOT NULL,
+    latency_ms  int NOT NULL DEFAULT 0,
+    tokens_in   int NOT NULL DEFAULT 0,
+    tokens_out  int NOT NULL DEFAULT 0,
+    cost_usd    numeric(12,6) NOT NULL DEFAULT 0,
+    status      text NOT NULL,
+    PRIMARY KEY (provider, time, model)
+);
+
+SELECT create_hypertable('inference_calls', 'time', if_not_exists => TRUE);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS inference_calls;
+DROP TABLE IF EXISTS swaps;
+DROP TABLE IF EXISTS orders;
+DROP TABLE IF EXISTS agent_decisions;
+DROP TABLE IF EXISTS agent_runs;
+DROP TABLE IF EXISTS agents;
+-- +goose StatementEnd


### PR DESCRIPTION
## Milestone
**M8 — Agent runtime.** A Strategy-driven decision loop that fetches state, calls \`Strategy.Decide\`, runs \`Risk.PreTrade\`, and **executes swaps before orders** (the spot-first invariant for basis strategies, [SCOPE.md §11](../blob/m8-agent-runtime/SCOPE.md#11-safety-rails-non-negotiable)). Paper mode is the default; it never touches venues.

> Stacked on top of #8 (M7).

## DB (\`migrations/0004_agents_and_decisions.sql\`)
| Table | Purpose |
|---|---|
| \`agents\` | id, mode, perp/spot venue, inference ref, universe[], allocation, tick_secs, status, config jsonb |
| \`agent_runs\` | supervisor lifecycle ledger |
| \`agent_decisions\` | hypertable; full Decision JSONB + LLM provenance (model, tokens, cost, latency) |
| \`orders\` | hypertable; every order intent, marked paper if paper-mode |
| \`swaps\` | hypertable; every swap intent, marked paper if paper-mode |
| \`inference_calls\` | hypertable; per-LLM-call audit log |

## Library (\`internal/agent\`)
- \`types.go\` — Agent, Mode (paper|live), Status, AgentRun.
- \`store.go\` — pgxpool-backed: Create, Get, List, SetStatus, StartRun/EndRun, PersistDecision/Order/Swap/InferenceCall, RecentDecisions.
- \`runtime.go\` — Runtime drives the tick loop:
  - \`buildDecisionInput\` pulls positions, balances, funding rates from the perp venue.
  - \`tickOnce\` runs Strategy → persists Decision → \`executeSwapsThenOrders\`.
  - \`executeSwap\` / \`executeOrder\` gate on \`Risk.PreTrade\`; paper mode records the intent and skips the venue; live mode quotes (swap) → submits → awaits confirm → persists actual on-chain results.
  - \`Start\` / \`Stop\` lifecycle with context cancellation; StartRun/EndRun bookkeeping; SetStatus(running|stopped).
  - Deterministic \`ClientID\` derivation for orders (\`types.DeriveClientID\`) and swaps (sha256).

## CLI
\`\`\`
permafrost agent create \\
  --strategy funding_arb_basic \\
  --perp hyperliquid --spot jupiter \\
  --inference openrouter:anthropic/claude-sonnet-4.5 \\
  --universe WIF,BONK,POPCAT \\
  --alloc 5000 --mode paper

permafrost agent list
permafrost agent status <id>
permafrost agent decisions <id> --since 1h --limit 100
permafrost agent set-mode <id> live
\`\`\`

## Tests
- **TickOnce paper mode**: passes Decision through, persists nothing to venues (\`Placed\`/\`Submitted\` both empty).
- **TickOnce live mode**: noop venues see Place + Swap calls.
- **Start/Stop lifecycle**: \`IsRunning\` toggles; double-start errors; Stop is idempotent.

## Verify locally
\`\`\`
go test ./internal/agent/... -race -count=1 -v
\`\`\`

## Out of scope (next PRs)
- Concrete risk policy + circuit breakers + kill switch → **PR #10 (M9)**
- \`funding_arb_basic\` strategy → **PR #11 (M10)**