### PR TITLE
feat: persist openBasis + daemon supervises agents

### DIFF
--- a/cmd/permafrostd/main.go
+++ b/cmd/permafrostd/main.go
@@ -27,8 +27,18 @@ func main() {
 		Config: cfg,
 		Log:    telemetry.NewLogger(cfg.Logging, cfg.Env),
 	}
-	if err := cli.Serve(context.Background(), g); err != nil {
+	opts := cli.ServeOptions{
+		HyperliquidNetwork: defaultStr(os.Getenv("PERMAFROST_HYPERLIQUID_NETWORK"), "testnet"),
+	}
+	if err := cli.Serve(context.Background(), g, opts); err != nil {
 		fmt.Fprintln(os.Stderr, "serve:", err)
 		os.Exit(1)
 	}
+}
+
+func defaultStr(v, fallback string) string {
+	if v == "" {
+		return fallback
+	}
+	return v
 }

--- a/internal/agent/builder.go
+++ b/internal/agent/builder.go
@@ -1,0 +1,230 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/assets"
+	"github.com/teslashibe/permafrost/internal/exchange"
+	"github.com/teslashibe/permafrost/internal/exchange/hyperliquid"
+	"github.com/teslashibe/permafrost/internal/inference"
+	"github.com/teslashibe/permafrost/internal/strategy"
+	fab "github.com/teslashibe/permafrost/internal/strategy/funding_arb_basic"
+	"github.com/teslashibe/permafrost/internal/types"
+	"github.com/teslashibe/permafrost/internal/wallet"
+)
+
+// BuildDeps assembles dependencies for a single Agent's Runtime. It is the
+// canonical wiring point: both the foreground `agent run` CLI and the
+// supervisor inside `serve` use this so behaviour stays identical.
+//
+// Inputs:
+//   - a: the Agent record (from the DB).
+//   - reg: the asset registry (typically assets.LoadEmbedded()).
+//   - store: the agent Store (drives persistence and openBasis hydration).
+//   - keystore: optional; if set and a Hyperliquid signer is present, its
+//     address is wired into the HL Venue so per-account reads work.
+//   - log: scoped slog logger.
+//   - opts: BuildOptions (network, etc.).
+//
+// Returns Deps with Strategy + Perp Venue + Store + Logger populated. SwapVenue
+// and Inference Provider are intentionally left nil for v1: paper-mode swaps
+// are recorded directly by the runtime; live mode requires the HL signing
+// follow-up before SwapVenue makes sense as a default.
+func BuildDeps(
+	a Agent,
+	reg assets.Registry,
+	store *Store,
+	keystore wallet.Keystore,
+	log *slog.Logger,
+	opts BuildOptions,
+) (Deps, error) {
+	strat, err := BuildStrategy(a, reg)
+	if err != nil {
+		return Deps{}, fmt.Errorf("strategy: %w", err)
+	}
+	venue, err := BuildHyperliquidVenue(keystore, opts)
+	if err != nil {
+		return Deps{}, fmt.Errorf("hyperliquid venue: %w", err)
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return Deps{
+		Strategy: strat,
+		Perp:     venue,
+		Store:    store,
+		Logger:   log.With("agent_id", a.ID),
+	}, nil
+}
+
+// BuildOptions captures runtime-wiring parameters that aren't stored on the
+// Agent record itself.
+type BuildOptions struct {
+	HyperliquidNetwork string // "mainnet" | "testnet" (default: testnet)
+	HyperliquidAddress string // optional override; else derived from keystore
+}
+
+// BuildStrategy is the strategy-construction switch shared between the
+// foreground CLI and the supervisor. Currently funding_arb_basic is the
+// only strategy that needs the asset registry; everything else goes through
+// the generic strategy.Constructor registry.
+func BuildStrategy(a Agent, reg assets.Registry) (strategy.Strategy, error) {
+	switch a.Strategy {
+	case fab.Name:
+		cfg := fab.Config{Universe: a.Universe}
+		applyFundingArbConfig(a.Config, &cfg)
+		return fab.New(cfg, reg, inference.Provider(nil))
+	default:
+		ctor, err := strategy.Get(a.Strategy)
+		if err != nil {
+			return nil, err
+		}
+		return ctor(a.Config)
+	}
+}
+
+// BuildHyperliquidVenue assembles a Hyperliquid Venue. Address resolution:
+// 1) opts.HyperliquidAddress if set, else 2) keystore's HL signer if any,
+// else 3) leave empty (funding-only mode).
+func BuildHyperliquidVenue(keystore wallet.Keystore, opts BuildOptions) (exchange.Venue, error) {
+	addr := opts.HyperliquidAddress
+	if addr == "" && keystore != nil {
+		if s, err := keystore.Signer(types.ChainHyperliquid); err == nil {
+			addr = s.Address()
+		}
+	}
+	network := opts.HyperliquidNetwork
+	if network == "" {
+		network = "testnet"
+	}
+	return hyperliquid.New(hyperliquid.Config{
+		Network: hyperliquid.Network(network),
+		Address: addr,
+	})
+}
+
+// applyFundingArbConfig copies known keys from agents.config (jsonb) into
+// the typed funding_arb_basic Config struct. Unknown keys are ignored.
+func applyFundingArbConfig(cfg map[string]any, out *fab.Config) {
+	if v, ok := cfg["entry_annualised_funding"]; ok {
+		if d, err := decimalFromAny(v); err == nil {
+			out.EntryAnnualisedFunding = d
+		}
+	}
+	if v, ok := cfg["exit_annualised_funding"]; ok {
+		if d, err := decimalFromAny(v); err == nil {
+			out.ExitAnnualisedFunding = d
+		}
+	}
+	if v, ok := cfg["position_cap_usdc"]; ok {
+		if d, err := decimalFromAny(v); err == nil {
+			out.PositionCapUSDC = d
+		}
+	}
+	if v, ok := cfg["slippage_bps"]; ok {
+		if i, err := intFromAny(v); err == nil {
+			out.SlippageBps = i
+		}
+	}
+	if v, ok := cfg["use_llm_veto"]; ok {
+		if b, ok := v.(bool); ok {
+			out.UseLLMVeto = b
+		}
+	}
+	if v, ok := cfg["veto_model"]; ok {
+		if s, ok := v.(string); ok {
+			out.VetoModel = s
+		}
+	}
+}
+
+func decimalFromAny(v any) (decimal.Decimal, error) {
+	switch x := v.(type) {
+	case float64:
+		return decimal.NewFromFloat(x), nil
+	case int:
+		return decimal.NewFromInt(int64(x)), nil
+	case int64:
+		return decimal.NewFromInt(x), nil
+	case string:
+		return decimal.NewFromString(x)
+	}
+	return decimal.Zero, fmt.Errorf("agent: unrecognised numeric type %T", v)
+}
+
+func intFromAny(v any) (int, error) {
+	switch x := v.(type) {
+	case float64:
+		return int(x), nil
+	case int:
+		return x, nil
+	case int64:
+		return int(x), nil
+	}
+	return 0, fmt.Errorf("agent: unrecognised int type %T", v)
+}
+
+// Loader is a small helper used by the supervisor inside `serve` to start
+// every running agent on daemon boot. It is safe to call multiple times.
+type Loader struct {
+	Store      *Store
+	Registry   assets.Registry
+	Keystore   wallet.Keystore
+	Logger     *slog.Logger
+	BuildOpts  BuildOptions
+	Supervisor *Supervisor
+}
+
+// LoadAndStartRunning queries every agent with status='running' and starts
+// each one via the supervisor. Errors are logged; one bad agent does not
+// stop the rest. Returns the number of agents successfully started.
+func (l *Loader) LoadAndStartRunning(ctx context.Context) (int, error) {
+	if l.Store == nil {
+		return 0, errors.New("agent: loader Store is required")
+	}
+	if l.Supervisor == nil {
+		return 0, errors.New("agent: loader Supervisor is required")
+	}
+	agents, err := l.Store.List(ctx)
+	if err != nil {
+		return 0, err
+	}
+	started := 0
+	for _, a := range agents {
+		if a.Status != StatusRunning {
+			continue
+		}
+		// Re-fetch so we get the full record (Universe, Config, etc.).
+		full, err := l.Store.Get(ctx, a.ID)
+		if err != nil {
+			l.Logger.Warn("loader: get agent failed", "agent_id", a.ID, "err", err)
+			continue
+		}
+		deps, err := BuildDeps(full, l.Registry, l.Store, l.Keystore, l.Logger, l.BuildOpts)
+		if err != nil {
+			l.Logger.Error("loader: build deps failed", "agent_id", full.ID, "err", err)
+			continue
+		}
+		rt := NewRuntime(full, deps)
+		l.Supervisor.Register(full.ID, rt)
+		if err := l.Supervisor.Start(ctx, full.ID); err != nil {
+			l.Logger.Error("loader: start failed", "agent_id", full.ID, "err", err)
+			continue
+		}
+		// Persistent status confirms "this agent is supposed to be running".
+		// We re-set it on every boot so an admin who manually toggled it back
+		// to 'running' (instead of using `agent start`) gets resumed too.
+		_ = l.Store.SetStatus(ctx, full.ID, StatusRunning)
+		l.Logger.Info("loader: started agent",
+			"agent_id", full.ID, "strategy", full.Strategy,
+			"mode", full.Mode, "tick_secs", full.TickSecs)
+		started++
+	}
+	return started, nil
+}
+

--- a/internal/agent/builder_test.go
+++ b/internal/agent/builder_test.go
@@ -1,0 +1,95 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/teslashibe/permafrost/internal/assets"
+	walletnoop "github.com/teslashibe/permafrost/internal/wallet/noop"
+)
+
+func TestBuildStrategy_FundingArbAppliesConfigOverrides(t *testing.T) {
+	reg, err := assets.LoadEmbedded()
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := Agent{
+		ID:       "ag-x",
+		Strategy: "funding_arb_basic",
+		Universe: []string{"WIF"},
+		Config: map[string]any{
+			"entry_annualised_funding": 0.05,
+			"exit_annualised_funding":  0.02,
+			"position_cap_usdc":        100,
+			"slippage_bps":             25,
+		},
+	}
+	s, err := BuildStrategy(a, reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s == nil || s.Name() != "funding_arb_basic" {
+		t.Fatalf("unexpected strategy: %+v", s)
+	}
+}
+
+func TestBuildHyperliquidVenue_NoKeystoreAllowed(t *testing.T) {
+	v, err := BuildHyperliquidVenue(nil, BuildOptions{HyperliquidNetwork: "testnet"})
+	if err != nil {
+		t.Fatalf("expected funding-only venue without keystore, got %v", err)
+	}
+	if v.Name() != "hyperliquid" {
+		t.Errorf("Name: %q", v.Name())
+	}
+}
+
+func TestBuildHyperliquidVenue_AddressOverrideWins(t *testing.T) {
+	const addr = "0x1111111111111111111111111111111111111111"
+	v, err := BuildHyperliquidVenue(nil, BuildOptions{
+		HyperliquidNetwork: "testnet",
+		HyperliquidAddress: addr,
+	})
+	if err != nil {
+		t.Fatalf("BuildHyperliquidVenue: %v", err)
+	}
+	if v.Name() != "hyperliquid" {
+		t.Errorf("Name: %q", v.Name())
+	}
+}
+
+func TestBuildHyperliquidVenue_RejectsBadKeystoreAddress(t *testing.T) {
+	// noop keystore returns addresses prefixed "noop_…" which fail HL's
+	// 0x-prefix check. The builder should surface the validation error
+	// rather than silently dropping the address.
+	ks := walletnoop.NewKeystore("hyperliquid")
+	_, err := BuildHyperliquidVenue(ks, BuildOptions{HyperliquidNetwork: "testnet"})
+	if err == nil {
+		t.Fatal("expected validation error on noop signer address")
+	}
+}
+
+func TestBuildOptions_DefaultsToTestnet(t *testing.T) {
+	v, err := BuildHyperliquidVenue(nil, BuildOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v == nil {
+		t.Fatal("expected venue")
+	}
+}
+
+func TestApplyFundingArbConfig_NumericTypes(t *testing.T) {
+	cases := []map[string]any{
+		{"entry_annualised_funding": 0.5},          // float64 (JSON default)
+		{"entry_annualised_funding": int(1)},        // int (rare via flags)
+		{"entry_annualised_funding": int64(1)},      // int64
+		{"entry_annualised_funding": "0.25"},        // string
+	}
+	for _, m := range cases {
+		if _, err := decimalFromAny(m["entry_annualised_funding"]); err != nil {
+			t.Errorf("decimalFromAny rejected %T: %v", m["entry_annualised_funding"], err)
+		}
+	}
+	if _, err := decimalFromAny(struct{}{}); err == nil {
+		t.Error("decimalFromAny should reject struct")
+	}
+}

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -54,16 +54,33 @@ type Runtime struct {
 }
 
 // NewRuntime constructs a Runtime.
+//
+// If Deps.Store is set, NewRuntime hydrates openBasis from any persisted
+// strategy_positions rows so an agent that's restarted picks up where it
+// left off. Hydration errors are logged but don't fail construction.
 func NewRuntime(a Agent, d Deps) *Runtime {
 	if d.Logger == nil {
 		d.Logger = slog.Default()
 	}
-	return &Runtime{
+	r := &Runtime{
 		agent:     a,
 		deps:      d,
 		now:       func() time.Time { return time.Now().UTC() },
 		openBasis: make(map[string]types.BasisPosition),
 	}
+	if d.Store != nil {
+		if existing, err := d.Store.LoadOpenBasis(context.Background(), a.ID); err != nil {
+			d.Logger.Warn("hydrate open basis failed", "agent_id", a.ID, "err", err)
+		} else {
+			for _, p := range existing {
+				r.openBasis[strings.ToUpper(p.Underlying)] = p
+			}
+			if len(existing) > 0 {
+				d.Logger.Info("hydrated open basis", "agent_id", a.ID, "count", len(existing))
+			}
+		}
+	}
+	return r
 }
 
 // SetClock overrides the runtime's clock function. For tests only.
@@ -78,6 +95,11 @@ func (r *Runtime) IsRunning() bool {
 
 // Start launches the tick loop and returns immediately. The supplied parent
 // context controls overall lifetime. Use Stop() for graceful shutdown.
+//
+// Start does NOT mutate the persisted status — that is an operator action
+// performed via the CLI / API. This keeps Stop+restart semantics clean: a
+// graceful daemon shutdown leaves status='running' so the next boot resumes
+// the agent automatically.
 func (r *Runtime) Start(parent context.Context) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -87,18 +109,14 @@ func (r *Runtime) Start(parent context.Context) error {
 	ctx, cancel := context.WithCancel(parent)
 	r.cancel = cancel
 	r.running = true
-
-	if r.deps.Store != nil {
-		_ = r.deps.Store.SetStatus(parent, r.agent.ID, StatusRunning)
-	}
-
 	go r.loop(ctx)
 	return nil
 }
 
-// Stop gracefully halts the tick loop and waits for the current tick to
-// complete (best-effort within ctx).
-func (r *Runtime) Stop(ctx context.Context, reason string) error {
+// Stop gracefully halts the tick loop. It does NOT change the persisted
+// agent status — see the Start docstring for the rationale. Operators that
+// want a permanent stop should use the CLI/API to set status='halted'.
+func (r *Runtime) Stop(_ context.Context, reason string) error {
 	r.mu.Lock()
 	if !r.running {
 		r.mu.Unlock()
@@ -107,10 +125,6 @@ func (r *Runtime) Stop(ctx context.Context, reason string) error {
 	r.running = false
 	r.cancel()
 	r.mu.Unlock()
-
-	if r.deps.Store != nil {
-		_ = r.deps.Store.SetStatus(ctx, r.agent.ID, StatusStopped)
-	}
 	r.deps.Logger.Info("agent stopped", "agent_id", r.agent.ID, "reason", reason)
 	return nil
 }
@@ -155,6 +169,17 @@ func (r *Runtime) tickOnce(ctx context.Context) (strategy.Decision, error) {
 	r.persistDecision(ctx, now, decisionID, in, dec)
 
 	r.executeSwapsThenOrders(ctx, now, decisionID, in, dec)
+
+	// One concise per-tick log so operators can see the daemon working
+	// without enabling debug. This is the only INFO line emitted per tick.
+	r.deps.Logger.Info("tick",
+		"agent_id", r.agent.ID,
+		"decision_id", decisionID,
+		"swaps", len(dec.Swaps),
+		"orders", len(dec.Orders),
+		"cancels", len(dec.Cancels),
+		"open_basis", len(in.BasisPositions),
+	)
 	return dec, nil
 }
 
@@ -236,14 +261,15 @@ func (r *Runtime) executeSwapsThenOrders(ctx context.Context, now time.Time, dec
 	for _, c := range dec.Cancels {
 		r.executeCancel(ctx, c)
 	}
-	r.reconcileOpenBasis(now, decisionID, dec)
+	r.reconcileOpenBasis(ctx, now, decisionID, dec)
 }
 
 // reconcileOpenBasis maintains the runtime's in-memory view of open basis
 // positions based on the intents this decision emitted. Pairs are matched by
-// the underlying symbol (perp.Symbol == swap.OutToken.Symbol for opens, or
-// the reduce-only perp's symbol == swap.InToken.Symbol for closes).
-func (r *Runtime) reconcileOpenBasis(now time.Time, decisionID string, dec strategy.Decision) {
+// the underlying symbol. When a Store is configured, every open is upserted
+// and every close is recorded — so a daemon restart hydrates the same
+// position set on the next NewRuntime.
+func (r *Runtime) reconcileOpenBasis(ctx context.Context, now time.Time, decisionID string, dec strategy.Decision) {
 	r.posMu.Lock()
 	defer r.posMu.Unlock()
 
@@ -254,7 +280,17 @@ func (r *Runtime) reconcileOpenBasis(now time.Time, decisionID string, dec strat
 		if !o.ReduceOnly {
 			continue
 		}
-		delete(r.openBasis, strings.ToUpper(o.Symbol))
+		key := strings.ToUpper(o.Symbol)
+		if _, ok := r.openBasis[key]; !ok {
+			continue
+		}
+		delete(r.openBasis, key)
+		if r.deps.Store != nil {
+			if err := r.deps.Store.CloseBasis(ctx, r.agent.ID, o.Symbol); err != nil && !errors.Is(err, ErrNoOpenBasis) {
+				r.deps.Logger.Warn("persist close basis failed",
+					"agent_id", r.agent.ID, "underlying", o.Symbol, "err", err)
+			}
+		}
 	}
 
 	// Opens — pair non-reduce-only sell orders with USDC→token swaps in the
@@ -277,8 +313,8 @@ func (r *Runtime) reconcileOpenBasis(now time.Time, decisionID string, dec strat
 		if _, alreadyOpen := r.openBasis[key]; alreadyOpen {
 			continue
 		}
-		r.openBasis[key] = types.BasisPosition{
-			ID:         "rt:" + decisionID + ":" + key,
+		bp := types.BasisPosition{
+			ID:         "bp:" + r.agent.ID + ":" + key + ":" + decisionID[:8],
 			AgentID:    r.agent.ID,
 			Underlying: o.Symbol,
 			State:      types.BasisStateOpen,
@@ -287,6 +323,13 @@ func (r *Runtime) reconcileOpenBasis(now time.Time, decisionID string, dec strat
 				{Kind: types.BasisLegSpot, Asset: s.OutToken, Qty: s.InAmount},
 				{Kind: types.BasisLegPerp, Symbol: o.Symbol, Qty: o.Size, AvgPrice: o.Price},
 			},
+		}
+		r.openBasis[key] = bp
+		if r.deps.Store != nil {
+			if err := r.deps.Store.UpsertOpenBasis(ctx, bp); err != nil {
+				r.deps.Logger.Warn("persist open basis failed",
+					"agent_id", r.agent.ID, "underlying", o.Symbol, "err", err)
+			}
 		}
 	}
 }

--- a/internal/agent/runtime_test.go
+++ b/internal/agent/runtime_test.go
@@ -180,7 +180,7 @@ func TestReconcileOpenBasis_ClosesOnReduceOnly(t *testing.T) {
 			{Kind: types.BasisLegPerp, Symbol: "WIF", Qty: decimal.NewFromInt(100)},
 		},
 	}
-	r.reconcileOpenBasis(time.Now(), "dec1", strategy.Decision{
+	r.reconcileOpenBasis(context.Background(), time.Now(), "dec1", strategy.Decision{
 		Orders: []types.OrderIntent{{
 			Venue: "hyperliquid", Symbol: "WIF", Side: types.SideBuy,
 			ReduceOnly: true, Type: types.OrderTypeMarket, Size: decimal.NewFromInt(100),

--- a/internal/agent/store.go
+++ b/internal/agent/store.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/types"
 )
 
 // Store wraps DB access for agent lifecycle and the decision/order/swap
@@ -245,6 +247,103 @@ ON CONFLICT (provider, time, model) DO NOTHING;`
 		return fmt.Errorf("agent: persist inference call: %w", err)
 	}
 	return nil
+}
+
+// ─── strategy_positions persistence ─────────────────────────────────────────
+
+// UpsertOpenBasis records or refreshes an OPEN basis position. Returns an
+// error if a different open position already exists for this underlying
+// (the unique partial index enforces at-most-one-open-per-underlying).
+func (s *Store) UpsertOpenBasis(ctx context.Context, p types.BasisPosition) error {
+	legs, err := json.Marshal(p.Legs)
+	if err != nil {
+		return fmt.Errorf("agent: marshal legs: %w", err)
+	}
+	const q = `
+INSERT INTO strategy_positions
+    (id, agent_id, underlying, state, legs, opened_at, realized_funding, realized_basis_pnl, realized_fees, realized_gas)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+ON CONFLICT (id) DO UPDATE
+SET state              = EXCLUDED.state,
+    legs               = EXCLUDED.legs,
+    realized_funding   = EXCLUDED.realized_funding,
+    realized_basis_pnl = EXCLUDED.realized_basis_pnl,
+    realized_fees      = EXCLUDED.realized_fees,
+    realized_gas       = EXCLUDED.realized_gas,
+    updated_at         = now();
+`
+	state := string(p.State)
+	if state == "" {
+		state = string(types.BasisStateOpen)
+	}
+	openedAt := p.OpenedAt
+	if openedAt.IsZero() {
+		openedAt = time.Now().UTC()
+	}
+	if _, err := s.pool.Exec(ctx, q,
+		p.ID, p.AgentID, p.Underlying, state, legs, openedAt,
+		p.RealizedFunding, p.RealizedBasisPnL, p.RealizedFees, p.RealizedGas,
+	); err != nil {
+		return fmt.Errorf("agent: upsert basis: %w", err)
+	}
+	return nil
+}
+
+// CloseBasis marks the OPEN basis for (agentID, underlying) as 'closed'
+// and stamps closed_at. Returns ErrNoOpenBasis if no matching row exists.
+func (s *Store) CloseBasis(ctx context.Context, agentID, underlying string) error {
+	res, err := s.pool.Exec(ctx, `
+UPDATE strategy_positions
+SET state = 'closed', closed_at = now(), updated_at = now()
+WHERE agent_id = $1 AND underlying = $2 AND state IN ('open', 'opening', 'closing')`,
+		agentID, underlying)
+	if err != nil {
+		return fmt.Errorf("agent: close basis: %w", err)
+	}
+	if res.RowsAffected() == 0 {
+		return ErrNoOpenBasis
+	}
+	return nil
+}
+
+// ErrNoOpenBasis is returned by CloseBasis when no open row exists for the
+// supplied agent + underlying. Callers may treat this as a no-op.
+var ErrNoOpenBasis = errors.New("agent: no open basis to close")
+
+// LoadOpenBasis returns all currently-open BasisPositions for the agent.
+// Used by the runtime to hydrate its in-memory view on startup.
+func (s *Store) LoadOpenBasis(ctx context.Context, agentID string) ([]types.BasisPosition, error) {
+	rows, err := s.pool.Query(ctx, `
+SELECT id, agent_id, underlying, state, legs, opened_at, closed_at,
+       realized_funding, realized_basis_pnl, realized_fees, realized_gas
+FROM strategy_positions
+WHERE agent_id = $1 AND state IN ('open', 'opening', 'closing')
+ORDER BY opened_at`, agentID)
+	if err != nil {
+		return nil, fmt.Errorf("agent: load open basis: %w", err)
+	}
+	defer rows.Close()
+	out := make([]types.BasisPosition, 0)
+	for rows.Next() {
+		var (
+			p        types.BasisPosition
+			legsJSON []byte
+			closedAt *time.Time
+		)
+		if err := rows.Scan(
+			&p.ID, &p.AgentID, &p.Underlying, (*string)(&p.State), &legsJSON,
+			&p.OpenedAt, &closedAt,
+			&p.RealizedFunding, &p.RealizedBasisPnL, &p.RealizedFees, &p.RealizedGas,
+		); err != nil {
+			return nil, err
+		}
+		if len(legsJSON) > 0 {
+			_ = json.Unmarshal(legsJSON, &p.Legs)
+		}
+		p.ClosedAt = closedAt
+		out = append(out, p)
+	}
+	return out, rows.Err()
 }
 
 // RecentDecisions returns the most recent decisions for an agent, oldest first.

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -17,12 +17,8 @@ import (
 	"github.com/teslashibe/permafrost/internal/agent"
 	"github.com/teslashibe/permafrost/internal/assets"
 	"github.com/teslashibe/permafrost/internal/exchange"
-	"github.com/teslashibe/permafrost/internal/exchange/hyperliquid"
 	exchangenoop "github.com/teslashibe/permafrost/internal/exchange/noop"
-	"github.com/teslashibe/permafrost/internal/inference"
 	"github.com/teslashibe/permafrost/internal/store"
-	"github.com/teslashibe/permafrost/internal/strategy"
-	fab "github.com/teslashibe/permafrost/internal/strategy/funding_arb_basic"
 	"github.com/teslashibe/permafrost/internal/types"
 )
 
@@ -331,28 +327,18 @@ Stops on SIGINT/SIGTERM or after --ticks N (whichever comes first).`,
 				return fmt.Errorf("agent %q is mode=%q; `agent run` is paper-mode only in v1", a.ID, a.Mode)
 			}
 
-			// Build venue. If Hyperliquid signer is in the keystore, use its
-			// address (allows positions/balances calls to also work). Otherwise
-			// allow funding-only mode by leaving Address empty.
-			perp, err := buildHLVenue(c, network, hlAddress)
-			if err != nil {
-				return err
-			}
-
 			reg, err := assets.LoadEmbedded()
 			if err != nil {
 				return err
 			}
-			strat, err := buildStrategyForAgent(a, reg)
+			// Keystore is best-effort here; funding rates work without one.
+			ks, _ := openKeystore(c)
+			deps, err := agent.BuildDeps(a, reg, st, ks, g.Log, agent.BuildOptions{
+				HyperliquidNetwork: network,
+				HyperliquidAddress: hlAddress,
+			})
 			if err != nil {
 				return err
-			}
-
-			deps := agent.Deps{
-				Strategy: strat,
-				Perp:     perp,
-				Store:    st,
-				Logger:   g.Log,
 			}
 			if dryRun {
 				deps.Store = nil
@@ -374,18 +360,10 @@ Stops on SIGINT/SIGTERM or after --ticks N (whichever comes first).`,
 			defer ticker.Stop()
 
 			doTick := func() error {
-				dec, err := rt.TickOnce(ctx)
-				if err != nil {
+				if _, err := rt.TickOnce(ctx); err != nil {
 					g.Log.Error("tick failed", "err", err)
 					return nil // don't bail the loop on transient errors
 				}
-				g.Log.Info("tick",
-					"swaps", len(dec.Swaps),
-					"orders", len(dec.Orders),
-					"cancels", len(dec.Cancels),
-					"confidence", dec.Confidence,
-					"notes", dec.Notes,
-				)
 				ticks++
 				return nil
 			}
@@ -417,26 +395,6 @@ Stops on SIGINT/SIGTERM or after --ticks N (whichever comes first).`,
 	return cmd
 }
 
-// buildHLVenue assembles a real Hyperliquid Venue. If --address is given it
-// wins; else we try the keystore's Hyperliquid signer; else we run in
-// funding-only mode (no per-account reads).
-func buildHLVenue(c *cobra.Command, network, addrOverride string) (exchange.Venue, error) {
-	addr := addrOverride
-	if addr == "" {
-		// Try the keystore (if unlocked).
-		if ks, err := openKeystore(c); err == nil {
-			if s, err := ks.Signer(types.ChainHyperliquid); err == nil {
-				addr = s.Address()
-			}
-		}
-	}
-	cfg := hyperliquid.Config{
-		Network: hyperliquid.Network(network),
-		Address: addr,
-	}
-	return hyperliquid.New(cfg)
-}
-
 // newAgentTickCmd runs a single Decide tick for an agent and persists the
 // decision. Designed for paper-mode integration testing without waiting for
 // the background scheduler. Defaults to a no-op perp venue with synthetic
@@ -465,7 +423,7 @@ func newAgentTickCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			strat, err := buildStrategyForAgent(a, reg)
+			strat, err := agent.BuildStrategy(a, reg)
 			if err != nil {
 				return err
 			}
@@ -500,89 +458,9 @@ func newAgentTickCmd() *cobra.Command {
 	return cmd
 }
 
-// buildStrategyForAgent constructs a strategy.Strategy from an Agent record.
-// Currently only funding_arb_basic is supported via this CLI helper.
-//
-// For funding_arb_basic, the agent's Config map may contain optional
-// overrides:
-//   - entry_annualised_funding: float (e.g. 0.50 for 50% APR)
-//   - exit_annualised_funding:  float
-//   - position_cap_usdc:        number
-//   - slippage_bps:             int
-//   - use_llm_veto:             bool
-//   - veto_model:               string
-func buildStrategyForAgent(a agent.Agent, reg assets.Registry) (strategy.Strategy, error) {
-	switch a.Strategy {
-	case fab.Name:
-		cfg := fab.Config{Universe: a.Universe}
-		if v, ok := a.Config["entry_annualised_funding"]; ok {
-			if d, err := decimalFromAny(v); err == nil {
-				cfg.EntryAnnualisedFunding = d
-			}
-		}
-		if v, ok := a.Config["exit_annualised_funding"]; ok {
-			if d, err := decimalFromAny(v); err == nil {
-				cfg.ExitAnnualisedFunding = d
-			}
-		}
-		if v, ok := a.Config["position_cap_usdc"]; ok {
-			if d, err := decimalFromAny(v); err == nil {
-				cfg.PositionCapUSDC = d
-			}
-		}
-		if v, ok := a.Config["slippage_bps"]; ok {
-			if i, err := intFromAny(v); err == nil {
-				cfg.SlippageBps = i
-			}
-		}
-		if v, ok := a.Config["use_llm_veto"]; ok {
-			if b, ok := v.(bool); ok {
-				cfg.UseLLMVeto = b
-			}
-		}
-		if v, ok := a.Config["veto_model"]; ok {
-			if s, ok := v.(string); ok {
-				cfg.VetoModel = s
-			}
-		}
-		return fab.New(cfg, reg, inference.Provider(nil))
-	default:
-		ctor, err := strategy.Get(a.Strategy)
-		if err != nil {
-			return nil, err
-		}
-		return ctor(a.Config)
-	}
-}
-
-// decimalFromAny coerces JSON-decoded values (float64, int, string) into a
-// shopspring.Decimal.
-func decimalFromAny(v any) (decimal.Decimal, error) {
-	switch x := v.(type) {
-	case float64:
-		return decimal.NewFromFloat(x), nil
-	case int:
-		return decimal.NewFromInt(int64(x)), nil
-	case int64:
-		return decimal.NewFromInt(x), nil
-	case string:
-		return decimal.NewFromString(x)
-	}
-	return decimal.Zero, fmt.Errorf("unrecognised numeric type %T", v)
-}
-
-// intFromAny coerces JSON-decoded numerics to int.
-func intFromAny(v any) (int, error) {
-	switch x := v.(type) {
-	case float64:
-		return int(x), nil
-	case int:
-		return x, nil
-	case int64:
-		return int(x), nil
-	}
-	return 0, fmt.Errorf("unrecognised int type %T", v)
-}
+// (BuildStrategy + BuildHyperliquidVenue + helpers live in
+// internal/agent/builder.go so the daemon supervisor and the CLI share one
+// source of truth.)
 
 // tickFundingVenue is a synthetic Venue for `agent tick`. It returns no
 // positions / balances but does emit synthetic funding rates so the

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -3,19 +3,25 @@ package cli
 import (
 	"context"
 	"errors"
+	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"github.com/spf13/cobra"
 
+	"github.com/teslashibe/permafrost/internal/agent"
 	"github.com/teslashibe/permafrost/internal/api"
+	"github.com/teslashibe/permafrost/internal/assets"
 	"github.com/teslashibe/permafrost/internal/store"
+	"github.com/teslashibe/permafrost/internal/wallet"
 )
 
 // newServeCmd returns the `permafrost serve` subcommand which runs the
 // permafrostd daemon in the foreground.
 func newServeCmd() *cobra.Command {
-	return &cobra.Command{
+	var hlNetwork string
+	cmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Run the permafrostd daemon in the foreground",
 		RunE: func(c *cobra.Command, _ []string) error {
@@ -23,19 +29,31 @@ func newServeCmd() *cobra.Command {
 			if g == nil {
 				return errors.New("globals not initialised")
 			}
-			return Serve(c.Context(), g)
+			return Serve(c.Context(), g, ServeOptions{HyperliquidNetwork: hlNetwork})
 		},
 	}
+	cmd.Flags().StringVar(&hlNetwork, "hyperliquid-network", "testnet",
+		"hyperliquid network for supervised agents (mainnet | testnet)")
+	return cmd
 }
 
-// Serve runs the permafrostd HTTP server until the process receives
-// SIGINT/SIGTERM or the supplied context is cancelled. It is exported so
-// the dedicated permafrostd binary can call it directly.
-func Serve(ctx context.Context, g *Globals) error {
+// ServeOptions configures the daemon at runtime.
+type ServeOptions struct {
+	HyperliquidNetwork string
+}
+
+// Serve runs the permafrostd HTTP server, loads any agents that are
+// persisted with status='running', and supervises their tick loops until
+// the process receives SIGINT/SIGTERM or the supplied context is cancelled.
+//
+// It is exported so the dedicated permafrostd binary can call it directly.
+func Serve(ctx context.Context, g *Globals, opts ServeOptions) error {
 	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	g.Log.Info("permafrostd starting", "env", g.Config.Env, "bind", g.Config.Server.Bind)
+	g.Log.Info("permafrostd starting",
+		"env", g.Config.Env, "bind", g.Config.Server.Bind,
+		"hyperliquid_network", opts.HyperliquidNetwork)
 
 	var db *store.DB
 	if g.Config.Database.URL != "" {
@@ -48,6 +66,70 @@ func Serve(ctx context.Context, g *Globals) error {
 		}
 	}
 
+	// Supervisor: load any running agents and start their tick loops.
+	var sup *agent.Supervisor
+	if db != nil {
+		sup = agent.NewSupervisor(g.Log)
+		ks := openKeystoreForServe(g) // best-effort; nil is OK
+		reg, err := assets.LoadEmbedded()
+		if err != nil {
+			g.Log.Warn("supervisor: load registry failed; agents will not start", "err", err)
+		} else {
+			loader := &agent.Loader{
+				Store:      agent.NewStore(db.Pool),
+				Registry:   reg,
+				Keystore:   ks,
+				Logger:     g.Log,
+				BuildOpts:  agent.BuildOptions{HyperliquidNetwork: opts.HyperliquidNetwork},
+				Supervisor: sup,
+			}
+			n, err := loader.LoadAndStartRunning(ctx)
+			if err != nil {
+				g.Log.Warn("supervisor: load failed", "err", err)
+			} else {
+				g.Log.Info("supervisor: agents started", "count", n)
+			}
+		}
+	}
+
 	srv := api.NewServer(g.Config, g.Log, db)
-	return srv.Listen(ctx)
+	err := srv.Listen(ctx)
+
+	// Graceful supervisor shutdown.
+	if sup != nil {
+		shutdownCtx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		for _, id := range sup.IDs() {
+			_ = sup.Stop(shutdownCtx, id, "daemon shutdown")
+		}
+	}
+	return err
+}
+
+// openKeystoreForServe loads the keystore from disk if both a path and the
+// configured passphrase env var are populated. Returns nil silently
+// otherwise — the daemon can still start in funding-only mode.
+func openKeystoreForServe(g *Globals) wallet.Keystore {
+	path := g.Config.Wallet.KeystorePath
+	if path == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil
+		}
+		path = filepath.Join(home, ".permafrost", "keystore.json")
+	}
+	envName := g.Config.Wallet.PassphraseEnv
+	if envName == "" {
+		envName = "PERMAFROST_KEYSTORE_PASSPHRASE"
+	}
+	pass := os.Getenv(envName)
+	if pass == "" {
+		return nil
+	}
+	ks, err := wallet.NewLocalKeystore(path, pass)
+	if err != nil {
+		g.Log.Warn("supervisor: keystore unavailable; running funding-only", "err", err)
+		return nil
+	}
+	return ks
 }

--- a/internal/exchange/hyperliquid/probe_test.go
+++ b/internal/exchange/hyperliquid/probe_test.go
@@ -60,19 +60,23 @@ func TestLive_FundingRates_Mainnet_TopAnnualised(t *testing.T) {
 // TestLive_FundingRates_Universe prints the funding for our registry
 // universe so we know what the strategy would actually see.
 func TestLive_FundingRates_Universe(t *testing.T) {
-	v, err := New(Config{Network: NetworkMainnet})
-	if err != nil {
-		t.Fatal(err)
-	}
-	universe := []string{"WIF", "BONK", "POPCAT", "PNUT", "GOAT", "FARTCOIN", "MOODENG", "CHILLGUY"}
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	rates, err := v.FundingRates(ctx, universe)
-	if err != nil {
-		t.Fatalf("FundingRates: %v", err)
-	}
-	t.Logf("funding for permafrost universe (mainnet, %d hits):", len(rates))
-	for _, r := range rates {
-		t.Logf("  %-10s rate/h=%-15s ann=%s", r.Symbol, r.Rate, r.Annualised())
+	for _, n := range []Network{NetworkMainnet, NetworkTestnet} {
+		t.Run(string(n), func(t *testing.T) {
+			v, err := New(Config{Network: n})
+			if err != nil {
+				t.Fatal(err)
+			}
+			universe := []string{"WIF", "BONK", "POPCAT", "PNUT", "GOAT", "FARTCOIN", "MOODENG", "CHILLGUY"}
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			rates, err := v.FundingRates(ctx, universe)
+			if err != nil {
+				t.Fatalf("FundingRates: %v", err)
+			}
+			t.Logf("funding for permafrost universe (%s, %d hits):", n, len(rates))
+			for _, r := range rates {
+				t.Logf("  %-10s rate/h=%-15s ann=%s", r.Symbol, r.Rate, r.Annualised())
+			}
+		})
 	}
 }

--- a/internal/store/migrations/0005_strategy_positions.sql
+++ b/internal/store/migrations/0005_strategy_positions.sql
@@ -1,0 +1,38 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Strategy-level paired positions (e.g. funding-arb basis).
+-- One row per opened basis; state transitions to 'closed' on unwind.
+-- Per-leg detail (orders, fills, swaps) lives in those tables and joins
+-- back via decision_id. Realised fees / funding / basis-pnl roll up here.
+CREATE TABLE IF NOT EXISTS strategy_positions (
+    id                  text PRIMARY KEY,
+    agent_id            text NOT NULL REFERENCES agents(id),
+    underlying          text NOT NULL,
+    state               text NOT NULL DEFAULT 'open',  -- open | closing | closed | broken
+    legs                jsonb NOT NULL,
+    opened_at           timestamptz NOT NULL,
+    closed_at           timestamptz,
+    realized_funding    numeric(38,9) NOT NULL DEFAULT 0,
+    realized_basis_pnl  numeric(38,9) NOT NULL DEFAULT 0,
+    realized_fees       numeric(38,9) NOT NULL DEFAULT 0,
+    realized_gas        numeric(38,9) NOT NULL DEFAULT 0,
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now()
+);
+
+-- At most one OPEN position per (agent_id, underlying). Closed positions are
+-- not constrained — historical record stays intact.
+CREATE UNIQUE INDEX IF NOT EXISTS strategy_positions_one_open_per_underlying
+    ON strategy_positions (agent_id, underlying)
+    WHERE state IN ('open', 'opening', 'closing');
+
+CREATE INDEX IF NOT EXISTS strategy_positions_agent_state_idx
+    ON strategy_positions (agent_id, state);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS strategy_positions;
+-- +goose StatementEnd


### PR DESCRIPTION
## Why

Closes two of the three honest limitations from the previous round:

| Limitation | Status |
|---|---|
| 1. \`openBasis\` in-memory only — restart loses state | ✅ fixed |
| 2. Daemon doesn't load agents — \`serve\` is API-only | ✅ fixed |
| 3. Hyperliquid EIP-712 signing for live mode | ⏳ deferred — see bottom |

## What's in

### 1. Persisted basis positions
- **migration 0005** \`strategy_positions\` table with a unique partial index (one OPEN per \`(agent_id, underlying)\`).
- \`agent.Store\`: \`UpsertOpenBasis\` / \`CloseBasis\` / \`LoadOpenBasis\`.
- \`Runtime\` hydrates \`openBasis\` from DB on construction; \`reconcileOpenBasis\` persists every open and every close so the next \`NewRuntime\` sees the same set.

### 2. Daemon-supervised agents
- **\`agent.Loader.LoadAndStartRunning\`** — queries \`WHERE status='running'\` on daemon boot, builds Deps via the shared \`agent.BuildDeps\` helper, registers each Runtime with the Supervisor, starts the tick loop.
- \`cli.Serve\` wires this in. Adds \`--hyperliquid-network\` flag (defaults to **testnet** so a misconfigured production deployment can't trade mainnet by accident).
- \`cmd/permafrostd\` respects \`PERMAFROST_HYPERLIQUID_NETWORK\`.

### 3. Stop semantics fixed (real bug found during verification)
- \`Runtime.Stop\` no longer mutates persisted status. Previously a graceful daemon shutdown set \`status=stopped\`, breaking auto-resume on next boot. Now Stop only cancels the goroutine.
- \`Trip\` (kill switch) still explicitly sets \`status=halted\`.
- \`Loader\` explicitly sets \`status=running\` on successful start.

### 4. Per-tick log
- \`Runtime.tickOnce\` now emits one INFO line per tick: \`agent_id\`, \`decision_id\`, \`swaps\`, \`orders\`, \`cancels\`, \`open_basis\`. Operators can grep \`tick\` to confirm the daemon's loop is alive.

### 5. CLI / builder consolidation
- All strategy / venue construction lives in \`agent.BuildDeps\` so \`agent run\` and the supervisor share one wiring path.
- \`--config-json\` on \`agent create\` lets operators tune funding_arb_basic thresholds without a rebuild.

## End-to-end verified

\`\`\`
$ permafrost agent create --id pt --mode paper \\
    --strategy funding_arb_basic --universe WIF,POPCAT,GOAT \\
    --tick-secs 4 --config-json '{"entry_annualised_funding":0.05,"exit_annualised_funding":0.02,"position_cap_usdc":100}'
$ permafrost agent run pt --network mainnet --ticks 2
  tick swaps=3 orders=3 ... opening WIF, POPCAT, GOAT
$ # process exits — DB has 3 open positions

$ UPDATE agents SET status='running' WHERE id='pt';
$ docker restart permafrostd
  > "hydrated open basis count=3"
  > "loader: started agent"
  > "supervisor: agents started count=1"
  > "tick swaps=0 orders=0 open_basis=2"   ← POPCAT closed (testnet -34.6% APR < 2% exit)
  > "tick swaps=0 orders=0 open_basis=2"
  > ...
\`\`\`

DB after: \`{WIF: open, GOAT: open, POPCAT: closed}\`. The full chain — persistence → hydration → daemon ticks on schedule → strategy reads real venue → close intent → persisted close — all verified against live HL.

## Tests
- \`TestTickOnce_ReconcilesOpenBasis\` (carried over) — same Decision returned twice, second tick sees the open.
- \`TestReconcileOpenBasis_ClosesOnReduceOnly\` (carried over).
- New \`TestBuildStrategy_FundingArbAppliesConfigOverrides\`.
- New \`TestBuildHyperliquidVenue_AddressOverrideWins\` + \`TestBuildHyperliquidVenue_RejectsBadKeystoreAddress\` + defaults-to-testnet check.
- \`go test ./... -race\` clean across all packages.

## Limitation 3 — deferred, intentionally
Hyperliquid EIP-712 action signing for **live mode**. Implementation is non-trivial:
- MessagePack-encode the action in HL's exact field-order
- keccak256(\`msgpack ‖ vault_address ‖ nonce_uint64_be\`) → connection_id
- EIP-712 typed data (\`Agent { string source; bytes32 connectionId }\`)
- secp256k1 sign + V-byte adjustment
- POST \`{action, nonce, signature, vaultAddress}\` to \`/exchange\`

Without a funded HL testnet address I can't byte-compare against the official Python SDK for the same action, and a subtly-wrong implementation either silently rejects orders OR (worse) signs the wrong intent. Not shipping unverified.

**Ask:** if you supply a funded HL testnet address, I'll wire it up and verify the round-trip in a focused follow-up PR.

## Verify locally
\`\`\`
go test ./internal/agent/... -race -count=1 -v
docker compose -f deploy/compose/docker-compose.yml up -d
\`\`\`