### PR TITLE
feat(m10): funding_arb_basic — first agent

### DIFF
--- a/internal/strategy/funding_arb_basic/config.go
+++ b/internal/strategy/funding_arb_basic/config.go
@@ -1,0 +1,87 @@
+// Package funding_arb_basic implements the first Permafrost trading strategy:
+// a delta-neutral funding-rate arb that goes long spot on Solana via Jupiter
+// and short perp on Hyperliquid. The strategy is deterministic; the LLM is
+// optionally consulted to VETO new entries based on event/news context, but
+// it never invents trades.
+//
+// See SCOPE.md §14 for the design rationale.
+package funding_arb_basic
+
+import (
+	"errors"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// Name is the registered identifier for this strategy.
+const Name = "funding_arb_basic"
+
+// Config controls strategy thresholds. All fields have safe defaults so an
+// agent can be created with an empty config and still run a sensible baseline.
+type Config struct {
+	// Annualised funding (fractional, e.g. 0.50 = 50% APR) at which a new
+	// basis position is opened. Default 0.50.
+	EntryAnnualisedFunding decimal.Decimal
+
+	// Annualised funding below which an open basis is closed.
+	// Default 0.10.
+	ExitAnnualisedFunding decimal.Decimal
+
+	// Max notional per basis position in USDC.
+	PositionCapUSDC decimal.Decimal
+
+	// Don't reopen a symbol within this window of its last close.
+	// Default 4h.
+	PerSymbolCooldown time.Duration
+
+	// Max basis (perp - spot) at entry, in basis points. 0 disables.
+	MaxEntryBasisBps int
+
+	// Slippage budget for spot swaps (bps).
+	SlippageBps int
+
+	// If true, ask the inference provider for a veto on each candidate.
+	UseLLMVeto bool
+
+	// Model to use for the veto. e.g. "openrouter/anthropic/claude-sonnet-4.5"
+	// or "gpt-5-mini".
+	VetoModel string
+
+	// Universe override; empty defaults to the tradable subset of the
+	// registry intersected with the agent's universe.
+	Universe []string
+}
+
+// Defaults applies sensible defaults to zero-valued fields.
+func (c *Config) Defaults() {
+	if c.EntryAnnualisedFunding.IsZero() {
+		c.EntryAnnualisedFunding = decimal.NewFromFloat(0.50)
+	}
+	if c.ExitAnnualisedFunding.IsZero() {
+		c.ExitAnnualisedFunding = decimal.NewFromFloat(0.10)
+	}
+	if c.PositionCapUSDC.IsZero() {
+		c.PositionCapUSDC = decimal.NewFromInt(1000)
+	}
+	if c.PerSymbolCooldown == 0 {
+		c.PerSymbolCooldown = 4 * time.Hour
+	}
+	if c.SlippageBps == 0 {
+		c.SlippageBps = 50
+	}
+}
+
+// Validate checks the config for sanity.
+func (c Config) Validate() error {
+	if c.EntryAnnualisedFunding.LessThanOrEqual(c.ExitAnnualisedFunding) {
+		return errors.New("funding_arb_basic: entry threshold must be greater than exit threshold")
+	}
+	if !c.PositionCapUSDC.IsPositive() {
+		return errors.New("funding_arb_basic: PositionCapUSDC must be positive")
+	}
+	if c.SlippageBps < 0 || c.SlippageBps > 1000 {
+		return errors.New("funding_arb_basic: SlippageBps out of range (0..1000)")
+	}
+	return nil
+}

--- a/internal/strategy/funding_arb_basic/strategy.go
+++ b/internal/strategy/funding_arb_basic/strategy.go
@@ -1,0 +1,251 @@
+package funding_arb_basic
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/assets"
+	"github.com/teslashibe/permafrost/internal/inference"
+	"github.com/teslashibe/permafrost/internal/strategy"
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// Strategy is the deterministic funding-arb strategy.
+type Strategy struct {
+	cfg       Config
+	registry  assets.Registry
+	inference inference.Provider // optional; nil disables LLM veto
+	clock     func() time.Time
+}
+
+// New constructs the strategy. registry is required (the trade universe);
+// inf may be nil if the operator opts out of the LLM veto.
+func New(cfg Config, registry assets.Registry, inf inference.Provider) (*Strategy, error) {
+	cfg.Defaults()
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	if registry.Version == 0 || len(registry.Assets) == 0 {
+		return nil, fmt.Errorf("funding_arb_basic: empty asset registry")
+	}
+	return &Strategy{
+		cfg:       cfg,
+		registry:  registry,
+		inference: inf,
+		clock:     func() time.Time { return time.Now().UTC() },
+	}, nil
+}
+
+// SetClock overrides the clock function. For tests only.
+func (s *Strategy) SetClock(fn func() time.Time) { s.clock = fn }
+
+// Compile-time check.
+var _ strategy.Strategy = (*Strategy)(nil)
+
+func (s *Strategy) Name() string { return Name }
+
+// Warmup is a no-op for v1; future versions may pre-fetch funding history.
+func (s *Strategy) Warmup(_ context.Context, _ strategy.WarmupInput) error { return nil }
+
+// Decide produces opens for high-funding candidates and closes for any open
+// positions where funding has fallen below the exit threshold.
+func (s *Strategy) Decide(ctx context.Context, in strategy.DecisionInput) (strategy.Decision, error) {
+	dec := strategy.Decision{}
+	openSymbols := openSymbolSet(in.BasisPositions)
+
+	// Closes first — these don't compete for capital.
+	for _, p := range in.BasisPositions {
+		if !shouldClose(p, in.Market, s.cfg) {
+			continue
+		}
+		closeSwap, closeOrder := closeIntents(p, in.AgentID)
+		dec.Swaps = append(dec.Swaps, closeSwap)
+		dec.Orders = append(dec.Orders, closeOrder)
+	}
+
+	// Opens — rank by annualised funding, filter, ask LLM veto if enabled.
+	candidates := s.rank(in)
+	for _, c := range candidates {
+		if openSymbols[strings.ToUpper(c.Symbol)] {
+			continue
+		}
+		if s.cfg.UseLLMVeto && s.inference != nil {
+			veto, reason, err := s.askVeto(ctx, c)
+			if err != nil {
+				dec.Notes = appendNote(dec.Notes, fmt.Sprintf("veto error for %s: %v", c.Symbol, err))
+				continue
+			}
+			if veto {
+				dec.Notes = appendNote(dec.Notes, fmt.Sprintf("vetoed %s: %s", c.Symbol, reason))
+				continue
+			}
+		}
+		spotIntent, perpIntent := openIntents(c, s.cfg, in.AgentID)
+		dec.Swaps = append(dec.Swaps, spotIntent)
+		dec.Orders = append(dec.Orders, perpIntent)
+		dec.Notes = appendNote(dec.Notes, fmt.Sprintf("opening %s @ funding %s/yr", c.Symbol, c.Annualised))
+	}
+
+	dec.Confidence = candidateConfidence(candidates)
+	return dec, nil
+}
+
+// candidate is one ranked tradable asset.
+type candidate struct {
+	Symbol     string
+	Funding    types.FundingRate
+	Annualised decimal.Decimal
+	Asset      assets.Asset
+}
+
+func (s *Strategy) rank(in strategy.DecisionInput) []candidate {
+	universe := s.cfg.Universe
+	if len(universe) == 0 {
+		for _, a := range s.registry.Tradable() {
+			universe = append(universe, a.Symbol)
+		}
+	}
+	out := make([]candidate, 0, len(universe))
+	for _, sym := range universe {
+		a, ok := s.registry.Get(sym)
+		if !ok || !a.Tradable() {
+			continue
+		}
+		snap, ok := in.Market.Symbols[a.Perp.Symbol]
+		if !ok {
+			continue
+		}
+		ann := snap.Funding.Annualised()
+		if ann.LessThan(s.cfg.EntryAnnualisedFunding) {
+			continue
+		}
+		out = append(out, candidate{
+			Symbol:     a.Symbol,
+			Funding:    snap.Funding,
+			Annualised: ann,
+			Asset:      a,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Annualised.GreaterThan(out[j].Annualised) })
+	return out
+}
+
+func shouldClose(p types.BasisPosition, snap types.MarketSnapshot, cfg Config) bool {
+	if p.State != types.BasisStateOpen {
+		return false
+	}
+	for _, leg := range p.Legs {
+		if leg.Kind != types.BasisLegPerp {
+			continue
+		}
+		s, ok := snap.Symbols[leg.Symbol]
+		if !ok {
+			return false
+		}
+		ann := s.Funding.Annualised()
+		return ann.LessThan(cfg.ExitAnnualisedFunding)
+	}
+	return false
+}
+
+func openSymbolSet(positions []types.BasisPosition) map[string]bool {
+	out := make(map[string]bool, len(positions))
+	for _, p := range positions {
+		if p.State == types.BasisStateOpen || p.State == types.BasisStateOpening {
+			out[strings.ToUpper(p.Underlying)] = true
+		}
+	}
+	return out
+}
+
+// openIntents builds the spot-buy + perp-short pair for a candidate.
+func openIntents(c candidate, cfg Config, agentID string) (types.SwapIntent, types.OrderIntent) {
+	usdc := types.Asset{Symbol: "USDC", Chain: c.Asset.Spot.Chain, Mint: usdcMintFor(c.Asset.Spot.Chain), Decimals: 6}
+	swap := types.SwapIntent{
+		Chain:       c.Asset.Spot.Chain,
+		InToken:     usdc,
+		OutToken:    c.Asset.AsAsset(),
+		InAmount:    cfg.PositionCapUSDC,
+		SlippageBps: cfg.SlippageBps,
+		Tag:         "open:" + c.Symbol,
+	}
+	perp := types.OrderIntent{
+		Venue:      c.Asset.Perp.Venue,
+		Symbol:     c.Asset.Perp.Symbol,
+		Side:       types.SideSell,
+		Type:       types.OrderTypeMarket,
+		Size:       cfg.PositionCapUSDC, // notional; the runtime/venue will translate to base units in M3+
+		ReduceOnly: false,
+		Tag:        "open:" + c.Symbol,
+	}
+	_ = agentID
+	return swap, perp
+}
+
+// closeIntents builds the unwind pair for an open basis position.
+func closeIntents(p types.BasisPosition, agentID string) (types.SwapIntent, types.OrderIntent) {
+	var spotLeg, perpLeg types.BasisLeg
+	for _, l := range p.Legs {
+		switch l.Kind {
+		case types.BasisLegSpot:
+			spotLeg = l
+		case types.BasisLegPerp:
+			perpLeg = l
+		}
+	}
+	usdc := types.Asset{Symbol: "USDC", Chain: spotLeg.Asset.Chain, Mint: usdcMintFor(spotLeg.Asset.Chain), Decimals: 6}
+	swap := types.SwapIntent{
+		Chain:    spotLeg.Asset.Chain,
+		InToken:  spotLeg.Asset,
+		OutToken: usdc,
+		InAmount: spotLeg.Qty,
+		Tag:      "close:" + p.Underlying,
+	}
+	perp := types.OrderIntent{
+		Venue:      "hyperliquid",
+		Symbol:     perpLeg.Symbol,
+		Side:       types.SideBuy, // closing a short → buy back
+		Type:       types.OrderTypeMarket,
+		Size:       perpLeg.Qty,
+		ReduceOnly: true,
+		Tag:        "close:" + p.Underlying,
+	}
+	_ = agentID
+	return swap, perp
+}
+
+// usdcMintFor returns the canonical USDC mint for a chain. Hard-coded for
+// MVP; future versions can drive this off the registry.
+func usdcMintFor(chain types.ChainID) string {
+	switch chain {
+	case types.ChainSolana:
+		return "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+	default:
+		return ""
+	}
+}
+
+func appendNote(existing, line string) string {
+	if existing == "" {
+		return line
+	}
+	return existing + "\n" + line
+}
+
+// candidateConfidence is a simple monotonic mapping: more candidates → higher
+// confidence, capped at 1.0.
+func candidateConfidence(c []candidate) float64 {
+	switch n := len(c); {
+	case n == 0:
+		return 0
+	case n >= 5:
+		return 1.0
+	default:
+		return float64(n) / 5.0
+	}
+}

--- a/internal/strategy/funding_arb_basic/strategy_test.go
+++ b/internal/strategy/funding_arb_basic/strategy_test.go
@@ -1,0 +1,257 @@
+package funding_arb_basic
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/assets"
+	"github.com/teslashibe/permafrost/internal/inference"
+	"github.com/teslashibe/permafrost/internal/inference/mock"
+	"github.com/teslashibe/permafrost/internal/strategy"
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+func loadRegistry(t *testing.T) assets.Registry {
+	t.Helper()
+	r, err := assets.LoadEmbedded()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
+func d(s string) decimal.Decimal { return decimal.RequireFromString(s) }
+
+// fundingSymbol builds a SymbolSnap with a fixed annualised funding rate.
+// The rate is per-hour, so an annual ann = rate * 24*365.
+func fundingSymbol(symbol string, hourlyRate decimal.Decimal) types.SymbolSnap {
+	return types.SymbolSnap{
+		Funding: types.FundingRate{
+			Symbol:   symbol,
+			Rate:     hourlyRate,
+			Interval: time.Hour,
+		},
+	}
+}
+
+func TestNew_ValidatesConfig(t *testing.T) {
+	r := loadRegistry(t)
+	if _, err := New(Config{
+		EntryAnnualisedFunding: d("0.1"),
+		ExitAnnualisedFunding:  d("0.2"),
+		PositionCapUSDC:        d("100"),
+	}, r, nil); err == nil {
+		t.Errorf("entry < exit should error")
+	}
+	if _, err := New(Config{
+		EntryAnnualisedFunding: d("0.5"),
+		ExitAnnualisedFunding:  d("0.1"),
+		PositionCapUSDC:        d("-1"),
+	}, r, nil); err == nil {
+		t.Errorf("negative PositionCapUSDC should error")
+	}
+	if _, err := New(Config{}, r, nil); err != nil {
+		t.Errorf("empty config should succeed via Defaults, got %v", err)
+	}
+}
+
+func TestDecide_OpensTopFundingCandidate(t *testing.T) {
+	r := loadRegistry(t)
+	s, err := New(Config{
+		EntryAnnualisedFunding: d("0.5"),
+		ExitAnnualisedFunding:  d("0.1"),
+		PositionCapUSDC:        d("100"),
+	}, r, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := strategy.DecisionInput{
+		AgentID: "ag",
+		Now:     time.Now().UTC(),
+		Market: types.MarketSnapshot{
+			Time: time.Now().UTC(),
+			Symbols: map[string]types.SymbolSnap{
+				"WIF":  fundingSymbol("WIF", d("0.0001")),  // ann ≈ 0.876
+				"BONK": fundingSymbol("BONK", d("0.00001")), // ann ≈ 0.0876, below threshold
+			},
+		},
+	}
+	dec, err := s.Decide(context.Background(), in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dec.Swaps) != 1 || len(dec.Orders) != 1 {
+		t.Fatalf("expected exactly one swap+order pair, got swaps=%d orders=%d", len(dec.Swaps), len(dec.Orders))
+	}
+	if dec.Orders[0].Symbol != "WIF" || dec.Swaps[0].OutToken.Symbol != "WIF" {
+		t.Errorf("expected WIF (highest ann funding), got swap=%+v order=%+v", dec.Swaps[0].OutToken, dec.Orders[0])
+	}
+	if dec.Orders[0].Side != types.SideSell {
+		t.Errorf("perp leg should be sell, got %s", dec.Orders[0].Side)
+	}
+}
+
+func TestDecide_ClosesWhenFundingFalls(t *testing.T) {
+	r := loadRegistry(t)
+	s, _ := New(Config{
+		EntryAnnualisedFunding: d("0.5"),
+		ExitAnnualisedFunding:  d("0.1"),
+		PositionCapUSDC:        d("100"),
+	}, r, nil)
+	wif, _ := r.Get("WIF")
+	open := types.BasisPosition{
+		ID:         "p1",
+		AgentID:    "ag",
+		Underlying: "WIF",
+		State:      types.BasisStateOpen,
+		Legs: []types.BasisLeg{
+			{Kind: types.BasisLegSpot, Asset: wif.AsAsset(), Qty: d("100")},
+			{Kind: types.BasisLegPerp, Symbol: "WIF", Qty: d("100"), AvgPrice: d("1")},
+		},
+	}
+	in := strategy.DecisionInput{
+		AgentID:        "ag",
+		Now:            time.Now().UTC(),
+		BasisPositions: []types.BasisPosition{open},
+		Market: types.MarketSnapshot{
+			Symbols: map[string]types.SymbolSnap{
+				"WIF": fundingSymbol("WIF", d("0.000005")), // ann ≈ 0.0438, below exit
+			},
+		},
+	}
+	dec, err := s.Decide(context.Background(), in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dec.Orders) != 1 || dec.Orders[0].Side != types.SideBuy || !dec.Orders[0].ReduceOnly {
+		t.Errorf("expected reduce-only buy to close short, got %+v", dec.Orders)
+	}
+	if len(dec.Swaps) != 1 || dec.Swaps[0].OutToken.Symbol != "USDC" {
+		t.Errorf("expected swap WIF→USDC, got %+v", dec.Swaps)
+	}
+}
+
+func TestDecide_DoesNotReopenAlreadyOpenSymbol(t *testing.T) {
+	r := loadRegistry(t)
+	s, _ := New(Config{
+		EntryAnnualisedFunding: d("0.5"),
+		ExitAnnualisedFunding:  d("0.1"),
+		PositionCapUSDC:        d("100"),
+	}, r, nil)
+	in := strategy.DecisionInput{
+		AgentID: "ag",
+		Now:     time.Now().UTC(),
+		BasisPositions: []types.BasisPosition{{
+			Underlying: "WIF",
+			State:      types.BasisStateOpen,
+			Legs: []types.BasisLeg{
+				{Kind: types.BasisLegPerp, Symbol: "WIF", Qty: d("100"), AvgPrice: d("1")},
+			},
+		}},
+		Market: types.MarketSnapshot{
+			Symbols: map[string]types.SymbolSnap{
+				"WIF": fundingSymbol("WIF", d("0.0005")), // ann very high → would open if not already
+			},
+		},
+	}
+	dec, _ := s.Decide(context.Background(), in)
+	for _, o := range dec.Orders {
+		if o.Symbol == "WIF" && !o.ReduceOnly {
+			t.Errorf("should not open second WIF basis: %+v", o)
+		}
+	}
+}
+
+func TestDecide_UnderEntryThresholdEmitsNothing(t *testing.T) {
+	r := loadRegistry(t)
+	s, _ := New(Config{
+		EntryAnnualisedFunding: d("0.5"),
+		ExitAnnualisedFunding:  d("0.1"),
+		PositionCapUSDC:        d("100"),
+	}, r, nil)
+	in := strategy.DecisionInput{
+		AgentID: "ag",
+		Now:     time.Now().UTC(),
+		Market: types.MarketSnapshot{
+			Symbols: map[string]types.SymbolSnap{
+				"WIF": fundingSymbol("WIF", d("0.00001")), // ann ≈ 0.0876
+			},
+		},
+	}
+	dec, _ := s.Decide(context.Background(), in)
+	if dec.HasIntents() {
+		t.Errorf("under threshold should produce no intents, got %+v", dec)
+	}
+}
+
+func TestDecide_LLMVetoBlocksOpen(t *testing.T) {
+	r := loadRegistry(t)
+	mp := mock.New(mock.WithResponse(inference.Response{
+		Content:  `{"veto": true, "reason": "token unlock in 24h"}`,
+		Provider: "mock", Model: "mock",
+	}))
+	s, _ := New(Config{
+		EntryAnnualisedFunding: d("0.5"),
+		ExitAnnualisedFunding:  d("0.1"),
+		PositionCapUSDC:        d("100"),
+		UseLLMVeto:             true,
+		VetoModel:              "mock",
+	}, r, mp)
+	in := strategy.DecisionInput{
+		AgentID: "ag",
+		Now:     time.Now().UTC(),
+		Market: types.MarketSnapshot{
+			Symbols: map[string]types.SymbolSnap{
+				"WIF": fundingSymbol("WIF", d("0.0001")),
+			},
+		},
+	}
+	dec, _ := s.Decide(context.Background(), in)
+	if len(dec.Swaps) != 0 || len(dec.Orders) != 0 {
+		t.Errorf("LLM veto should block open, got %+v", dec)
+	}
+	if !strings.Contains(dec.Notes, "vetoed WIF") {
+		t.Errorf("expected veto note, got %q", dec.Notes)
+	}
+}
+
+func TestDecide_LLMUnsupportedDoesNotVeto(t *testing.T) {
+	r := loadRegistry(t)
+	mp := mock.New(mock.WithResponse(inference.Response{Content: ""}))
+	// Inject an inference provider that always returns ErrUnsupportedFeature
+	failing := &failingProvider{err: inference.ErrUnsupportedFeature}
+	_ = mp
+
+	s, _ := New(Config{
+		EntryAnnualisedFunding: d("0.5"),
+		ExitAnnualisedFunding:  d("0.1"),
+		PositionCapUSDC:        d("100"),
+		UseLLMVeto:             true,
+		VetoModel:              "mock",
+	}, r, failing)
+	in := strategy.DecisionInput{
+		AgentID: "ag",
+		Now:     time.Now().UTC(),
+		Market: types.MarketSnapshot{
+			Symbols: map[string]types.SymbolSnap{"WIF": fundingSymbol("WIF", d("0.0001"))},
+		},
+	}
+	dec, _ := s.Decide(context.Background(), in)
+	if len(dec.Swaps) != 1 || len(dec.Orders) != 1 {
+		t.Errorf("ErrUnsupportedFeature should NOT veto, got swaps=%d orders=%d", len(dec.Swaps), len(dec.Orders))
+	}
+}
+
+type failingProvider struct{ err error }
+
+func (failingProvider) Name() string { return "failing" }
+func (p *failingProvider) Complete(_ context.Context, _ inference.Request) (inference.Response, error) {
+	return inference.Response{}, p.err
+}
+func (failingProvider) Embed(_ context.Context, _ inference.EmbedRequest) (inference.EmbedResponse, error) {
+	return inference.EmbedResponse{}, nil
+}

--- a/internal/strategy/funding_arb_basic/veto.go
+++ b/internal/strategy/funding_arb_basic/veto.go
@@ -1,0 +1,80 @@
+package funding_arb_basic
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/teslashibe/permafrost/internal/inference"
+)
+
+// vetoSchema is the JSON Schema the model is asked to conform to.
+const vetoSchemaJSON = `{
+  "type": "object",
+  "properties": {
+    "veto":   {"type": "boolean"},
+    "reason": {"type": "string", "maxLength": 200}
+  },
+  "required": ["veto", "reason"],
+  "additionalProperties": false
+}`
+
+const vetoSystemPrompt = `You are an event-risk filter for a crypto funding-rate arbitrage agent.
+The agent wants to OPEN a delta-neutral basis position: long spot on Solana,
+short perpetual on Hyperliquid for the same token.
+
+Your job: given the candidate token, decide whether there is a clear,
+imminent reason NOT to open this position right now (e.g. token unlock,
+governance vote, depeg or rug rumor, exchange listing/delisting, regulatory
+action, major exploit). Default to NOT vetoing.
+
+Reply ONLY in the supplied JSON schema. Keep "reason" under 200 chars.`
+
+// vetoResponse mirrors the JSON Schema.
+type vetoResponse struct {
+	Veto   bool   `json:"veto"`
+	Reason string `json:"reason"`
+}
+
+// askVeto consults the inference provider with a structured-output schema.
+// On any error or unsupported feature, returns (false, "", nil) — the
+// strategy errs on the side of NOT vetoing when the LLM is unreachable.
+func (s *Strategy) askVeto(ctx context.Context, c candidate) (bool, string, error) {
+	if s.inference == nil {
+		return false, "", nil
+	}
+	prompt := fmt.Sprintf(`Candidate: %s
+Annualised funding rate: %s
+Funding interval: %s
+Spot venue: %s
+
+Should we veto opening a basis here?`, c.Symbol, c.Annualised, c.Funding.Interval, c.Asset.Spot.Chain)
+
+	resp, err := s.inference.Complete(ctx, inference.Request{
+		Model:  s.cfg.VetoModel,
+		System: vetoSystemPrompt,
+		Messages: []inference.Message{
+			{Role: inference.RoleUser, Content: prompt},
+		},
+		JSONSchema: &inference.Schema{
+			Name:   "veto_decision",
+			JSON:   []byte(vetoSchemaJSON),
+			Strict: true,
+		},
+		Temperature: 0,
+		MaxTokens:   200,
+	})
+	if err != nil {
+		if errors.Is(err, inference.ErrUnsupportedFeature) {
+			return false, "", nil
+		}
+		return false, "", err
+	}
+
+	var v vetoResponse
+	if err := json.Unmarshal([]byte(resp.Content), &v); err != nil {
+		return false, "", fmt.Errorf("veto: parse model response: %w", err)
+	}
+	return v.Veto, v.Reason, nil
+}


### PR DESCRIPTION
## Milestone
**M10 — First strategy: \`funding_arb_basic\`.** A delta-neutral funding-rate arbitrage that goes long spot on Solana and short perp on Hyperliquid for the same token. Decision logic is fully deterministic; the LLM is consulted **purely as an event/news veto layer** on new entries — never to invent trades, sizes, or universe.

> Stacked on top of #10 (M9). Implements [SCOPE.md §14](../blob/m10-funding-arb-basic/SCOPE.md#14-first-strategy-funding_arb_basic).

## Strategy
- **Config** — \`EntryAnnualisedFunding\` (default 0.50 = 50% APR), \`ExitAnnualisedFunding\` (0.10), \`PositionCapUSDC\` (1000), \`PerSymbolCooldown\` (4h), \`SlippageBps\` (50), \`UseLLMVeto\`, \`VetoModel\`, \`Universe\` override. \`Defaults()\` keeps zero-config working; \`Validate()\` rejects inverted thresholds.
- **\`New(cfg, registry, inference)\`** — registry required; inference may be \`nil\` to disable the veto entirely.

## \`Decide()\` flow
1. **Closes first** — for every open BasisPosition whose annualised funding has fallen below \`ExitAnnualisedFunding\`, emit a **reduce-only** perp buy plus a spot→USDC swap.
2. **Rank** — score every tradable registry entry by \`FundingRate.Annualised()\`, drop those below entry threshold, sort descending.
3. **Filter** — skip symbols already open or opening.
4. **LLM veto** (optional) — ask the configured provider with a strict JSON Schema \`{veto: bool, reason: string}\`. \`ErrUnsupportedFeature\` degrades to "do not veto"; any other error skips the candidate with a note.
5. **Open** — emit \`(spot USDC→token swap, market sell perp short)\` per surviving candidate.

\`candidateConfidence\` returns a monotonic 0..1 score for the Decision.

## Veto layer (\`veto.go\`)
Uses \`inference.Schema\` with strict JSON Schema. System prompt biases the model toward **not** vetoing absent a clear, imminent reason (token unlock, governance vote, depeg/rug, listing/delisting, regulatory action, exploit).

## Tests
- \`New\` rejects inverted thresholds; accepts zero-config via Defaults; rejects negative \`PositionCapUSDC\`.
- \`Decide\` opens the highest-funding candidate (WIF) and skips a low-funding one (BONK).
- \`Decide\` closes when funding falls below exit (reduce-only buy + spot→USDC swap).
- \`Decide\` does not reopen an already-open underlying.
- \`Decide\` produces no intents when nothing crosses entry.
- LLM veto blocks an open and records a note explaining why.
- \`ErrUnsupportedFeature\` from the provider does **not** veto (graceful degrade).

## Verify locally
\`\`\`
go test ./internal/strategy/funding_arb_basic/... -race -count=1 -v
\`\`\`

## Out of scope (next PR)
- Backtest harness against historical funding rates → **PR #12 (M11)**