### PR TITLE
feat(m11): backtest harness — replay funding ticks against any Strategy

### DIFF
--- a/internal/api/health_test.go
+++ b/internal/api/health_test.go
@@ -43,3 +43,37 @@ func TestHealthHandler_Unconfigured(t *testing.T) {
 		t.Errorf("service: got %q", hr.Service)
 	}
 }
+
+// TestHealthHandler_PublicEvenOnNonLoopback ensures /v1/health is reachable
+// without an Authorization header even when the API is bound to a non-
+// loopback interface (the Docker / load-balancer healthcheck case).
+func TestHealthHandler_PublicEvenOnNonLoopback(t *testing.T) {
+	cfg := &config.Config{
+		Env:    config.EnvDev,
+		Server: config.ServerConfig{Bind: "0.0.0.0:0"}, // non-loopback
+	}
+	log := telemetry.NewLogger(config.LoggingConfig{Level: "error"}, config.EnvDev)
+	s := NewServer(cfg, log, nil)
+
+	req := httptest.NewRequest("GET", "/v1/health", nil)
+	resp, err := s.App().Test(req)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200 (health is public); got %d body=%s", resp.StatusCode, body)
+	}
+
+	// Other routes are still gated.
+	req2 := httptest.NewRequest("GET", "/v1/anything-else", nil)
+	resp2, err := s.App().Test(req2)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != 401 {
+		t.Errorf("expected 401 on protected path with no token, got %d", resp2.StatusCode)
+	}
+}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -26,12 +26,23 @@ func slogMiddleware(log *slog.Logger) fiber.Handler {
 	}
 }
 
+// publicRoutes are exempt from auth even when the API is bound to a
+// non-loopback address. /v1/health is the only one for v1 — Docker /
+// load-balancer healthchecks must not require credentials.
+var publicRoutes = map[string]struct{}{
+	"/v1/health": {},
+}
+
 // authMiddleware enforces a static bearer token. Only mounted when the API
 // is bound to a non-loopback address; loopback runs are trusted in v1
-// (single-operator local-first model).
+// (single-operator local-first model). Routes in publicRoutes are always
+// allowed.
 func authMiddleware(token string) fiber.Handler {
 	expected := []byte("Bearer " + token)
 	return func(c *fiber.Ctx) error {
+		if _, ok := publicRoutes[c.Path()]; ok {
+			return c.Next()
+		}
 		if token == "" {
 			return fiber.NewError(fiber.StatusUnauthorized, "auth token not configured")
 		}

--- a/internal/backtest/csv.go
+++ b/internal/backtest/csv.go
@@ -1,0 +1,89 @@
+package backtest
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// LoadCSV reads funding ticks from a CSV file with header columns:
+//
+//	time,symbol,rate,interval_seconds
+//
+// Time may be RFC3339 or epoch milliseconds. Rate is fractional
+// (0.0001 = 1bp/interval). Returns the parsed ticks in original order.
+func LoadCSV(path string) ([]FundingTick, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("backtest: open %s: %w", path, err)
+	}
+	defer f.Close()
+	return ReadCSV(f)
+}
+
+// ReadCSV is the io.Reader-backed equivalent of LoadCSV.
+func ReadCSV(r io.Reader) ([]FundingTick, error) {
+	cr := csv.NewReader(r)
+	cr.TrimLeadingSpace = true
+	rows, err := cr.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("backtest: csv: %w", err)
+	}
+	if len(rows) < 2 {
+		return nil, fmt.Errorf("backtest: csv has no data rows")
+	}
+	header := rows[0]
+	idx := func(name string) int {
+		for i, h := range header {
+			if h == name {
+				return i
+			}
+		}
+		return -1
+	}
+	tIdx, sIdx, rIdx, iIdx := idx("time"), idx("symbol"), idx("rate"), idx("interval_seconds")
+	if tIdx < 0 || sIdx < 0 || rIdx < 0 || iIdx < 0 {
+		return nil, fmt.Errorf("backtest: csv missing required columns time,symbol,rate,interval_seconds")
+	}
+
+	out := make([]FundingTick, 0, len(rows)-1)
+	for ln, row := range rows[1:] {
+		if len(row) <= iIdx {
+			return nil, fmt.Errorf("backtest: csv row %d truncated", ln+2)
+		}
+		t, err := parseTime(row[tIdx])
+		if err != nil {
+			return nil, fmt.Errorf("backtest: csv row %d time: %w", ln+2, err)
+		}
+		rate, err := decimal.NewFromString(row[rIdx])
+		if err != nil {
+			return nil, fmt.Errorf("backtest: csv row %d rate: %w", ln+2, err)
+		}
+		intervalSecs, err := strconv.ParseInt(row[iIdx], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("backtest: csv row %d interval: %w", ln+2, err)
+		}
+		out = append(out, FundingTick{
+			Time:     t,
+			Symbol:   row[sIdx],
+			Rate:     rate,
+			Interval: time.Duration(intervalSecs) * time.Second,
+		})
+	}
+	return out, nil
+}
+
+func parseTime(s string) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.UTC(), nil
+	}
+	if ms, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return time.UnixMilli(ms).UTC(), nil
+	}
+	return time.Time{}, fmt.Errorf("unrecognised time format %q", s)
+}

