### PR TITLE
fix: real paper-mode end-to-end loop — agent run + reconcile + HL public reads

### DIFF
--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -43,6 +44,13 @@ type Runtime struct {
 	mu      sync.Mutex
 	running bool
 	cancel  context.CancelFunc
+
+	// openBasis tracks paper-mode (and to-be-fully-persisted live-mode)
+	// basis positions across ticks within a Run. Keyed by underlying symbol.
+	// This is in-memory state only; v1.1 should drive this off a
+	// strategy_positions row in the database so it survives restarts.
+	posMu     sync.Mutex
+	openBasis map[string]types.BasisPosition
 }
 
 // NewRuntime constructs a Runtime.
@@ -51,9 +59,10 @@ func NewRuntime(a Agent, d Deps) *Runtime {
 		d.Logger = slog.Default()
 	}
 	return &Runtime{
-		agent: a,
-		deps:  d,
-		now:   func() time.Time { return time.Now().UTC() },
+		agent:     a,
+		deps:      d,
+		now:       func() time.Time { return time.Now().UTC() },
+		openBasis: make(map[string]types.BasisPosition),
 	}
 }
 
@@ -150,13 +159,16 @@ func (r *Runtime) tickOnce(ctx context.Context) (strategy.Decision, error) {
 }
 
 // buildDecisionInput pulls current state from venues + the configured
