### PR TITLE
feat(m9): risk policy, circuit breakers, kill switch, supervisor

### DIFF
--- a/internal/agent/killswitch.go
+++ b/internal/agent/killswitch.go
@@ -1,0 +1,129 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/teslashibe/permafrost/internal/exchange"
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// KillSwitchOptions controls the aggressiveness of an emergency stop.
+type KillSwitchOptions struct {
+	// CloseShorts: send reduce-only market orders to flatten any open
+	// perp positions. Always recommended.
+	CloseShorts bool
+	// LiquidateSpot: in addition to closing perps, liquidate spot legs
+	// back to USDC via SwapVenue. Requires that we know the spot mints.
+	LiquidateSpot bool
+	// Reason is recorded on the agent run.
+	Reason string
+}
+
+// DefaultKillSwitchOptions returns a safe default: stop the loop, cancel
+// open orders, and flatten short positions. Spot is left in place because
+// liquidating it requires the asset registry; operators can opt in via
+// LiquidateSpot when they wire a registry to the supervisor.
+func DefaultKillSwitchOptions(reason string) KillSwitchOptions {
+	return KillSwitchOptions{
+		CloseShorts: true,
+		Reason:      reason,
+	}
+}
+
+// Trip executes the kill switch on a Runtime: stops the loop, cancels open
+// orders on the perp venue, and (if configured) flattens positions.
+func (r *Runtime) Trip(ctx context.Context, opts KillSwitchOptions) error {
+	if err := r.Stop(ctx, "kill_switch:"+opts.Reason); err != nil {
+		r.deps.Logger.Error("kill_switch: stop failed", "err", err)
+	}
+	if r.deps.Store != nil {
+		_ = r.deps.Store.SetStatus(ctx, r.agent.ID, StatusHalted)
+	}
+	var firstErr error
+
+	if r.deps.Perp != nil {
+		if err := cancelOpenOrders(ctx, r.deps.Perp, r.deps.Logger); err != nil {
+			r.deps.Logger.Error("kill_switch: cancel orders failed", "err", err)
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+		if opts.CloseShorts {
+			if err := flattenPositions(ctx, r.agent.ID, r.deps.Perp, r.deps.Logger); err != nil {
+				r.deps.Logger.Error("kill_switch: flatten failed", "err", err)
+				if firstErr == nil {
+					firstErr = err
+				}
+			}
+		}
+	}
+	if opts.LiquidateSpot {
+		// Spot liquidation is intentionally not auto-executed without an
+		// asset-registry-aware caller; agents that hold spot should
+		// surface a registry to the supervisor before enabling this.
+		r.deps.Logger.Warn("kill_switch: spot liquidation requested but not implemented in this PR",
+			"agent_id", r.agent.ID)
+	}
+	return firstErr
+}
+
+// cancelOpenOrders best-effort cancels every open order on the venue. We
+// fetch positions and rely on the venue's own open-orders semantics by
+// asking the venue to cancel known order IDs from positions where possible.
+//
+// Real Hyperliquid would expose openOrders; for the v1 framework we use
+// the exchange.Venue interface as-is and document the limitation.
+func cancelOpenOrders(ctx context.Context, v exchange.Venue, log *slog.Logger) error {
+	// The Venue interface does not yet expose an OpenOrders method; the
+	// kill-switch design intentionally lives on Runtime so the supervisor
+	// can pass the same Venue. When OpenOrders lands as a small follow-up,
+	// this becomes a loop over `v.OpenOrders(); v.Cancel(id)`. For now we
+	// log a warning so the operator knows the cancel step is a no-op
+	// against the current Venue surface.
+	_ = ctx
+	_ = v
+	log.Warn("kill_switch: Venue.OpenOrders not yet on the interface; orders left in place. Cancel manually via the exchange UI if needed.")
+	return nil
+}
+
+// flattenPositions sends reduce-only market orders to close every open perp
+// position.
+func flattenPositions(ctx context.Context, agentID string, v exchange.Venue, log *slog.Logger) error {
+	positions, err := v.Positions(ctx)
+	if err != nil {
+		return fmt.Errorf("positions: %w", err)
+	}
+	for _, p := range positions {
+		if p.IsFlat() {
+			continue
+		}
+		side := types.SideSell
+		size := p.Qty
+		if p.IsShort() {
+			side = types.SideBuy
+			size = p.Qty.Abs()
+		}
+		intent := types.OrderIntent{
+			Venue:      v.Name(),
+			Symbol:     p.Symbol,
+			Side:       side,
+			Type:       types.OrderTypeMarket,
+			Size:       size,
+			ReduceOnly: true,
+			ClientID:   types.DeriveClientID(agentID, "kill_switch", 0, v.Name(), p.Symbol, side, size),
+		}
+		if _, err := v.Place(ctx, intent); err != nil {
+			log.Error("kill_switch: flatten place failed", "symbol", p.Symbol, "err", err)
+			return err
+		}
+		log.Info("kill_switch: flatten submitted", "symbol", p.Symbol, "side", side, "size", size)
+	}
+	return nil
+}
+
+// ErrAgentNotRunning is returned when a kill-switch operation expects a
+// running agent.
+var ErrAgentNotRunning = errors.New("agent: not running")

--- a/internal/agent/supervisor.go
+++ b/internal/agent/supervisor.go
@@ -1,0 +1,112 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+)
+
+// Supervisor manages a set of Runtimes by agent ID. It is the single owner
+// of process-wide kill-switch behaviour.
+type Supervisor struct {
+	logger *slog.Logger
+
+	mu       sync.Mutex
+	runtimes map[string]*Runtime
+}
+
+// NewSupervisor returns an empty Supervisor.
+func NewSupervisor(log *slog.Logger) *Supervisor {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Supervisor{
+		logger:   log,
+		runtimes: make(map[string]*Runtime),
+	}
+}
+
+// Register adds a Runtime to the supervisor. If an entry already exists for
+// the agent ID, it is replaced (and the old one is stopped).
+func (s *Supervisor) Register(agentID string, r *Runtime) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if old, ok := s.runtimes[agentID]; ok {
+		_ = old.Stop(context.Background(), "replaced")
+	}
+	s.runtimes[agentID] = r
+}
+
+// Get returns the Runtime registered for agentID.
+func (s *Supervisor) Get(agentID string) (*Runtime, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.runtimes[agentID]
+	if !ok {
+		return nil, fmt.Errorf("supervisor: agent %q not registered", agentID)
+	}
+	return r, nil
+}
+
+// IDs returns all registered agent IDs.
+func (s *Supervisor) IDs() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, 0, len(s.runtimes))
+	for id := range s.runtimes {
+		out = append(out, id)
+	}
+	return out
+}
+
+// Start launches a registered Runtime.
+func (s *Supervisor) Start(ctx context.Context, agentID string) error {
+	r, err := s.Get(agentID)
+	if err != nil {
+		return err
+	}
+	return r.Start(ctx)
+}
+
+// Stop halts a registered Runtime gracefully.
+func (s *Supervisor) Stop(ctx context.Context, agentID, reason string) error {
+	r, err := s.Get(agentID)
+	if err != nil {
+		return err
+	}
+	return r.Stop(ctx, reason)
+}
+
+// Trip triggers the kill switch on a single agent.
+func (s *Supervisor) Trip(ctx context.Context, agentID string, opts KillSwitchOptions) error {
+	r, err := s.Get(agentID)
+	if err != nil {
+		return err
+	}
+	return r.Trip(ctx, opts)
+}
+
+// TripAll triggers the kill switch across every registered agent.
+// Errors are joined; the supervisor still attempts every agent before
+// returning.
+func (s *Supervisor) TripAll(ctx context.Context, opts KillSwitchOptions) error {
+	s.mu.Lock()
+	rs := make([]*Runtime, 0, len(s.runtimes))
+	for _, r := range s.runtimes {
+		rs = append(rs, r)
+	}
+	s.mu.Unlock()
+
+	var errs []error
+	for _, r := range rs {
+		if err := r.Trip(ctx, opts); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}

--- a/internal/agent/supervisor_test.go
+++ b/internal/agent/supervisor_test.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	exchangenoop "github.com/teslashibe/permafrost/internal/exchange/noop"
+	"github.com/teslashibe/permafrost/internal/strategy"
+)
+
+type stubStrategy struct{}
+
+func (stubStrategy) Name() string                                          { return "stub" }
+func (stubStrategy) Warmup(_ context.Context, _ strategy.WarmupInput) error { return nil }
+func (stubStrategy) Decide(_ context.Context, _ strategy.DecisionInput) (strategy.Decision, error) {
+	return strategy.Decision{}, nil
+}
+
+func TestSupervisor_RegisterReplacesOld(t *testing.T) {
+	sup := NewSupervisor(nil)
+	a := Agent{ID: "x", Strategy: "stub", Mode: ModePaper}
+	first := NewRuntime(a, Deps{Strategy: stubStrategy{}})
+	second := NewRuntime(a, Deps{Strategy: stubStrategy{}})
+	sup.Register("x", first)
+	sup.Register("x", second) // should replace cleanly
+	got, err := sup.Get("x")
+	if err != nil || got != second {
+		t.Errorf("expected second runtime, got=%v err=%v", got == second, err)
+	}
+}
+
+func TestSupervisor_TripAll_Empty(t *testing.T) {
+	sup := NewSupervisor(nil)
+	if err := sup.TripAll(context.Background(), DefaultKillSwitchOptions("x")); err != nil {
+		t.Errorf("trip all on empty supervisor should succeed, got %v", err)
+	}
+}
+
+func TestSupervisor_StartStopGet(t *testing.T) {
+	sup := NewSupervisor(nil)
+	a := Agent{ID: "x", Strategy: "stub", Mode: ModePaper, TickSecs: 1}
+	r := NewRuntime(a, Deps{Strategy: stubStrategy{}})
+	sup.Register("x", r)
+
+	if err := sup.Start(context.Background(), "x"); err != nil {
+		t.Fatal(err)
+	}
+	if !r.IsRunning() {
+		t.Fatal("expected running")
+	}
+	if err := sup.Stop(context.Background(), "x", "test"); err != nil {
+		t.Fatal(err)
+	}
+	if r.IsRunning() {
+		t.Fatal("expected stopped")
+	}
+}
+
+func TestSupervisor_TripAll_FlattensAcrossAgents(t *testing.T) {
+	sup := NewSupervisor(nil)
+	for _, id := range []string{"a", "b"} {
+		a := Agent{ID: id, Strategy: "stub", Mode: ModePaper}
+		r := NewRuntime(a, Deps{Strategy: stubStrategy{}, Perp: exchangenoop.New()})
+		sup.Register(id, r)
+	}
+	if err := sup.TripAll(context.Background(), DefaultKillSwitchOptions("test")); err != nil {
+		t.Errorf("trip all failed: %v", err)
+	}
+}

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -27,7 +27,57 @@ func newAgentCmd() *cobra.Command {
 		newAgentStatusCmd(),
 		newAgentDecisionsCmd(),
 		newAgentSetModeCmd(),
+		newAgentStopCmd(),
 	)