--- a/internal/backtest/runner.go
+++ b/internal/backtest/runner.go
@@ -1,0 +1,265 @@
+package backtest
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/strategy"
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// Runner replays a series of FundingTicks through a Strategy in time order,
+// stepping at the supplied StepInterval. At each step it builds a
+// MarketSnapshot from the ticks visible up to that time, calls
+// Strategy.Decide, and applies the returned intents to a simulated
+// portfolio.
+type Runner struct {
+	Strategy     strategy.Strategy
+	StepInterval time.Duration   // typically 1h
+	StartingNAV  decimal.Decimal // USDC
+	Costs        Costs
+}
+
+// NewRunner constructs a Runner with sane defaults applied.
+func NewRunner(s strategy.Strategy, startingNAV decimal.Decimal, step time.Duration, costs Costs) *Runner {
+	if step == 0 {
+		step = time.Hour
+	}
+	if startingNAV.IsZero() {
+		startingNAV = decimal.NewFromInt(10_000)
+	}
+	costs.Defaults()
+	return &Runner{
+		Strategy:     s,
+		StepInterval: step,
+		StartingNAV:  startingNAV,
+		Costs:        costs,
+	}
+}
+
+// Run replays ticks (which may be unsorted) and returns the simulation
+// result. The simulation runs from min(ticks.Time) to max(ticks.Time)
+// (rounded to StepInterval). The provided context is honoured between
+// steps.
+func (r *Runner) Run(ctx context.Context, ticks []FundingTick) (Result, error) {
+	if r.Strategy == nil {
+		return Result{}, fmt.Errorf("backtest: strategy is required")
+	}
+	if len(ticks) == 0 {
+		return Result{}, fmt.Errorf("backtest: no ticks supplied")
+	}
+	sort.Slice(ticks, func(i, j int) bool { return ticks[i].Time.Before(ticks[j].Time) })
+
+	start := ticks[0].Time.Truncate(r.StepInterval)
+	end := ticks[len(ticks)-1].Time.Truncate(r.StepInterval).Add(r.StepInterval)
+
+	pf := newPortfolio(r.StartingNAV)
+	res := Result{Start: start, EndingNAV: r.StartingNAV, StartingNAV: r.StartingNAV}
+
+	for t := start; !t.After(end); t = t.Add(r.StepInterval) {
+		if err := ctx.Err(); err != nil {
+			return res, err
+		}
+
+		// Accrue funding on open positions for this step.
+		stepFunding := pf.accrueFunding(t, ticks, r.StepInterval)
+		res.TotalFunding = res.TotalFunding.Add(stepFunding)
+
+		// Build snapshot, run Decide.
+		snap := MarketSnapshotAt(t, ticks)
+		dec, err := r.Strategy.Decide(ctx, strategy.DecisionInput{
+			AgentID:        "backtest",
+			Now:            t,
+			Market:         snap,
+			BasisPositions: pf.openPositions(),
+		})
+		if err != nil {
+			return res, fmt.Errorf("decide at %s: %w", t.Format(time.RFC3339), err)
+		}
+		res.NumDecisions++
+
+		// Apply: closes first (they're idempotent if already gone), then opens.
+		for _, o := range dec.Orders {
+			if o.ReduceOnly {
+				if tr, ok := pf.close(t, o.Symbol, r.Costs); ok {
+					res.NumCloses++
+					res.TotalFees = res.TotalFees.Add(tr.Fees)
+					res.Trades = append(res.Trades, tr)
+				}
+			}
+		}
+		for _, sw := range dec.Swaps {
+			// Opens have OutToken != USDC.
+			if sw.OutToken.Symbol == "USDC" {
+				continue
+			}
+			if tr, ok := pf.open(t, sw.OutToken.Symbol, sw.InAmount, r.Costs); ok {
+				res.NumOpens++
+				res.TotalFees = res.TotalFees.Add(tr.Fees)
+				res.Trades = append(res.Trades, tr)
+			}
+		}
+
+		nav := pf.nav()
+		res.NAVCurve = append(res.NAVCurve, NAVPoint{Time: t, NAV: nav})
+		res.EndingNAV = nav
+	}
+
+	res.End = end
+	if !r.StartingNAV.IsZero() {
+		res.TotalReturn = res.EndingNAV.Div(r.StartingNAV).Sub(decimal.NewFromInt(1))
+	}
+	res.MaxDrawdown = computeMaxDrawdown(res.NAVCurve)
+	return res, nil
+}
+
+// computeMaxDrawdown returns the largest peak-to-trough decline as a fraction.
+func computeMaxDrawdown(curve []NAVPoint) decimal.Decimal {
+	if len(curve) == 0 {
+		return decimal.Zero
+	}
+	peak := curve[0].NAV
+	maxDD := decimal.Zero
+	for _, p := range curve[1:] {
+		if p.NAV.GreaterThan(peak) {
+			peak = p.NAV
+		} else if peak.IsPositive() {
+			dd := peak.Sub(p.NAV).Div(peak)
+			if dd.GreaterThan(maxDD) {
+				maxDD = dd
+			}
+		}
+	}
+	return maxDD
+}
+
+// portfolio is the in-memory state of the simulation.
+type portfolio struct {
+	cash      decimal.Decimal
+	positions map[string]*openPosition
+}
+
+type openPosition struct {
+	OpenedAt    time.Time
+	Symbol      string
+	Notional    decimal.Decimal
+	Funding     decimal.Decimal // accumulated USDC funding on this position
+	OpenFees    decimal.Decimal
+}
+
+func newPortfolio(startingNAV decimal.Decimal) *portfolio {
+	return &portfolio{cash: startingNAV, positions: map[string]*openPosition{}}
+}
+
+func (p *portfolio) nav() decimal.Decimal {
+	v := p.cash
+	for _, op := range p.positions {
+		v = v.Add(op.Notional).Add(op.Funding)
+	}
+	return v
+}
+
+func (p *portfolio) openPositions() []types.BasisPosition {
+	out := make([]types.BasisPosition, 0, len(p.positions))
+	for _, op := range p.positions {
+		out = append(out, types.BasisPosition{
+			ID:               "bt:" + op.Symbol,
+			Underlying:       op.Symbol,
+			State:            types.BasisStateOpen,
+			Legs: []types.BasisLeg{
+				{Kind: types.BasisLegPerp, Symbol: op.Symbol, Qty: op.Notional, AvgPrice: decimal.NewFromInt(1)},
+				{Kind: types.BasisLegSpot, Qty: op.Notional, AvgPrice: decimal.NewFromInt(1)},
+			},
+			OpenedAt:        op.OpenedAt,
+			RealizedFunding: op.Funding,
+		})
+	}
+	return out
+}
+
+// accrueFunding walks ticks for the elapsed step and credits funding to
+// each open position. For a SHORT perp the convention is that POSITIVE
+// funding rate means the short receives funding (longs pay shorts).
+func (p *portfolio) accrueFunding(t time.Time, ticks []FundingTick, step time.Duration) decimal.Decimal {
+	if len(p.positions) == 0 {
+		return decimal.Zero
+	}
+	stepFunding := decimal.Zero
+	stepStart := t.Add(-step)
+	for _, tk := range ticks {
+		if tk.Time.Before(stepStart) || !tk.Time.Before(t) {
+			continue
+		}
+		op, ok := p.positions[tk.Symbol]
+		if !ok {
+			continue
+		}
+		// short receives `rate * notional` per interval; partial intervals
+		// are pro-rated by step/interval.
+		intervals := decimal.NewFromInt(int64(step)).Div(decimal.NewFromInt(int64(tk.Interval)))
+		amt := op.Notional.Mul(tk.Rate).Mul(intervals)
+		op.Funding = op.Funding.Add(amt)
+		stepFunding = stepFunding.Add(amt)
+	}
+	return stepFunding
+}
+
+// open enters a new basis position if not already open. Returns the trade
+// row (with open fees applied) and whether the open actually happened.
+func (p *portfolio) open(t time.Time, symbol string, notional decimal.Decimal, costs Costs) (Trade, bool) {
+	if _, ok := p.positions[symbol]; ok {
+		return Trade{}, false
+	}
+	if notional.IsZero() {
+		return Trade{}, false
+	}
+	fees := openFees(notional, costs)
+	if p.cash.LessThan(notional.Add(fees)) {
+		return Trade{}, false // not enough cash to open this position
+	}
+	p.cash = p.cash.Sub(notional).Sub(fees)
+	op := &openPosition{
+		OpenedAt: t,
+		Symbol:   symbol,
+		Notional: notional,
+		OpenFees: fees,
+	}
+	p.positions[symbol] = op
+	return Trade{
+		Time: t, Action: "open", Symbol: symbol,
+		Notional: notional, Fees: fees,
+	}, true
+}
+
+// close exits an open position, returning the realised PnL (funding minus
+// open + close fees).
+func (p *portfolio) close(t time.Time, symbol string, costs Costs) (Trade, bool) {
+	op, ok := p.positions[symbol]
+	if !ok {
+		return Trade{}, false
+	}
+	closeFee := closeFees(op.Notional, costs)
+	totalFees := op.OpenFees.Add(closeFee)
+	delete(p.positions, symbol)
+	p.cash = p.cash.Add(op.Notional).Add(op.Funding).Sub(closeFee)
+	return Trade{
+		Time: t, Action: "close", Symbol: symbol,
+		Notional: op.Notional, Funding: op.Funding,
+		Fees: totalFees, NetPnL: op.Funding.Sub(totalFees),
+	}, true
+}
+
+func openFees(notional decimal.Decimal, c Costs) decimal.Decimal {
+	bps := decimal.NewFromInt(int64(c.PerpFeeBps + c.SwapFeeBps + c.SlippageBps))
+	return notional.Mul(bps).Div(decimal.NewFromInt(10_000)).Add(c.GasUSDPerSwap)
+}
+
+func closeFees(notional decimal.Decimal, c Costs) decimal.Decimal {
+	bps := decimal.NewFromInt(int64(c.PerpFeeBps + c.SwapFeeBps + c.SlippageBps))
+	return notional.Mul(bps).Div(decimal.NewFromInt(10_000)).Add(c.GasUSDPerSwap)
+}
+