-// universe and bundles it for Strategy.Decide.
+// universe and bundles it for Strategy.Decide. PerpPositions and Balances
+// are only fetched if the venue supports them (per-account reads can fail
+// gracefully when no Address is configured — see hyperliquid.ErrAddressRequired).
 func (r *Runtime) buildDecisionInput(ctx context.Context, now time.Time) (strategy.DecisionInput, error) {
 	in := strategy.DecisionInput{
-		AgentID: r.agent.ID,
-		Now:     now,
-		Cash:    map[string]types.Balance{},
-		Limits:  types.RiskLimits{},
+		AgentID:        r.agent.ID,
+		Now:            now,
+		Cash:           map[string]types.Balance{},
+		Limits:         types.RiskLimits{},
+		BasisPositions: r.snapshotOpenBasis(),
 	}
 	if r.deps.Perp != nil {
 		if pos, err := r.deps.Perp.Positions(ctx); err == nil {
@@ -178,6 +190,18 @@ func (r *Runtime) buildDecisionInput(ctx context.Context, now time.Time) (strate
 	return in, nil
 }
 
+// snapshotOpenBasis returns a defensive copy of the runtime's currently-open
+// basis positions, in deterministic order.
+func (r *Runtime) snapshotOpenBasis() []types.BasisPosition {
+	r.posMu.Lock()
+	defer r.posMu.Unlock()
+	out := make([]types.BasisPosition, 0, len(r.openBasis))
+	for _, p := range r.openBasis {
+		out = append(out, p)
+	}
+	return out
+}
+
 func (r *Runtime) persistDecision(ctx context.Context, now time.Time, decisionID string, in strategy.DecisionInput, dec strategy.Decision) {
 	if r.deps.Store == nil {
 		return
@@ -197,6 +221,11 @@ func (r *Runtime) persistDecision(ctx context.Context, now time.Time, decisionID
 
 // executeSwapsThenOrders runs swaps first (spot leg), then orders (perp leg)
 // — this is the spot-first invariant called for in SCOPE.md §11.
+//
+// After execution, the runtime's in-memory openBasis is reconciled so the
+// next tick's DecisionInput.BasisPositions reflects what just opened/closed.
+// This stops basis strategies from re-emitting opens for symbols they
+// already opened on a previous tick within the same Run.
 func (r *Runtime) executeSwapsThenOrders(ctx context.Context, now time.Time, decisionID string, _ strategy.DecisionInput, dec strategy.Decision) {
 	for i, s := range dec.Swaps {
 		r.executeSwap(ctx, now, decisionID, i, s)
@@ -206,6 +235,59 @@ func (r *Runtime) executeSwapsThenOrders(ctx context.Context, now time.Time, dec
 	}
 	for _, c := range dec.Cancels {
 		r.executeCancel(ctx, c)
+	}
+	r.reconcileOpenBasis(now, decisionID, dec)
+}
+
+// reconcileOpenBasis maintains the runtime's in-memory view of open basis
+// positions based on the intents this decision emitted. Pairs are matched by
+// the underlying symbol (perp.Symbol == swap.OutToken.Symbol for opens, or
+// the reduce-only perp's symbol == swap.InToken.Symbol for closes).
+func (r *Runtime) reconcileOpenBasis(now time.Time, decisionID string, dec strategy.Decision) {
+	r.posMu.Lock()
+	defer r.posMu.Unlock()
+
+	// Closes first — for any reduce-only order where we already track an
+	// open basis on that symbol, drop it. This matches funding_arb_basic's
+	// closeIntents shape (reduce-only buy + spot→USDC swap).
+	for _, o := range dec.Orders {
+		if !o.ReduceOnly {
+			continue
+		}
+		delete(r.openBasis, strings.ToUpper(o.Symbol))
+	}
+
+	// Opens — pair non-reduce-only sell orders with USDC→token swaps in the
+	// same Decision.
+	swapsByOut := map[string]types.SwapIntent{}
+	for _, s := range dec.Swaps {
+		if s.InToken.Symbol == "USDC" && s.OutToken.Symbol != "USDC" {
+			swapsByOut[strings.ToUpper(s.OutToken.Symbol)] = s
+		}
+	}
+	for _, o := range dec.Orders {
+		if o.ReduceOnly || o.Side != types.SideSell {
+			continue
+		}
+		key := strings.ToUpper(o.Symbol)
+		s, ok := swapsByOut[key]
+		if !ok {
+			continue
+		}
+		if _, alreadyOpen := r.openBasis[key]; alreadyOpen {
+			continue
+		}
+		r.openBasis[key] = types.BasisPosition{
+			ID:         "rt:" + decisionID + ":" + key,
+			AgentID:    r.agent.ID,
+			Underlying: o.Symbol,
+			State:      types.BasisStateOpen,
+			OpenedAt:   now,
+			Legs: []types.BasisLeg{
+				{Kind: types.BasisLegSpot, Asset: s.OutToken, Qty: s.InAmount},
+				{Kind: types.BasisLegPerp, Symbol: o.Symbol, Qty: o.Size, AvgPrice: o.Price},
+			},
+		}
 	}
 }
 

--- a/internal/agent/runtime_test.go
+++ b/internal/agent/runtime_test.go
@@ -103,6 +103,94 @@ func TestTickOnce_LiveMode_CallsVenues(t *testing.T) {
 	}
 }
 
+// TestTickOnce_ReconcilesOpenBasis exercises the runtime's in-memory
+// position bookkeeping: after a Decision opens a basis, the next tick's
+// DecisionInput.BasisPositions reflects it (so the strategy doesn't
+// re-emit the same open).
+func TestTickOnce_ReconcilesOpenBasis(t *testing.T) {
+	openIntent := strategy.Decision{
+		Notes: "open WIF",
+		Swaps: []types.SwapIntent{{
+			Chain:    types.ChainSolana,
+			InToken:  types.Asset{Symbol: "USDC", Chain: types.ChainSolana},
+			OutToken: types.Asset{Symbol: "WIF", Chain: types.ChainSolana, Mint: "wifmint"},
+			InAmount: decimal.NewFromInt(100),
+		}},
+		Orders: []types.OrderIntent{{
+			Venue: "hyperliquid", Symbol: "WIF", Side: types.SideSell,
+			Type: types.OrderTypeMarket, Size: decimal.NewFromInt(100),
+		}},
+	}
+
+	captured := []strategy.DecisionInput{}
+	strat := &captureStrategy{
+		decisions: []strategy.Decision{openIntent, openIntent}, // same intent twice
+		captured:  &captured,
+	}
+
+	a := Agent{ID: "a1", Strategy: "test", Mode: ModePaper}
+	r := NewRuntime(a, Deps{Strategy: strat})
+
+	if _, err := r.TickOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(r.snapshotOpenBasis()); got != 1 {
+		t.Fatalf("after first tick, expected 1 open basis, got %d", got)
+	}
+
+	if _, err := r.TickOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(captured); got != 2 {
+		t.Fatalf("strategy should have been called twice, got %d", got)
+	}
+	// Second tick must have seen the open basis.
+	if got := len(captured[1].BasisPositions); got != 1 {
+		t.Errorf("second tick BasisPositions: got %d want 1", got)
+	}
+	if captured[1].BasisPositions[0].Underlying != "WIF" {
+		t.Errorf("expected WIF, got %s", captured[1].BasisPositions[0].Underlying)
+	}
+}
+
+// captureStrategy records the DecisionInput it was called with and replays
+// scripted Decisions in order.
+type captureStrategy struct {
+	decisions []strategy.Decision
+	captured  *[]strategy.DecisionInput
+	calls     int
+}
+
+func (s *captureStrategy) Name() string                                          { return "capture" }
+func (s *captureStrategy) Warmup(_ context.Context, _ strategy.WarmupInput) error { return nil }
+func (s *captureStrategy) Decide(_ context.Context, in strategy.DecisionInput) (strategy.Decision, error) {
+	*s.captured = append(*s.captured, in)
+	d := s.decisions[s.calls%len(s.decisions)]
+	s.calls++
+	return d, nil
+}
+
+func TestReconcileOpenBasis_ClosesOnReduceOnly(t *testing.T) {
+	a := Agent{ID: "a", Strategy: "x", Mode: ModePaper}
+	r := NewRuntime(a, Deps{Strategy: nil})
+	r.openBasis["WIF"] = types.BasisPosition{
+		Underlying: "WIF",
+		State:      types.BasisStateOpen,
+		Legs: []types.BasisLeg{
+			{Kind: types.BasisLegPerp, Symbol: "WIF", Qty: decimal.NewFromInt(100)},
+		},
+	}
+	r.reconcileOpenBasis(time.Now(), "dec1", strategy.Decision{
+		Orders: []types.OrderIntent{{
+			Venue: "hyperliquid", Symbol: "WIF", Side: types.SideBuy,
+			ReduceOnly: true, Type: types.OrderTypeMarket, Size: decimal.NewFromInt(100),
+		}},
+	})
+	if len(r.snapshotOpenBasis()) != 0 {
+		t.Errorf("reduce-only buy should have closed the basis")
+	}
+}
+
 func TestRuntime_StartStop(t *testing.T) {
 	strat := &scriptedStrategy{name: "noop"}
 	a := Agent{ID: "a1", Strategy: "noop", Mode: ModePaper, TickSecs: 1}

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -2,9 +2,12 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/google/uuid"
@@ -14,6 +17,7 @@ import (
 	"github.com/teslashibe/permafrost/internal/agent"
 	"github.com/teslashibe/permafrost/internal/assets"
 	"github.com/teslashibe/permafrost/internal/exchange"
+	"github.com/teslashibe/permafrost/internal/exchange/hyperliquid"
 	exchangenoop "github.com/teslashibe/permafrost/internal/exchange/noop"
 	"github.com/teslashibe/permafrost/internal/inference"
 	"github.com/teslashibe/permafrost/internal/store"
@@ -37,6 +41,7 @@ func newAgentCmd() *cobra.Command {
 		newAgentSetModeCmd(),
 		newAgentStopCmd(),
 		newAgentTickCmd(),
+		newAgentRunCmd(),
 	)
 	return cmd
 }
@@ -108,6 +113,7 @@ func newAgentCreateCmd() *cobra.Command {
 		universeCSV                                            string
 		alloc                                                  string
 		tickSecs                                               int
+		configJSON                                             string
 	)
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -129,6 +135,12 @@ func newAgentCreateCmd() *cobra.Command {
 				}
 			}
 			universe := splitCSV(universeCSV)
+			cfgMap := map[string]any{}
+			if configJSON != "" {
+				if err := json.Unmarshal([]byte(configJSON), &cfgMap); err != nil {
+					return fmt.Errorf("--config-json: %w", err)
+				}
+			}
 			a := agent.Agent{
 				ID:             id,
 				Name:           name,
@@ -140,6 +152,7 @@ func newAgentCreateCmd() *cobra.Command {
 				Universe:       universe,
 				AllocationUSDC: amt,
 				TickSecs:       tickSecs,
+				Config:         cfgMap,
 			}
 			out, err := s.Create(c.Context(), a)
 			if err != nil {
@@ -160,6 +173,8 @@ func newAgentCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&universeCSV, "universe", "", "comma-separated symbols (e.g. WIF,BONK,POPCAT)")
 	cmd.Flags().StringVar(&alloc, "alloc", "", "allocation in USDC")
 	cmd.Flags().IntVar(&tickSecs, "tick-secs", 60, "tick interval seconds")
+	cmd.Flags().StringVar(&configJSON, "config-json", "",
+		`strategy-specific config as JSON (e.g. '{"entry_annualised_funding":0.05,"position_cap_usdc":100}')`)
 	return cmd
 }
 
@@ -272,6 +287,156 @@ func newAgentSetModeCmd() *cobra.Command {
 	}
 }
 
+// newAgentRunCmd runs the full Runtime tick loop for ONE agent in the
+// foreground. Designed for paper-mode end-to-end testing against the real
+// Hyperliquid funding API: no signer required (Hyperliquid funding is
+// public). Stops on SIGINT/SIGTERM or after --ticks N (whichever first).
+//
+// For live mode this command will refuse to start unless a signer is
+// configured. The supervisor-driven multi-agent runner is a v1.1 concern.
+func newAgentRunCmd() *cobra.Command {
+	var (
+		network    string
+		hlAddress  string
+		maxTicks   int
+		dryRun     bool
+	)
+	cmd := &cobra.Command{
+		Use:   "run <id>",
+		Short: "Run an agent's tick loop in the foreground (paper-mode only in v1)",
+		Long: `Runs ONE agent's Strategy.Decide loop in the foreground, against the real
+Hyperliquid public funding-rate API. Decisions and (paper) orders/swaps are
+persisted to the database.
+
+This is the proper end-to-end paper-mode flow — equivalent to what a
+multi-agent daemon will do once supervisor-driven agent loading lands.
+
+Stops on SIGINT/SIGTERM or after --ticks N (whichever comes first).`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			g := FromContext(c.Context())
+			if g == nil {
+				return errors.New("globals not initialised")
+			}
+			st, db, err := openAgentStore(c)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			a, err := st.Get(c.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			if a.Mode != agent.ModePaper {
+				return fmt.Errorf("agent %q is mode=%q; `agent run` is paper-mode only in v1", a.ID, a.Mode)
+			}
+
+			// Build venue. If Hyperliquid signer is in the keystore, use its
+			// address (allows positions/balances calls to also work). Otherwise
+			// allow funding-only mode by leaving Address empty.
+			perp, err := buildHLVenue(c, network, hlAddress)
+			if err != nil {
+				return err
+			}
+
+			reg, err := assets.LoadEmbedded()
+			if err != nil {
+				return err
+			}
+			strat, err := buildStrategyForAgent(a, reg)
+			if err != nil {
+				return err
+			}
+
+			deps := agent.Deps{
+				Strategy: strat,
+				Perp:     perp,
+				Store:    st,
+				Logger:   g.Log,
+			}
+			if dryRun {
+				deps.Store = nil
+				g.Log.Info("dry-run: no DB writes")
+			}
+			rt := agent.NewRuntime(a, deps)
+
+			ctx, stop := signal.NotifyContext(c.Context(), syscall.SIGINT, syscall.SIGTERM)
+			defer stop()
+
+			g.Log.Info("agent run starting",
+				"agent_id", a.ID, "strategy", a.Strategy, "mode", a.Mode,
+				"tick_secs", a.TickSecs, "universe", a.Universe,
+				"hyperliquid_network", network)
+
+			ticks := 0
+			tickInterval := a.Interval()
+			ticker := time.NewTicker(tickInterval)
+			defer ticker.Stop()
+
+			doTick := func() error {
+				dec, err := rt.TickOnce(ctx)
+				if err != nil {
+					g.Log.Error("tick failed", "err", err)
+					return nil // don't bail the loop on transient errors
+				}
+				g.Log.Info("tick",
+					"swaps", len(dec.Swaps),
+					"orders", len(dec.Orders),
+					"cancels", len(dec.Cancels),
+					"confidence", dec.Confidence,
+					"notes", dec.Notes,
+				)
+				ticks++
+				return nil
+			}
+
+			if err := doTick(); err != nil {
+				return err
+			}
+			for {
+				if maxTicks > 0 && ticks >= maxTicks {
+					g.Log.Info("max ticks reached, exiting", "ticks", ticks)
+					return nil
+				}
+				select {
+				case <-ctx.Done():
+					g.Log.Info("agent run stopping", "ticks", ticks)
+					return nil
+				case <-ticker.C:
+					if err := doTick(); err != nil {
+						return err
+					}
+				}
+			}
+		},
+	}
+	cmd.Flags().StringVar(&network, "network", "testnet", "hyperliquid network: mainnet | testnet")
+	cmd.Flags().StringVar(&hlAddress, "address", "", "hyperliquid address override (default: derived from keystore)")
+	cmd.Flags().IntVar(&maxTicks, "ticks", 0, "stop after N ticks (0 = run until SIGINT)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "do not persist decisions/orders/swaps")
+	return cmd
+}
+
+// buildHLVenue assembles a real Hyperliquid Venue. If --address is given it
+// wins; else we try the keystore's Hyperliquid signer; else we run in
+// funding-only mode (no per-account reads).
+func buildHLVenue(c *cobra.Command, network, addrOverride string) (exchange.Venue, error) {
+	addr := addrOverride
+	if addr == "" {
+		// Try the keystore (if unlocked).
+		if ks, err := openKeystore(c); err == nil {
+			if s, err := ks.Signer(types.ChainHyperliquid); err == nil {
+				addr = s.Address()
+			}
+		}
+	}
+	cfg := hyperliquid.Config{
+		Network: hyperliquid.Network(network),
+		Address: addr,
+	}
+	return hyperliquid.New(cfg)
+}
+
 // newAgentTickCmd runs a single Decide tick for an agent and persists the
 // decision. Designed for paper-mode integration testing without waiting for
 // the background scheduler. Defaults to a no-op perp venue with synthetic
@@ -337,12 +502,50 @@ func newAgentTickCmd() *cobra.Command {
 
 // buildStrategyForAgent constructs a strategy.Strategy from an Agent record.
 // Currently only funding_arb_basic is supported via this CLI helper.
+//
+// For funding_arb_basic, the agent's Config map may contain optional
+// overrides:
+//   - entry_annualised_funding: float (e.g. 0.50 for 50% APR)
+//   - exit_annualised_funding:  float
+//   - position_cap_usdc:        number
+//   - slippage_bps:             int
+//   - use_llm_veto:             bool
+//   - veto_model:               string
 func buildStrategyForAgent(a agent.Agent, reg assets.Registry) (strategy.Strategy, error) {
 	switch a.Strategy {
 	case fab.Name:
-		return fab.New(fab.Config{
-			Universe: a.Universe,
-		}, reg, inference.Provider(nil))
+		cfg := fab.Config{Universe: a.Universe}
+		if v, ok := a.Config["entry_annualised_funding"]; ok {
+			if d, err := decimalFromAny(v); err == nil {
+				cfg.EntryAnnualisedFunding = d
+			}
+		}
+		if v, ok := a.Config["exit_annualised_funding"]; ok {
+			if d, err := decimalFromAny(v); err == nil {
+				cfg.ExitAnnualisedFunding = d
+			}
+		}
+		if v, ok := a.Config["position_cap_usdc"]; ok {
+			if d, err := decimalFromAny(v); err == nil {
+				cfg.PositionCapUSDC = d
+			}
+		}
+		if v, ok := a.Config["slippage_bps"]; ok {
+			if i, err := intFromAny(v); err == nil {
+				cfg.SlippageBps = i
+			}
+		}
+		if v, ok := a.Config["use_llm_veto"]; ok {
+			if b, ok := v.(bool); ok {
+				cfg.UseLLMVeto = b
+			}
+		}
+		if v, ok := a.Config["veto_model"]; ok {
+			if s, ok := v.(string); ok {
+				cfg.VetoModel = s
+			}
+		}
+		return fab.New(cfg, reg, inference.Provider(nil))
 	default:
 		ctor, err := strategy.Get(a.Strategy)
 		if err != nil {
@@ -350,6 +553,35 @@ func buildStrategyForAgent(a agent.Agent, reg assets.Registry) (strategy.Strateg
 		}
 		return ctor(a.Config)
 	}
+}
+
+// decimalFromAny coerces JSON-decoded values (float64, int, string) into a
+// shopspring.Decimal.
+func decimalFromAny(v any) (decimal.Decimal, error) {
+	switch x := v.(type) {
+	case float64:
+		return decimal.NewFromFloat(x), nil
+	case int:
+		return decimal.NewFromInt(int64(x)), nil
+	case int64:
+		return decimal.NewFromInt(x), nil
+	case string:
+		return decimal.NewFromString(x)
+	}
+	return decimal.Zero, fmt.Errorf("unrecognised numeric type %T", v)
+}
+
+// intFromAny coerces JSON-decoded numerics to int.
+func intFromAny(v any) (int, error) {
+	switch x := v.(type) {
+	case float64:
+		return int(x), nil
+	case int:
+		return x, nil
+	case int64:
+		return int(x), nil
+	}
+	return 0, fmt.Errorf("unrecognised int type %T", v)
 }
 
 // tickFundingVenue is a synthetic Venue for `agent tick`. It returns no

--- a/internal/exchange/hyperliquid/config.go
+++ b/internal/exchange/hyperliquid/config.go
@@ -52,9 +52,16 @@ func EndpointsFor(n Network) (Endpoints, error) {
 	}
 }
 
-// Config configures a Hyperliquid Venue. Address is the user account address
-// (0x-prefixed hex). Network selects mainnet vs testnet. RESTOverride and
-// WSOverride allow tests and private gateways to redirect traffic.
+// Config configures a Hyperliquid Venue.
+//
+// Address is the user account address (0x-prefixed 42-char hex). It is
+// REQUIRED for any per-account read (Positions, Balances) or write
+// (Place, Cancel) operation, but is OPTIONAL for funding-only / public
+// market data — Subscribe and FundingRates work without one. This lets
+// paper-mode agents pull venue data without any keys configured.
+//
+// Network selects mainnet vs testnet. RESTOverride and WSOverride allow
+// tests and private gateways to redirect traffic.
 type Config struct {
 	Network      Network
 	Address      string
@@ -76,13 +83,18 @@ func (c Config) endpoints() (Endpoints, error) {
 	return ep, nil
 }
 
-// validate checks the config has the minimum required fields.
+// validate checks the config. Address is optional; if supplied it must be
+// well-formed.
 func (c Config) validate() error {
 	if c.Address == "" {
-		return errors.New("hyperliquid: Address is required")
+		return nil
 	}
 	if !strings.HasPrefix(c.Address, "0x") || len(c.Address) != 42 {
 		return fmt.Errorf("hyperliquid: Address %q must be 0x-prefixed 42-char hex", c.Address)
 	}
 	return nil
 }
+
+// ErrAddressRequired is returned when a per-account read/write is attempted
+// without an Address configured.
+var ErrAddressRequired = errors.New("hyperliquid: Address is required for this operation")

--- a/internal/exchange/hyperliquid/probe_test.go
+++ b/internal/exchange/hyperliquid/probe_test.go
@@ -1,0 +1,78 @@
+//go:build live
+
+// Live integration test against the real Hyperliquid REST API. Run with:
+//
+//	go test -tags=live ./internal/exchange/hyperliquid/... -v -run TestLive
+//
+// Excluded from the default build to avoid hitting the network in CI.
+package hyperliquid
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+)
+
+func TestLive_FundingRates_Testnet(t *testing.T) {
+	v, err := New(Config{Network: NetworkTestnet})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	rates, err := v.FundingRates(ctx, nil)
+	if err != nil {
+		t.Fatalf("FundingRates testnet: %v", err)
+	}
+	if len(rates) == 0 {
+		t.Fatal("expected at least one funding rate from testnet")
+	}
+	t.Logf("got %d funding rates from hyperliquid testnet", len(rates))
+}
+
+// TestLive_FundingRates_Mainnet_TopAnnualised prints the highest-annualised
+// funding rates on mainnet — useful to know whether default thresholds will
+// trigger entries during a paper run.
+func TestLive_FundingRates_Mainnet_TopAnnualised(t *testing.T) {
+	v, err := New(Config{Network: NetworkMainnet})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	rates, err := v.FundingRates(ctx, nil)
+	if err != nil {
+		t.Fatalf("FundingRates mainnet: %v", err)
+	}
+	sort.Slice(rates, func(i, j int) bool {
+		return rates[i].Annualised().Abs().GreaterThan(rates[j].Annualised().Abs())
+	})
+	t.Logf("top 10 |annualised funding| on mainnet (out of %d):", len(rates))
+	for i, r := range rates {
+		if i >= 10 {
+			break
+		}
+		t.Logf("  %-12s rate/h=%-15s ann=%s", r.Symbol, r.Rate, r.Annualised())
+	}
+}
+
+// TestLive_FundingRates_Universe prints the funding for our registry
+// universe so we know what the strategy would actually see.
+func TestLive_FundingRates_Universe(t *testing.T) {
+	v, err := New(Config{Network: NetworkMainnet})
+	if err != nil {
+		t.Fatal(err)
+	}
+	universe := []string{"WIF", "BONK", "POPCAT", "PNUT", "GOAT", "FARTCOIN", "MOODENG", "CHILLGUY"}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	rates, err := v.FundingRates(ctx, universe)
+	if err != nil {
+		t.Fatalf("FundingRates: %v", err)
+	}
+	t.Logf("funding for permafrost universe (mainnet, %d hits):", len(rates))
+	for _, r := range rates {
+		t.Logf("  %-10s rate/h=%-15s ann=%s", r.Symbol, r.Rate, r.Annualised())
+	}
+}

--- a/internal/exchange/hyperliquid/venue.go
+++ b/internal/exchange/hyperliquid/venue.go
@@ -64,8 +64,12 @@ var _ exchange.Venue = (*Venue)(nil)
 
 func (v *Venue) Name() string { return VenueName }
 
-// Positions returns currently-open positions across all coins.
+// Positions returns currently-open positions across all coins. Requires
+// Address to be configured.
 func (v *Venue) Positions(ctx context.Context) ([]types.Position, error) {
+	if v.cfg.Address == "" {
+		return nil, ErrAddressRequired
+	}
 	var out clearinghouseStateResp
 	if err := v.client.info(ctx, infoRequest{Type: "clearinghouseState", User: v.cfg.Address}, &out); err != nil {
 		return nil, err
@@ -98,7 +102,11 @@ func (v *Venue) Positions(ctx context.Context) ([]types.Position, error) {
 
 // Balances returns the venue-side USDC balance. Hyperliquid is a USDC-margined
 // venue, so we synthesise a single Balance from the clearinghouse summary.
+// Requires Address to be configured.
 func (v *Venue) Balances(ctx context.Context) ([]types.Balance, error) {
+	if v.cfg.Address == "" {
+		return nil, ErrAddressRequired
+	}
 	var out clearinghouseStateResp
 	if err := v.client.info(ctx, infoRequest{Type: "clearinghouseState", User: v.cfg.Address}, &out); err != nil {
 		return nil, err

--- a/internal/exchange/hyperliquid/venue_test.go
+++ b/internal/exchange/hyperliquid/venue_test.go
@@ -49,14 +49,26 @@ func newTestVenue(t *testing.T, srv *httptest.Server) *Venue {
 }
 
 func TestConfigValidation(t *testing.T) {
-	if _, err := New(Config{}); err == nil {
-		t.Error("missing address should error")
+	if _, err := New(Config{}); err != nil {
+		t.Errorf("empty Address should be allowed (funding-only mode): %v", err)
 	}
 	if _, err := New(Config{Address: "0xZZZ"}); err == nil {
 		t.Error("malformed address should error")
 	}
 	if _, err := New(Config{Address: testAddr, Network: "rinkeby"}); err == nil {
 		t.Error("unknown network should error")
+	}
+
+	// Without an address, per-account reads must fail with ErrAddressRequired.
+	v, err := New(Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := v.Positions(context.Background()); !errors.Is(err, ErrAddressRequired) {
+		t.Errorf("Positions: expected ErrAddressRequired, got %v", err)
+	}
+	if _, err := v.Balances(context.Background()); !errors.Is(err, ErrAddressRequired) {
+		t.Errorf("Balances: expected ErrAddressRequired, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Why

The pre-merge audit only verified single-shot ticks via the CLI helper (\`agent tick\`) using a synthetic in-memory funding venue. The actual loop story — daemon-driven scheduler reading real Hyperliquid funding on a tick interval — was never exercised end-to-end, and once exercised revealed three real gaps. Fixed here.

## Gaps fixed

### 1. No foreground runner for an agent's tick loop
The daemon's \`Serve()\` only runs the Fiber API; multi-agent supervisor wiring is deferred to v1.1. New \`permafrost agent run <id>\`:
- Loads the agent from DB.
- Refuses to start unless \`mode=paper\` (live mode requires the EIP-712 signing follow-up).
- Constructs a real \`internal/exchange/hyperliquid\` Venue (mainnet or testnet via \`--network\`).
- Drives the runtime tick loop in the foreground.
- Stops on SIGINT or after \`--ticks N\`.

### 2. Hyperliquid Venue rejected an empty Address
So paper mode without a keystore couldn't even fetch public funding rates. Loosened \`hyperliquid.Config.validate\` to allow empty Address; per-account reads (\`Positions\`, \`Balances\`) return \`ErrAddressRequired\` instead. Funding rates and Subscribe work without an address.

### 3. Runtime fed empty BasisPositions on every tick
A basis strategy would re-emit the same opens forever. Added in-memory \`openBasis\` bookkeeping to \`Runtime\`:
- After each tick the runtime pairs swaps + non-reduce-only sells into a \`BasisPosition\` entry keyed by underlying.
- Reduce-only orders close the entry.
- The next tick's \`DecisionInput.BasisPositions\` reflects what the runtime has open.
- v1.1 should drive this off a \`strategy_positions\` DB row so it survives restarts (the table already exists from M6).

### Plumbing
\`agent create --config-json '{...}'\` lets operators pass strategy-specific overrides into \`agents.config\` (jsonb). \`buildStrategyForAgent\` reads \`funding_arb_basic\`-relevant keys back out (entry/exit funding, position cap, slippage, LLM veto toggle, model).

## Tests
- \`TestTickOnce_ReconcilesOpenBasis\` — same Decision returned twice; the second tick's input reflects the first open, so a real strategy would skip re-opening.
- \`TestReconcileOpenBasis_ClosesOnReduceOnly\` — a reduce-only buy removes the matching open basis from the runtime.
- HL venue: \`TestConfigValidation\` now asserts empty Address is allowed AND that \`Positions\`/\`Balances\` return \`ErrAddressRequired\` without one.
- \`internal/exchange/hyperliquid/probe_test.go\` (build tag \`live\`) — hits real testnet + mainnet to print top-funding alts. Excluded from CI.

## End-to-end verified against live HL mainnet
\`\`\`
$ permafrost agent run paper-real-03 --network mainnet --ticks 4
agent run starting agent_id=paper-real-03 ... hyperliquid_network=mainnet
tick swaps=6 orders=6 cancels=0 confidence=1 notes="opening WIF @ funding 0.1095/yr
                                                    opening POPCAT @ funding 0.1095/yr
                                                    opening GOAT @ funding 0.1095/yr
                                                    opening FARTCOIN @ funding 0.1095/yr
                                                    opening MOODENG @ funding 0.1095/yr
                                                    opening CHILLGUY @ funding 0.1095/yr"
tick swaps=0 orders=0 cancels=0 confidence=1 notes=""
tick swaps=0 orders=0 cancels=0 confidence=1 notes=""
tick swaps=0 orders=0 cancels=0 confidence=1 notes=""
max ticks reached, exiting
\`\`\`

DB after the run: \`4 decisions, 6 paper orders, 6 paper swaps\`. All \`paper=true\`. Reconciliation working — the strategy correctly refuses to double-open.

## Verify locally
\`\`\`
go test ./internal/agent/... -race -count=1 -v
# live HL probe (network):
go test -tags=live ./internal/exchange/hyperliquid/... -v -run TestLive
\`\`\`

## Out of scope
- Persisting \`openBasis\` to the \`strategy_positions\` table (v1.1).
- Multi-agent supervisor inside \`serve\` (v1.1).
- Real EIP-712 Hyperliquid action signing → unblocks live mode.