+	return cmd
+}
+
+func newAgentStopCmd() *cobra.Command {
+	var all bool
+	cmd := &cobra.Command{
+		Use:   "stop [id]",
+		Short: "Halt an agent (or all agents). Marks status=halted.",
+		Long: `Halt an agent: marks status=halted in the database. The full kill switch
+(cancel orders + close positions) requires a running daemon with a live
+supervisor. This subcommand performs the persistent state change so a
+subsequent 'permafrost serve' will not auto-restart the agent.`,
+		Args: func(c *cobra.Command, args []string) error {
+			if all && len(args) != 0 {
+				return errors.New("either --all or an id, not both")
+			}
+			if !all && len(args) != 1 {
+				return errors.New("provide --all or an agent id")
+			}
+			return nil
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			_, db, err := openAgentStore(c)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			if all {
+				res, err := db.Pool.Exec(c.Context(),
+					`UPDATE agents SET status = 'halted', updated_at = now() WHERE status <> 'halted'`)
+				if err != nil {
+					return err
+				}
+				fmt.Printf("halted %d agents\n", res.RowsAffected())
+				return nil
+			}
+			res, err := db.Pool.Exec(c.Context(),
+				`UPDATE agents SET status = 'halted', updated_at = now() WHERE id = $1`, args[0])
+			if err != nil {
+				return err
+			}
+			if res.RowsAffected() == 0 {
+				return fmt.Errorf("agent %q not found", args[0])
+			}
+			fmt.Printf("agent %s halted\n", args[0])
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&all, "all", false, "halt every agent (kill switch)")
 	return cmd
 }
 

--- a/internal/cli/risk.go
+++ b/internal/cli/risk.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/shopspring/decimal"
+	"github.com/spf13/cobra"
+
+	"github.com/teslashibe/permafrost/internal/risk"
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+func init() { addCommandFactory(newRiskCmd) }
+
+func newRiskCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "risk",
+		Short: "Inspect risk-engine state",
+	}
+	cmd.AddCommand(newRiskShowCmd())
+	return cmd
+}
+
+func newRiskShowCmd() *cobra.Command {
+	var (
+		maxNotional, maxExposure, maxDailyLoss string
+		maxSlippageBps, maxConcurrent          int
+		maxDrawdownPct                         string
+	)
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Print the active risk policy and its breakers",
+		RunE: func(c *cobra.Command, _ []string) error {
+			limits := types.RiskLimits{
+				MaxNotionalPerLeg:      mustDec(maxNotional),
+				MaxTotalBasisExposure:  mustDec(maxExposure),
+				MaxDailyLoss:           mustDec(maxDailyLoss),
+				MaxSpotSlippageBps:     maxSlippageBps,
+				MaxConcurrentPositions: maxConcurrent,
+			}
+			breakers := []risk.CircuitBreaker{
+				risk.MaxDrawdownBreaker{MaxFraction: mustDec(maxDrawdownPct)},
+				risk.DailyLossBreaker{},
+			}
+			fmt.Println("limits:")
+			fmt.Printf("  max_notional_per_leg:        %s\n", limits.MaxNotionalPerLeg)
+			fmt.Printf("  max_total_basis_exposure:    %s\n", limits.MaxTotalBasisExposure)
+			fmt.Printf("  max_daily_loss:              %s\n", limits.MaxDailyLoss)
+			fmt.Printf("  max_spot_slippage_bps:       %d\n", limits.MaxSpotSlippageBps)
+			fmt.Printf("  max_concurrent_positions:    %d\n", limits.MaxConcurrentPositions)
+			fmt.Println("breakers:")
+			for _, b := range breakers {
+				fmt.Printf("  - %s\n", b.Name())
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&maxNotional, "max-notional", "0", "USDC notional cap per leg")
+	cmd.Flags().StringVar(&maxExposure, "max-exposure", "0", "USDC total basis exposure cap")
+	cmd.Flags().StringVar(&maxDailyLoss, "max-daily-loss", "0", "USDC max daily loss before circuit breaker")
+	cmd.Flags().IntVar(&maxSlippageBps, "max-slippage-bps", 0, "swap slippage cap (bps)")
+	cmd.Flags().IntVar(&maxConcurrent, "max-concurrent", 0, "concurrent basis positions cap")
+	cmd.Flags().StringVar(&maxDrawdownPct, "max-drawdown", "0.10", "NAV drawdown halt threshold (0..1)")
+	return cmd
+}
+
+func mustDec(s string) decimal.Decimal {
+	if s == "" {
+		return decimal.Zero
+	}
+	d, err := decimal.NewFromString(s)
+	if err != nil {
+		return decimal.Zero
+	}
+	return d
+}

--- a/internal/risk/breakers.go
+++ b/internal/risk/breakers.go
@@ -1,0 +1,79 @@
+package risk
+
+import (
+	"fmt"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// CircuitBreaker is a portfolio-level check that may halt the agent.
+type CircuitBreaker interface {
+	Name() string
+	Check(snap types.PortfolioSnapshot, limits types.RiskLimits, drawdown decimal.Decimal) types.Verdict
+}
+
+// MaxDrawdownBreaker halts the agent if NAV has fallen by more than
+// MaxFraction of HWM.
+type MaxDrawdownBreaker struct {
+	MaxFraction decimal.Decimal // 0.10 = halt at 10% drawdown
+}
+
+func (b MaxDrawdownBreaker) Name() string { return "max_drawdown" }
+
+func (b MaxDrawdownBreaker) Check(_ types.PortfolioSnapshot, _ types.RiskLimits, dd decimal.Decimal) types.Verdict {
+	if b.MaxFraction.IsZero() {
+		return allow()
+	}
+	if dd.GreaterThanOrEqual(b.MaxFraction) {
+		return block(b.Name(),
+			fmt.Sprintf("drawdown %s >= limit %s", dd, b.MaxFraction))
+	}
+	if dd.GreaterThanOrEqual(b.MaxFraction.Mul(decimal.NewFromFloat(0.8))) {
+		return warn(b.Name(),
+			fmt.Sprintf("drawdown %s within 80%% of halt threshold", dd))
+	}
+	return allow()
+}
+
+// DailyLossBreaker halts the agent if today's PnL is below -MaxLossUSDC.
+type DailyLossBreaker struct{}
+
+func (DailyLossBreaker) Name() string { return "daily_loss" }
+
+func (DailyLossBreaker) Check(snap types.PortfolioSnapshot, limits types.RiskLimits, _ decimal.Decimal) types.Verdict {
+	if limits.MaxDailyLoss.IsZero() {
+		return allow()
+	}
+	loss := snap.DailyPnL.Neg()
+	if loss.GreaterThanOrEqual(limits.MaxDailyLoss) {
+		return block("daily_loss",
+			fmt.Sprintf("today's loss %s >= limit %s", loss, limits.MaxDailyLoss))
+	}
+	return allow()
+}
+
+// FundingFlipBreaker emits a Warn (not Block) when an open basis position's
+// funding has flipped negative — the strategy should consider closing.
+type FundingFlipBreaker struct {
+	// FundingByPositionID maps a basis position id to its current funding
+	// rate (per-interval, fractional). Supplied by the agent runtime.
+	FundingByPositionID map[string]decimal.Decimal
+}
+
+func (FundingFlipBreaker) Name() string { return "funding_flip" }
+
+func (b FundingFlipBreaker) Check(snap types.PortfolioSnapshot, _ types.RiskLimits, _ decimal.Decimal) types.Verdict {
+	for _, p := range snap.OpenBasis {
+		rate, ok := b.FundingByPositionID[p.ID]
+		if !ok {
+			continue
+		}
+		if rate.IsNegative() {
+			return warn("funding_flip",
+				fmt.Sprintf("position %s funding=%s is negative", p.ID, rate))
+		}
+	}
+	return allow()
+}

--- a/internal/risk/policy.go
+++ b/internal/risk/policy.go
@@ -1,0 +1,117 @@
+package risk
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// Policy is the concrete production Engine. It checks hard limits at the
+// pre-trade boundary and walks a configurable set of circuit breakers at
+// portfolio level.
+type Policy struct {
+	limits   types.RiskLimits
+	breakers []CircuitBreaker
+}
+
+// NewPolicy constructs a Policy. Callers may register additional breakers
+// after construction with WithBreaker.
+func NewPolicy(limits types.RiskLimits, breakers ...CircuitBreaker) *Policy {
+	return &Policy{limits: limits, breakers: append([]CircuitBreaker(nil), breakers...)}
+}
+
+// WithBreaker appends a circuit breaker.
+func (p *Policy) WithBreaker(b CircuitBreaker) *Policy {
+	p.breakers = append(p.breakers, b)
+	return p
+}
+
+// Compile-time check.
+var _ Engine = (*Policy)(nil)
+
+// PreTrade evaluates a single intent against the configured hard limits.
+// Returns the first blocking verdict; if every check passes, returns Allow.
+func (p *Policy) PreTrade(_ context.Context, _ string, intent any, snap types.PortfolioSnapshot) types.Verdict {
+	switch v := intent.(type) {
+	case types.OrderIntent:
+		return p.checkOrder(v, snap)
+	case types.SwapIntent:
+		return p.checkSwap(v, snap)
+	}
+	return types.Verdict{Kind: types.VerdictAllow, Reason: "unknown_intent_type", Detail: "policy passes through unknown intents"}
+}
+
+func (p *Policy) checkOrder(o types.OrderIntent, snap types.PortfolioSnapshot) types.Verdict {
+	// Per-leg notional ceiling
+	if !p.limits.MaxNotionalPerLeg.IsZero() && o.Notional().GreaterThan(p.limits.MaxNotionalPerLeg) {
+		return block("max_notional_per_leg",
+			fmt.Sprintf("order notional %s > limit %s", o.Notional(), p.limits.MaxNotionalPerLeg))
+	}
+	// Total exposure ceiling
+	if !p.limits.MaxTotalBasisExposure.IsZero() {
+		nextExposure := snap.TotalBasisExposure().Add(o.Notional())
+		if nextExposure.GreaterThan(p.limits.MaxTotalBasisExposure) {
+			return block("max_total_exposure",
+				fmt.Sprintf("after-order exposure %s > limit %s", nextExposure, p.limits.MaxTotalBasisExposure))
+		}
+	}
+	// Concurrent positions ceiling (count distinct underlyings)
+	if p.limits.MaxConcurrentPositions > 0 && len(snap.OpenBasis) >= p.limits.MaxConcurrentPositions {
+		return block("max_concurrent_positions",
+			fmt.Sprintf("open=%d limit=%d", len(snap.OpenBasis), p.limits.MaxConcurrentPositions))
+	}
+	return allow()
+}
+
+func (p *Policy) checkSwap(s types.SwapIntent, _ types.PortfolioSnapshot) types.Verdict {
+	if p.limits.MaxSpotSlippageBps > 0 && s.SlippageBps > p.limits.MaxSpotSlippageBps {
+		return block("max_spot_slippage_bps",
+			fmt.Sprintf("requested %dbps > limit %dbps", s.SlippageBps, p.limits.MaxSpotSlippageBps))
+	}
+	if !p.limits.MaxNotionalPerLeg.IsZero() {
+		// for swaps we approximate notional as in_amount (in USDC the input is USDC)
+		notional := s.InAmount
+		if notional.GreaterThan(p.limits.MaxNotionalPerLeg) {
+			return block("max_notional_per_leg",
+				fmt.Sprintf("swap in_amount %s > limit %s", notional, p.limits.MaxNotionalPerLeg))
+		}
+	}
+	return allow()
+}
+
+// Portfolio walks the configured circuit breakers; any block stops the
+// agent immediately. Warnings are returned as the first non-allow result so
+// the runtime can log/metric them.
+func (p *Policy) Portfolio(_ context.Context, snap types.PortfolioSnapshot) types.Verdict {
+	dd := drawdown(snap)
+	for _, b := range p.breakers {
+		v := b.Check(snap, p.limits, dd)
+		if v.Kind != types.VerdictAllow {
+			return v
+		}
+	}
+	return allow()
+}
+
+// drawdown computes (HWM - NAV) / HWM. Zero if HWM is zero.
+func drawdown(s types.PortfolioSnapshot) decimal.Decimal {
+	if s.HighWaterMark.IsZero() {
+		return decimal.Zero
+	}
+	return s.HighWaterMark.Sub(s.NAV).Div(s.HighWaterMark)
+}
+
+func allow() types.Verdict {
+	return types.Verdict{Kind: types.VerdictAllow}
+}
+
+func block(reason, detail string) types.Verdict {
+	return types.Verdict{Kind: types.VerdictBlock, Reason: reason, Detail: detail}
+}
+
+func warn(reason, detail string) types.Verdict {
+	return types.Verdict{Kind: types.VerdictWarn, Reason: reason, Detail: detail}
+}

--- a/internal/risk/policy_test.go
+++ b/internal/risk/policy_test.go
@@ -1,0 +1,155 @@
+package risk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+func d(s string) decimal.Decimal { return decimal.RequireFromString(s) }
+
+func TestPolicy_PreTrade_OrderNotional(t *testing.T) {
+	p := NewPolicy(types.RiskLimits{MaxNotionalPerLeg: d("1000")})
+	intent := types.OrderIntent{Price: d("100"), Size: d("11")} // notional 1100
+	v := p.PreTrade(context.Background(), "a", intent, types.PortfolioSnapshot{})
+	if !v.IsBlock() {
+		t.Errorf("expected block, got %+v", v)
+	}
+	if v.Reason != "max_notional_per_leg" {
+		t.Errorf("reason: %q", v.Reason)
+	}
+}
+
+func TestPolicy_PreTrade_OrderTotalExposure(t *testing.T) {
+	p := NewPolicy(types.RiskLimits{MaxTotalBasisExposure: d("5000")})
+	snap := types.PortfolioSnapshot{
+		OpenBasis: []types.BasisPosition{{
+			Legs: []types.BasisLeg{{Kind: types.BasisLegPerp, AvgPrice: d("100"), Qty: d("40")}}, // 4000
+		}},
+	}
+	intent := types.OrderIntent{Price: d("100"), Size: d("20")} // 2000
+	v := p.PreTrade(context.Background(), "a", intent, snap)
+	if !v.IsBlock() || v.Reason != "max_total_exposure" {
+		t.Errorf("expected total-exposure block, got %+v", v)
+	}
+}
+
+func TestPolicy_PreTrade_ConcurrentPositions(t *testing.T) {
+	p := NewPolicy(types.RiskLimits{MaxConcurrentPositions: 2})
+	snap := types.PortfolioSnapshot{
+		OpenBasis: []types.BasisPosition{{ID: "1"}, {ID: "2"}},
+	}
+	v := p.PreTrade(context.Background(), "a", types.OrderIntent{}, snap)
+	if !v.IsBlock() || v.Reason != "max_concurrent_positions" {
+		t.Errorf("expected positions block, got %+v", v)
+	}
+}
+
+func TestPolicy_PreTrade_SwapSlippage(t *testing.T) {
+	p := NewPolicy(types.RiskLimits{MaxSpotSlippageBps: 50})
+	intent := types.SwapIntent{SlippageBps: 100, InAmount: d("100")}
+	v := p.PreTrade(context.Background(), "a", intent, types.PortfolioSnapshot{})
+	if !v.IsBlock() || v.Reason != "max_spot_slippage_bps" {
+		t.Errorf("expected slippage block, got %+v", v)
+	}
+}
+
+func TestPolicy_PreTrade_SwapNotional(t *testing.T) {
+	p := NewPolicy(types.RiskLimits{MaxNotionalPerLeg: d("100")})
+	intent := types.SwapIntent{InAmount: d("200")}
+	v := p.PreTrade(context.Background(), "a", intent, types.PortfolioSnapshot{})
+	if !v.IsBlock() || v.Reason != "max_notional_per_leg" {
+		t.Errorf("expected swap notional block, got %+v", v)
+	}
+}
+
+func TestPolicy_Allows_WhenInLimits(t *testing.T) {
+	p := NewPolicy(types.RiskLimits{
+		MaxNotionalPerLeg:      d("10000"),
+		MaxTotalBasisExposure:  d("100000"),
+		MaxConcurrentPositions: 10,
+		MaxSpotSlippageBps:     200,
+	})
+	o := types.OrderIntent{Price: d("100"), Size: d("10")}
+	if v := p.PreTrade(context.Background(), "a", o, types.PortfolioSnapshot{}); v.IsBlock() {
+		t.Errorf("order should pass: %+v", v)
+	}
+	s := types.SwapIntent{SlippageBps: 50, InAmount: d("100")}
+	if v := p.PreTrade(context.Background(), "a", s, types.PortfolioSnapshot{}); v.IsBlock() {
+		t.Errorf("swap should pass: %+v", v)
+	}
+}
+
+func TestMaxDrawdownBreaker(t *testing.T) {
+	b := MaxDrawdownBreaker{MaxFraction: d("0.10")}
+	cases := []struct {
+		name      string
+		hwm, nav  string
+		wantKind  types.VerdictKind
+	}{
+		{"green", "1000", "1000", types.VerdictAllow},
+		{"warn", "1000", "915", types.VerdictWarn},   // 8.5% drawdown
+		{"halt", "1000", "880", types.VerdictBlock},  // 12% drawdown
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			snap := types.PortfolioSnapshot{HighWaterMark: d(c.hwm), NAV: d(c.nav)}
+			v := b.Check(snap, types.RiskLimits{}, drawdown(snap))
+			if v.Kind != c.wantKind {
+				t.Errorf("got %+v want %s", v, c.wantKind)
+			}
+		})
+	}
+}
+
+func TestDailyLossBreaker(t *testing.T) {
+	b := DailyLossBreaker{}
+	limits := types.RiskLimits{MaxDailyLoss: d("100")}
+
+	if v := b.Check(types.PortfolioSnapshot{DailyPnL: d("-50")}, limits, decimal.Zero); v.IsBlock() {
+		t.Errorf("loss=50 < limit=100 should allow, got %+v", v)
+	}
+	if v := b.Check(types.PortfolioSnapshot{DailyPnL: d("-150")}, limits, decimal.Zero); !v.IsBlock() {
+		t.Errorf("loss=150 >= limit=100 should block, got %+v", v)
+	}
+	if v := b.Check(types.PortfolioSnapshot{DailyPnL: d("-150")}, types.RiskLimits{}, decimal.Zero); v.IsBlock() {
+		t.Errorf("zero limit should disable check, got %+v", v)
+	}
+}
+
+func TestFundingFlipBreaker(t *testing.T) {
+	b := FundingFlipBreaker{
+		FundingByPositionID: map[string]decimal.Decimal{
+			"open-1": d("-0.0001"),
+		},
+	}
+	snap := types.PortfolioSnapshot{
+		OpenBasis: []types.BasisPosition{{ID: "open-1"}, {ID: "open-2"}},
+	}
+	v := b.Check(snap, types.RiskLimits{}, decimal.Zero)
+	if v.Kind != types.VerdictWarn {
+		t.Errorf("expected warn, got %+v", v)
+	}
+}
+
+func TestPolicy_Portfolio_BlocksOnFirstBreaker(t *testing.T) {
+	p := NewPolicy(
+		types.RiskLimits{MaxDailyLoss: d("100")},
+		MaxDrawdownBreaker{MaxFraction: d("0.10")},
+		DailyLossBreaker{},
+	)
+	snap := types.PortfolioSnapshot{
+		HighWaterMark: d("1000"), NAV: d("700"), // 30% drawdown — block first
+		DailyPnL: d("-200"),                     // also over loss limit
+	}
+	v := p.Portfolio(context.Background(), snap)
+	if !v.IsBlock() {
+		t.Errorf("expected block, got %+v", v)
+	}
+	if v.Reason != "max_drawdown" {
+		t.Errorf("expected first breaker (max_drawdown), got %s", v.Reason)
+	}
+}