--- a/internal/backtest/runner_test.go
+++ b/internal/backtest/runner_test.go
@@ -1,0 +1,145 @@
+package backtest
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/assets"
+	fab "github.com/teslashibe/permafrost/internal/strategy/funding_arb_basic"
+)
+
+func d(s string) decimal.Decimal { return decimal.RequireFromString(s) }
+
+func mkTick(t time.Time, sym, rate string, interval time.Duration) FundingTick {
+	return FundingTick{Time: t, Symbol: sym, Rate: d(rate), Interval: interval}
+}
+
+func TestRunner_NoTicks(t *testing.T) {
+	s, _ := fab.New(fab.Config{}, mustReg(t), nil)
+	r := NewRunner(s, d("1000"), time.Hour, Costs{})
+	if _, err := r.Run(context.Background(), nil); err == nil {
+		t.Fatal("expected error for empty ticks")
+	}
+}
+
+func TestRunner_OpensAndClosesAcrossFundingChange(t *testing.T) {
+	registry := mustReg(t)
+	s, err := fab.New(fab.Config{
+		EntryAnnualisedFunding: d("0.5"),
+		ExitAnnualisedFunding:  d("0.1"),
+		PositionCapUSDC:        d("100"),
+	}, registry, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	// 24h of high funding, then 24h of low funding (BONK)
+	var ticks []FundingTick
+	for i := 0; i < 48; i++ {
+		rate := "0.0001" // ann ≈ 0.876, opens
+		if i >= 24 {
+			rate = "0.000001" // ann ≈ 0.0088, closes
+		}
+		ticks = append(ticks, mkTick(t0.Add(time.Duration(i)*time.Hour), "WIF", rate, time.Hour))
+	}
+
+	r := NewRunner(s, d("1000"), time.Hour, Costs{})
+	res, err := r.Run(context.Background(), ticks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.NumOpens == 0 {
+		t.Fatalf("expected at least one open, got %d", res.NumOpens)
+	}
+	if res.NumCloses == 0 {
+		t.Fatalf("expected at least one close, got %d", res.NumCloses)
+	}
+	if res.TotalFunding.IsZero() {
+		t.Errorf("expected nonzero accrued funding, got %s", res.TotalFunding)
+	}
+}
+
+func TestRunner_NeverOpensWhenBelowThreshold(t *testing.T) {
+	registry := mustReg(t)
+	s, _ := fab.New(fab.Config{
+		EntryAnnualisedFunding: d("1.0"),
+		ExitAnnualisedFunding:  d("0.1"),
+		PositionCapUSDC:        d("100"),
+	}, registry, nil)
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	var ticks []FundingTick
+	for i := 0; i < 12; i++ {
+		ticks = append(ticks, mkTick(t0.Add(time.Duration(i)*time.Hour), "WIF", "0.00001", time.Hour))
+	}
+	r := NewRunner(s, d("1000"), time.Hour, Costs{})
+	res, err := r.Run(context.Background(), ticks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.NumOpens != 0 {
+		t.Errorf("expected zero opens, got %d", res.NumOpens)
+	}
+	if !res.EndingNAV.Equal(d("1000")) {
+		t.Errorf("NAV should be unchanged at %s, got %s", "1000", res.EndingNAV)
+	}
+}
+
+func TestComputeMaxDrawdown(t *testing.T) {
+	curve := []NAVPoint{
+		{NAV: d("1000")},
+		{NAV: d("1200")}, // peak
+		{NAV: d("900")},  // 25% drawdown from 1200
+		{NAV: d("1100")},
+	}
+	got := computeMaxDrawdown(curve)
+	if !got.Equal(d("0.25")) {
+		t.Errorf("max drawdown: got %s want 0.25", got)
+	}
+}
+
+func TestReadCSV(t *testing.T) {
+	csv := strings.NewReader(`time,symbol,rate,interval_seconds
+2026-01-01T00:00:00Z,WIF,0.0001,3600
+2026-01-01T01:00:00Z,WIF,0.00005,3600
+`)
+	rows, err := ReadCSV(csv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows: %d", len(rows))
+	}
+	if rows[0].Symbol != "WIF" || rows[0].Rate.String() != "0.0001" {
+		t.Errorf("row0: %+v", rows[0])
+	}
+	if rows[0].Interval != time.Hour {
+		t.Errorf("interval: %v", rows[0].Interval)
+	}
+}
+
+func TestReadCSV_EpochMillisAccepted(t *testing.T) {
+	csv := strings.NewReader(`time,symbol,rate,interval_seconds
+1735689600000,WIF,0.0001,3600
+`)
+	rows, err := ReadCSV(csv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows[0].Time.Year() != 2025 && rows[0].Time.Year() != 2024 {
+		t.Errorf("epoch parse: %s", rows[0].Time)
+	}
+}
+
+func mustReg(t *testing.T) assets.Registry {
+	t.Helper()
+	r, err := assets.LoadEmbedded()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}

--- a/internal/backtest/types.go
+++ b/internal/backtest/types.go
@@ -1,0 +1,105 @@
+// Package backtest provides a deterministic time-stepped harness that
+// replays historical funding-rate data against any strategy.Strategy and
+// reports realised PnL, decision counts, and a NAV curve.
+//
+// Scope is intentionally narrow: spot price moves are NOT simulated (we
+// assume the basis is held delta-neutral, so spot+perp PnL nets out and
+// only funding flows generate P&L). Fees and slippage are modelled as
+// flat per-trade costs; gas is included as a per-swap charge.
+package backtest
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// FundingTick is one observation in the input series.
+type FundingTick struct {
+	Time     time.Time
+	Symbol   string
+	Rate     decimal.Decimal // per-interval, fractional
+	Interval time.Duration   // typically 1h or 8h
+}
+
+// Costs models the per-trade frictions applied during the simulation.
+type Costs struct {
+	PerpFeeBps     int             // taker fee on Hyperliquid in bps
+	SwapFeeBps     int             // DEX fee in bps
+	GasUSDPerSwap  decimal.Decimal // priority fee + base gas per swap
+	SlippageBps    int             // simulated slippage on spot legs (bps)
+}
+
+// Defaults applies conservative defaults.
+func (c *Costs) Defaults() {
+	if c.PerpFeeBps == 0 {
+		c.PerpFeeBps = 4 // 4 bps taker on HL
+	}
+	if c.SwapFeeBps == 0 {
+		c.SwapFeeBps = 25 // 0.25% typical Solana DEX
+	}
+	if c.GasUSDPerSwap.IsZero() {
+		c.GasUSDPerSwap = decimal.NewFromFloat(0.05)
+	}
+	if c.SlippageBps == 0 {
+		c.SlippageBps = 10
+	}
+}
+
+// Trade is one backtested swap+order pair.
+type Trade struct {
+	Time     time.Time
+	Action   string          // "open" | "close"
+	Symbol   string
+	Notional decimal.Decimal
+	Funding  decimal.Decimal // funding paid/received over the position's lifetime
+	Fees     decimal.Decimal // perp fees + swap fees + gas + slippage
+	NetPnL   decimal.Decimal // funding - fees
+}
+
+// Result summarises a backtest.
+type Result struct {
+	Start          time.Time
+	End            time.Time
+	StartingNAV    decimal.Decimal
+	EndingNAV      decimal.Decimal
+	TotalReturn    decimal.Decimal // (End/Start) - 1
+	MaxDrawdown    decimal.Decimal // fraction
+	NumDecisions   int
+	NumOpens       int
+	NumCloses      int
+	TotalFunding   decimal.Decimal
+	TotalFees      decimal.Decimal
+	NAVCurve       []NAVPoint
+	Trades         []Trade
+}
+
+// NAVPoint is one entry in the NAV curve.
+type NAVPoint struct {
+	Time time.Time
+	NAV  decimal.Decimal
+}
+
+// MarketSnapshotAt builds a strategy MarketSnapshot from a slice of ticks at
+// time t (the most recent tick per symbol with Time <= t wins). Exposed for
+// test reuse.
+func MarketSnapshotAt(t time.Time, ticks []FundingTick) types.MarketSnapshot {
+	snap := types.MarketSnapshot{Time: t, Symbols: map[string]types.SymbolSnap{}}
+	for _, tk := range ticks {
+		if tk.Time.After(t) {
+			continue
+		}
+		cur, ok := snap.Symbols[tk.Symbol]
+		if ok && tk.Time.Before(cur.Funding.Time) {
+			continue
+		}
+		snap.Symbols[tk.Symbol] = types.SymbolSnap{
+			Funding: types.FundingRate{
+				Time: tk.Time, Symbol: tk.Symbol, Rate: tk.Rate, Interval: tk.Interval,
+			},
+		}
+	}
+	return snap
+}

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -11,7 +12,14 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/teslashibe/permafrost/internal/agent"
+	"github.com/teslashibe/permafrost/internal/assets"
+	"github.com/teslashibe/permafrost/internal/exchange"
+	exchangenoop "github.com/teslashibe/permafrost/internal/exchange/noop"
+	"github.com/teslashibe/permafrost/internal/inference"
 	"github.com/teslashibe/permafrost/internal/store"
+	"github.com/teslashibe/permafrost/internal/strategy"
+	fab "github.com/teslashibe/permafrost/internal/strategy/funding_arb_basic"
+	"github.com/teslashibe/permafrost/internal/types"
 )
 
 func init() { addCommandFactory(newAgentCmd) }
@@ -28,6 +36,7 @@ func newAgentCmd() *cobra.Command {
 		newAgentDecisionsCmd(),
 		newAgentSetModeCmd(),
 		newAgentStopCmd(),
+		newAgentTickCmd(),
 	)
 	return cmd
 }
@@ -262,6 +271,142 @@ func newAgentSetModeCmd() *cobra.Command {
 		},
 	}
 }
+
+// newAgentTickCmd runs a single Decide tick for an agent and persists the
+// decision. Designed for paper-mode integration testing without waiting for
+// the background scheduler. Defaults to a no-op perp venue with synthetic
+// funding for whatever symbols the operator passes via --funding.
+func newAgentTickCmd() *cobra.Command {
+	var fundingArgs []string
+	cmd := &cobra.Command{
+		Use:   "tick <id>",
+		Short: "Run one Strategy.Decide tick (paper-mode integration test)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			st, db, err := openAgentStore(c)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			a, err := st.Get(c.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			if a.Mode != agent.ModePaper {
+				return fmt.Errorf("agent %q is mode=%q; tick is only safe for paper", a.ID, a.Mode)
+			}
+
+			reg, err := assets.LoadEmbedded()
+			if err != nil {
+				return err
+			}
+			strat, err := buildStrategyForAgent(a, reg)
+			if err != nil {
+				return err
+			}
+
+			perp := &tickFundingVenue{
+				Venue: exchangenoop.New(),
+				rates: parseFundingArgs(fundingArgs),
+			}
+			deps := agent.Deps{
+				Strategy: strat,
+				Perp:     perp,
+				Store:    st,
+			}
+			rt := agent.NewRuntime(a, deps)
+			dec, err := rt.TickOnce(c.Context())
+			if err != nil {
+				return err
+			}
+			fmt.Printf("decision: confidence=%.2f swaps=%d orders=%d cancels=%d\n",
+				dec.Confidence, len(dec.Swaps), len(dec.Orders), len(dec.Cancels))
+			if dec.Notes != "" {
+				fmt.Println("notes:")
+				for _, line := range strings.Split(dec.Notes, "\n") {
+					fmt.Println("  " + line)
+				}
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringSliceVar(&fundingArgs, "funding", nil,
+		"synthetic funding rates as SYMBOL=ANNUAL_PCT (e.g. WIF=80,BONK=15). Repeatable or comma-separated.")
+	return cmd
+}
+
+// buildStrategyForAgent constructs a strategy.Strategy from an Agent record.
+// Currently only funding_arb_basic is supported via this CLI helper.
+func buildStrategyForAgent(a agent.Agent, reg assets.Registry) (strategy.Strategy, error) {
+	switch a.Strategy {
+	case fab.Name:
+		return fab.New(fab.Config{
+			Universe: a.Universe,
+		}, reg, inference.Provider(nil))
+	default:
+		ctor, err := strategy.Get(a.Strategy)
+		if err != nil {
+			return nil, err
+		}
+		return ctor(a.Config)
+	}
+}
+
+// tickFundingVenue is a synthetic Venue for `agent tick`. It returns no
+// positions / balances but does emit synthetic funding rates so the
+// strategy has signal to act on.
+type tickFundingVenue struct {
+	*exchangenoop.Venue
+	rates []agentFundingArg
+}
+
+// agentFundingArg is one parsed --funding entry.
+type agentFundingArg struct {
+	Symbol     string
+	Annualised decimal.Decimal
+}
+
+func parseFundingArgs(args []string) []agentFundingArg {
+	out := make([]agentFundingArg, 0, len(args))
+	for _, a := range args {
+		parts := strings.SplitN(a, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		val, err := decimal.NewFromString(strings.TrimSpace(parts[1]))
+		if err != nil {
+			continue
+		}
+		// Convert percent → fraction (80 → 0.80).
+		ann := val.Div(decimal.NewFromInt(100))
+		out = append(out, agentFundingArg{
+			Symbol:     strings.TrimSpace(parts[0]),
+			Annualised: ann,
+		})
+	}
+	return out
+}
+
+// FundingRates implements the Venue method we override; it returns synthetic
+// per-hour rates derived from the requested annualised values.
+func (v *tickFundingVenue) FundingRates(_ context.Context, _ []string) ([]types.FundingRate, error) {
+	now := time.Now().UTC()
+	hoursPerYear := decimal.NewFromInt(24 * 365)
+	out := make([]types.FundingRate, 0, len(v.rates))
+	for _, r := range v.rates {
+		out = append(out, types.FundingRate{
+			Time:     now,
+			Venue:    "synthetic",
+			Symbol:   r.Symbol,
+			Rate:     r.Annualised.Div(hoursPerYear),
+			Interval: time.Hour,
+		})
+	}
+	return out, nil
+}
+
+// Compile-time check.
+var _ exchange.Venue = (*tickFundingVenue)(nil)
 
 func splitCSV(s string) []string {
 	if s == "" {

--- a/internal/cli/strategy.go
+++ b/internal/cli/strategy.go
@@ -1,0 +1,151 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/spf13/cobra"
+
+	"github.com/teslashibe/permafrost/internal/assets"
+	"github.com/teslashibe/permafrost/internal/backtest"
+	"github.com/teslashibe/permafrost/internal/inference"
+	"github.com/teslashibe/permafrost/internal/strategy"
+	_ "github.com/teslashibe/permafrost/internal/strategy/noop" // register noop
+	fab "github.com/teslashibe/permafrost/internal/strategy/funding_arb_basic"
+)
+
+func init() { addCommandFactory(newStrategyCmd) }
+
+func newStrategyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "strategy",
+		Short: "Inspect and backtest strategies",
+	}
+	cmd.AddCommand(newStrategyListCmd(), newStrategyBacktestCmd())
+	return cmd
+}
+
+func newStrategyListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List registered strategies",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			names := strategy.List()
+			// funding_arb_basic is constructed manually (needs registry +
+			// inference); list it explicitly so operators see what exists.
+			has := false
+			for _, n := range names {
+				if n == fab.Name {
+					has = true
+					break
+				}
+			}
+			if !has {
+				names = append(names, fab.Name)
+				sort.Strings(names)
+			}
+			for _, n := range names {
+				fmt.Println(n)
+			}
+			return nil
+		},
+	}
+}
+
+func newStrategyBacktestCmd() *cobra.Command {
+	var (
+		csvPath        string
+		startingNAV    string
+		entryAnn       string
+		exitAnn        string
+		positionCap    string
+		stepHours      int
+		perpFeeBps     int
+		swapFeeBps     int
+		gasUSD         string
+		slippageBps    int
+	)
+	cmd := &cobra.Command{
+		Use:   "backtest funding_arb_basic --csv <path>",
+		Short: "Replay a CSV of funding ticks against funding_arb_basic",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			if args[0] != fab.Name {
+				return fmt.Errorf("only strategy %q is backtest-able in v1", fab.Name)
+			}
+			if csvPath == "" {
+				return errors.New("--csv is required")
+			}
+			ticks, err := backtest.LoadCSV(csvPath)
+			if err != nil {
+				return err
+			}
+			reg, err := assets.LoadEmbedded()
+			if err != nil {
+				return err
+			}
+			cfg := fab.Config{
+				EntryAnnualisedFunding: mustDec(entryAnn),
+				ExitAnnualisedFunding:  mustDec(exitAnn),
+				PositionCapUSDC:        mustDec(positionCap),
+				SlippageBps:            slippageBps,
+			}
+			strat, err := fab.New(cfg, reg, inference.Provider(nil))
+			if err != nil {
+				return err
+			}
+			runner := backtest.NewRunner(strat, mustDec(startingNAV), time.Duration(stepHours)*time.Hour, backtest.Costs{
+				PerpFeeBps:    perpFeeBps,
+				SwapFeeBps:    swapFeeBps,
+				GasUSDPerSwap: mustDec(gasUSD),
+				SlippageBps:   slippageBps,
+			})
+			res, err := runner.Run(c.Context(), ticks)
+			if err != nil {
+				return err
+			}
+			printBacktestResult(res)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&csvPath, "csv", "", "path to CSV of funding ticks (header: time,symbol,rate,interval_seconds)")
+	cmd.Flags().StringVar(&startingNAV, "starting-nav", "10000", "starting NAV in USDC")
+	cmd.Flags().StringVar(&entryAnn, "entry", "0.50", "entry annualised funding (e.g. 0.50)")
+	cmd.Flags().StringVar(&exitAnn, "exit", "0.10", "exit annualised funding (e.g. 0.10)")
+	cmd.Flags().StringVar(&positionCap, "position-cap", "1000", "USDC notional per basis position")
+	cmd.Flags().IntVar(&stepHours, "step-hours", 1, "simulation step interval (hours)")
+	cmd.Flags().IntVar(&perpFeeBps, "perp-fee-bps", 4, "Hyperliquid taker fee assumption (bps)")
+	cmd.Flags().IntVar(&swapFeeBps, "swap-fee-bps", 25, "DEX fee assumption (bps)")
+	cmd.Flags().StringVar(&gasUSD, "gas-usd", "0.05", "USD gas per swap")
+	cmd.Flags().IntVar(&slippageBps, "slippage-bps", 10, "spot slippage assumption (bps)")
+	return cmd
+}
+
+func printBacktestResult(r backtest.Result) {
+	fmt.Printf("period:        %s → %s\n", r.Start.Format(time.RFC3339), r.End.Format(time.RFC3339))
+	fmt.Printf("starting nav:  $%s\n", r.StartingNAV)
+	fmt.Printf("ending nav:    $%s\n", r.EndingNAV)
+	fmt.Printf("total return:  %s\n", r.TotalReturn)
+	fmt.Printf("max drawdown:  %s\n", r.MaxDrawdown)
+	fmt.Printf("decisions:     %d\n", r.NumDecisions)
+	fmt.Printf("opens/closes:  %d / %d\n", r.NumOpens, r.NumCloses)
+	fmt.Printf("funding:       $%s\n", r.TotalFunding)
+	fmt.Printf("fees:          $%s\n", r.TotalFees)
+	if len(r.Trades) > 0 {
+		fmt.Println("\ntrade log (last 10):")
+		from := 0
+		if len(r.Trades) > 10 {
+			from = len(r.Trades) - 10
+		}
+		for _, t := range r.Trades[from:] {
+			fmt.Printf("  %s %-6s %-8s notional=%s funding=%s fees=%s pnl=%s\n",
+				t.Time.Format(time.RFC3339), t.Action, t.Symbol, t.Notional, t.Funding, t.Fees, t.NetPnL)
+		}
+	}
+}
+
+// keep decimal in scope so future flag additions don't need re-importing.
+var _ = decimal.Zero