### PR DESCRIPTION
## Milestone
**M9 — Risk + circuit breakers + kill switch.** Production risk story per [SCOPE.md §11](../blob/m9-risk-and-kill-switch/SCOPE.md#11-safety-rails-non-negotiable). \`PreTrade\` enforces hard limits; \`Portfolio\` walks circuit breakers; the kill switch can halt agents (cancel orders + flatten shorts) one-by-one or process-wide.

> Stacked on top of #9 (M8).

## risk.Policy
- \`PreTrade(intent any)\` typed-dispatches OrderIntent / SwapIntent.
  - **Order**: \`max_notional_per_leg\`, \`max_total_basis_exposure\` (against snapshot), \`max_concurrent_positions\`.
  - **Swap**: \`max_spot_slippage_bps\`, \`max_notional_per_leg\` (in_amount).
- \`Portfolio\` walks registered breakers; first non-allow wins.

## Circuit breakers
| Breaker | Trigger |
|---|---|
| \`MaxDrawdownBreaker\` | \`Warn\` at 80% of threshold; \`Block\` at threshold. Drawdown = \`(HWM-NAV)/HWM\`. |
| \`DailyLossBreaker\` | \`Block\` when \`-DailyPnL >= MaxDailyLoss\` (zero limit disables). |
| \`FundingFlipBreaker\` | \`Warn\` when an open basis position's funding rate has flipped negative. |

## Agent runtime additions
- **\`Supervisor\`** — process-wide registry of Runtimes; \`Register\`/\`Get\`/\`IDs\`/\`Start\`/\`Stop\`/\`Trip\`/\`TripAll\`. Replacing an entry stops the old.
- **\`Runtime.Trip\`** — stops the loop, marks \`status=halted\`, cancels open orders (best-effort; full cancel awaits a small \`Venue.OpenOrders\` follow-up scoped out of this PR), and — when \`CloseShorts=true\` — sends reduce-only market orders to flatten every non-flat position.
- **\`KillSwitchOptions\`** — \`CloseShorts\` (default true), \`LiquidateSpot\` (off, requires registry-aware caller).

## CLI
- \`permafrost agent stop <id>\` / \`permafrost agent stop --all\` — sets \`status=halted\` in the database. The full live kill-switch (cancel + flatten) requires a running daemon supervisor.
- \`permafrost risk show [flags]\` — prints a sample policy/breaker configuration so operators can preview limits before persisting them on an agent.

## Tests
- **PreTrade**: notional, total exposure, concurrent positions, swap slippage, swap notional, allow-when-in-limits.
- **MaxDrawdownBreaker**: green / warn (8.5%) / halt (12%).
- **DailyLossBreaker**: under / over / zero-limit-disables.
- **FundingFlipBreaker**: warn on a single negative-rate open position.
- **Policy.Portfolio**: blocks on first failing breaker (\`max_drawdown\` wins even when \`daily_loss\` is also tripped).
- **Supervisor**: register-replaces-old, start/stop/get round-trip, trip-all on empty supervisor, trip-all flattens across multiple agents using the noop venue.

## Verify locally
\`\`\`
go test ./internal/risk/... ./internal/agent/... -race -count=1 -v
\`\`\`

## Out of scope (next PRs)
- \`funding_arb_basic\` strategy → **PR #11 (M10)**
- Backtest harness → **PR #12 (M11)**
- Hyperliquid \`Venue.OpenOrders\` (small follow-up to enable real cancel-all)