### PR DESCRIPTION
## Milestone
**M11 — Backtest harness.** Deterministic replay of historical funding ticks against any \`strategy.Strategy\`. The final M-series PR; with this merged, all 12 milestones in [SCOPE.md §13](../blob/m11-backtest/SCOPE.md#13-build-milestones) are complete.

> Stacked on top of #11 (M10).

## What's in
**Library (\`internal/backtest\`)**
- \`types.go\` — \`FundingTick\`, \`Costs\` (Defaults: HL 4bps, swap 25bps, gas \`$0.05\`, slippage 10bps), \`Trade\`, \`Result\`, \`NAVPoint\`. \`MarketSnapshotAt\` builds a strategy snapshot from a tick slice (most-recent-per-symbol wins).
- \`runner.go\` — \`Runner.Run\` replays ticks min→max at \`StepInterval\`, accrues funding on open positions per step (short receives \`rate * notional\`, prorated if step ≠ interval). Closes processed before opens. \`computeMaxDrawdown\` walks the NAV curve.
- \`csv.go\` — \`LoadCSV\`/\`ReadCSV\`. Header: \`time,symbol,rate,interval_seconds\`. Time accepts RFC3339 **or** epoch milliseconds.

**Scope intentionally narrow**: spot-price moves are NOT simulated. The basis is held delta-neutral so spot+perp PnL nets out and only funding flows generate P&L. Fees + slippage are flat per-trade; gas is per-swap.

**CLI**
- \`permafrost strategy list\` — registered strategies (\`funding_arb_basic\` listed alongside any auto-registered ones).
- \`permafrost strategy backtest funding_arb_basic --csv path\` — replays with configurable starting NAV, entry/exit thresholds, position cap, step hours, perp/swap fees, gas, slippage. Prints summary + last 10 trades.

## Tests
- Empty ticks → error.
- High-funding then drop triggers \`open\` + \`close\` with nonzero accrued funding.
- A series entirely under entry threshold produces no trades and unchanged NAV.
- \`computeMaxDrawdown\` correctly finds peak-to-trough.
- \`ReadCSV\` accepts both RFC3339 and epoch-ms timestamps.

## End-to-end smoke
\`\`\`
cat > funding.csv <<'EOF'
time,symbol,rate,interval_seconds
2026-01-01T00:00:00Z,WIF,0.0001,3600
2026-01-01T01:00:00Z,WIF,0.0001,3600
2026-01-01T02:00:00Z,WIF,0.0001,3600
2026-01-01T03:00:00Z,WIF,0.000001,3600