### PR TITLE
feat: per-agent network (default paper-mainnet)

### DIFF
--- a/cmd/permafrostd/main.go
+++ b/cmd/permafrostd/main.go
@@ -28,17 +28,13 @@ func main() {
 		Log:    telemetry.NewLogger(cfg.Logging, cfg.Env),
 	}
 	opts := cli.ServeOptions{
-		HyperliquidNetwork: defaultStr(os.Getenv("PERMAFROST_HYPERLIQUID_NETWORK"), "testnet"),
+		// PERMAFROST_HYPERLIQUID_NETWORK acts as the global override; empty
+		// means "use each agent's stored network". Default left empty so
+		// the daemon respects per-agent network choices out of the box.
+		HyperliquidNetworkOverride: os.Getenv("PERMAFROST_HYPERLIQUID_NETWORK"),
 	}
 	if err := cli.Serve(context.Background(), g, opts); err != nil {
 		fmt.Fprintln(os.Stderr, "serve:", err)
 		os.Exit(1)
 	}
-}
-
-func defaultStr(v, fallback string) string {
-	if v == "" {
-		return fallback
-	}
-	return v
 }

--- a/internal/agent/builder.go
+++ b/internal/agent/builder.go
@@ -23,13 +23,14 @@ import (
 // supervisor inside `serve` use this so behaviour stays identical.
 //
 // Inputs:
-//   - a: the Agent record (from the DB).
+//   - a: the Agent record (from the DB). a.Network drives the HL network
+//     unless opts.HyperliquidNetwork overrides it.
 //   - reg: the asset registry (typically assets.LoadEmbedded()).
 //   - store: the agent Store (drives persistence and openBasis hydration).
 //   - keystore: optional; if set and a Hyperliquid signer is present, its
 //     address is wired into the HL Venue so per-account reads work.
 //   - log: scoped slog logger.
-//   - opts: BuildOptions (network, etc.).
+//   - opts: BuildOptions overrides (rarely needed by the daemon).
 //
 // Returns Deps with Strategy + Perp Venue + Store + Logger populated. SwapVenue
 // and Inference Provider are intentionally left nil for v1: paper-mode swaps
@@ -47,7 +48,16 @@ func BuildDeps(
 	if err != nil {
 		return Deps{}, fmt.Errorf("strategy: %w", err)
 	}
-	venue, err := BuildHyperliquidVenue(keystore, opts)
+	// Resolve network: explicit override wins, else fall back to what the
+	// agent itself records, else default to mainnet (paper-safe by design).
+	network := opts.HyperliquidNetwork
+	if network == "" {
+		network = string(a.Network.OrDefault(NetworkMainnet))
+	}
+	venue, err := BuildHyperliquidVenue(keystore, BuildOptions{
+		HyperliquidNetwork: network,
+		HyperliquidAddress: opts.HyperliquidAddress,
+	})
 	if err != nil {
 		return Deps{}, fmt.Errorf("hyperliquid venue: %w", err)
 	}
@@ -58,15 +68,21 @@ func BuildDeps(
 		Strategy: strat,
 		Perp:     venue,
 		Store:    store,
-		Logger:   log.With("agent_id", a.ID),
+		Logger:   log.With("agent_id", a.ID, "network", network, "mode", a.Mode),
 	}, nil
 }
 
-// BuildOptions captures runtime-wiring parameters that aren't stored on the
-// Agent record itself.
+// BuildOptions are caller-supplied OVERRIDES of fields the Agent already
+// carries on its DB record. An empty value means "use the agent's own
+// stored value". Both fields default to non-overriding empty strings.
+//
+// HyperliquidNetwork override is mostly useful as an emergency switch
+// ("force everything to testnet for safety") or for the foreground
+// `agent run` command's --network flag. The daemon supervisor leaves it
+// empty so each agent runs on its own configured network.
 type BuildOptions struct {
-	HyperliquidNetwork string // "mainnet" | "testnet" (default: testnet)
-	HyperliquidAddress string // optional override; else derived from keystore
+	HyperliquidNetwork string // empty → use Agent.Network
+	HyperliquidAddress string // empty → derive from keystore (or no address)
 }
 
 // BuildStrategy is the strategy-construction switch shared between the
@@ -91,6 +107,10 @@ func BuildStrategy(a Agent, reg assets.Registry) (strategy.Strategy, error) {
 // BuildHyperliquidVenue assembles a Hyperliquid Venue. Address resolution:
 // 1) opts.HyperliquidAddress if set, else 2) keystore's HL signer if any,
 // else 3) leave empty (funding-only mode).
+//
+// Network defaults to mainnet here as a low-level safety: callers (BuildDeps)
+// are expected to plumb the agent's stored network, but if invoked directly
+// without a network the safer choice is real-data paper.
 func BuildHyperliquidVenue(keystore wallet.Keystore, opts BuildOptions) (exchange.Venue, error) {
 	addr := opts.HyperliquidAddress
 	if addr == "" && keystore != nil {
@@ -100,7 +120,7 @@ func BuildHyperliquidVenue(keystore wallet.Keystore, opts BuildOptions) (exchang
 	}
 	network := opts.HyperliquidNetwork
 	if network == "" {
-		network = "testnet"
+		network = string(NetworkMainnet)
 	}
 	return hyperliquid.New(hyperliquid.Config{
 		Network: hyperliquid.Network(network),
@@ -171,6 +191,12 @@ func intFromAny(v any) (int, error) {
 
 // Loader is a small helper used by the supervisor inside `serve` to start
 // every running agent on daemon boot. It is safe to call multiple times.
+//
+// BuildOpts is an emergency-override hatch — leave it zero in normal
+// operation so each agent uses the network stored on its own record.
+// Setting BuildOpts.HyperliquidNetwork forces every supervised agent to
+// that network regardless of their stored value (useful for "panic
+// switch all agents to testnet" scenarios).
 type Loader struct {
 	Store      *Store
 	Registry   assets.Registry

--- a/internal/agent/builder_test.go
+++ b/internal/agent/builder_test.go
@@ -77,6 +77,71 @@ func TestBuildOptions_DefaultsToTestnet(t *testing.T) {
 	}
 }
 
+func TestNetwork_Validate(t *testing.T) {
+	for _, n := range []Network{NetworkMainnet, NetworkTestnet, ""} {
+		if err := n.Validate(); err != nil {
+			t.Errorf("Validate(%q): unexpected error %v", n, err)
+		}
+	}
+	if err := Network("rinkeby").Validate(); err == nil {
+		t.Error("expected error for unknown network")
+	}
+}
+
+func TestNetwork_OrDefault(t *testing.T) {
+	if got := Network("").OrDefault(NetworkMainnet); got != NetworkMainnet {
+		t.Errorf("OrDefault: empty should fall back, got %q", got)
+	}
+	if got := NetworkTestnet.OrDefault(NetworkMainnet); got != NetworkTestnet {
+		t.Errorf("OrDefault: non-empty should pass through, got %q", got)
+	}
+}
+
+// TestBuildDeps_PerAgentNetworkPlumbed ensures that BuildDeps uses
+// agent.Network when no override is supplied. We can't easily check the
+// venue's resolved endpoint without poking internals, but we CAN check
+// that an agent with Network=testnet doesn't error and that the override
+// path explicitly wins.
+func TestBuildDeps_PerAgentNetworkPlumbed(t *testing.T) {
+	reg, err := assets.LoadEmbedded()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name           string
+		stored         Network
+		override       string
+		expectError    bool
+	}{
+		{"stored=mainnet, no override", NetworkMainnet, "", false},
+		{"stored=testnet, no override", NetworkTestnet, "", false},
+		{"empty stored, no override", "", "", false},
+		{"override=testnet wins", NetworkMainnet, "testnet", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := Agent{
+				ID:       "ag",
+				Strategy: "funding_arb_basic",
+				Network:  tc.stored,
+				Universe: []string{"WIF"},
+			}
+			deps, err := BuildDeps(a, reg, nil, nil, nil, BuildOptions{
+				HyperliquidNetwork: tc.override,
+			})
+			if tc.expectError && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tc.expectError && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !tc.expectError && deps.Perp == nil {
+				t.Fatal("Perp venue should be set")
+			}
+		})
+	}
+}
+
 func TestApplyFundingArbConfig_NumericTypes(t *testing.T) {
 	cases := []map[string]any{
 		{"entry_annualised_funding": 0.5},          // float64 (JSON default)

--- a/internal/agent/store.go
+++ b/internal/agent/store.go
@@ -37,13 +37,20 @@ func (s *Store) Create(ctx context.Context, a Agent) (Agent, error) {
 	if a.Status == "" {
 		a.Status = StatusStopped
 	}
+	if a.Network == "" {
+		a.Network = NetworkMainnet
+	}
+	if err := a.Network.Validate(); err != nil {
+		return Agent{}, err
+	}
 	cfgBytes, _ := json.Marshal(orZero(a.Config))
 	const q = `
-INSERT INTO agents (id, name, strategy, mode, perp_venue, spot_venue, inference, universe, allocation_usdc, tick_secs, status, config)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+INSERT INTO agents (id, name, strategy, mode, network, perp_venue, spot_venue, inference, universe, allocation_usdc, tick_secs, status, config)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
 RETURNING created_at, updated_at;`
 	if err := s.pool.QueryRow(ctx, q,
-		a.ID, a.Name, a.Strategy, string(a.Mode), a.PerpVenue, a.SpotVenue, a.Inference,
+		a.ID, a.Name, a.Strategy, string(a.Mode), string(a.Network),
+		a.PerpVenue, a.SpotVenue, a.Inference,
 		a.Universe, a.AllocationUSDC, a.TickSecs, string(a.Status), cfgBytes,
 	).Scan(&a.CreatedAt, &a.UpdatedAt); err != nil {
 		return Agent{}, fmt.Errorf("agent: create: %w", err)
@@ -53,15 +60,16 @@ RETURNING created_at, updated_at;`
 
 // Get returns an agent by id.
 func (s *Store) Get(ctx context.Context, id string) (Agent, error) {
-	const q = `SELECT id, name, strategy, mode, perp_venue, spot_venue, inference, universe, allocation_usdc, tick_secs, status, config, created_at, updated_at
+	const q = `SELECT id, name, strategy, mode, network, perp_venue, spot_venue, inference, universe, allocation_usdc, tick_secs, status, config, created_at, updated_at
 FROM agents WHERE id = $1`
 	var (
 		a   Agent
 		cfg []byte
 	)
 	if err := s.pool.QueryRow(ctx, q, id).Scan(
-		&a.ID, &a.Name, &a.Strategy, (*string)(&a.Mode), &a.PerpVenue, &a.SpotVenue,
-		&a.Inference, &a.Universe, &a.AllocationUSDC, &a.TickSecs, (*string)(&a.Status),
+		&a.ID, &a.Name, &a.Strategy, (*string)(&a.Mode), (*string)(&a.Network),
+		&a.PerpVenue, &a.SpotVenue, &a.Inference, &a.Universe,
+		&a.AllocationUSDC, &a.TickSecs, (*string)(&a.Status),
 		&cfg, &a.CreatedAt, &a.UpdatedAt,
 	); err != nil {
 		return Agent{}, fmt.Errorf("agent: get: %w", err)
@@ -74,7 +82,7 @@ FROM agents WHERE id = $1`
 
 // List returns all agents (newest first).
 func (s *Store) List(ctx context.Context) ([]Agent, error) {
-	rows, err := s.pool.Query(ctx, `SELECT id, name, strategy, mode, status, allocation_usdc, created_at FROM agents ORDER BY created_at DESC`)
+	rows, err := s.pool.Query(ctx, `SELECT id, name, strategy, mode, network, status, allocation_usdc, created_at FROM agents ORDER BY created_at DESC`)
 	if err != nil {
 		return nil, err
 	}
@@ -82,12 +90,32 @@ func (s *Store) List(ctx context.Context) ([]Agent, error) {
 	out := make([]Agent, 0)
 	for rows.Next() {
 		var a Agent
-		if err := rows.Scan(&a.ID, &a.Name, &a.Strategy, (*string)(&a.Mode), (*string)(&a.Status), &a.AllocationUSDC, &a.CreatedAt); err != nil {
+		if err := rows.Scan(&a.ID, &a.Name, &a.Strategy, (*string)(&a.Mode), (*string)(&a.Network), (*string)(&a.Status), &a.AllocationUSDC, &a.CreatedAt); err != nil {
 			return nil, err
 		}
 		out = append(out, a)
 	}
 	return out, rows.Err()
+}
+
+// SetNetwork updates an agent's persisted network.
+func (s *Store) SetNetwork(ctx context.Context, id string, network Network) error {
+	if err := network.Validate(); err != nil {
+		return err
+	}
+	if network == "" {
+		return errors.New("agent: network required")
+	}
+	res, err := s.pool.Exec(ctx,
+		`UPDATE agents SET network = $1, updated_at = now() WHERE id = $2`,
+		string(network), id)
+	if err != nil {
+		return fmt.Errorf("agent: set network: %w", err)
+	}
+	if res.RowsAffected() == 0 {
+		return fmt.Errorf("agent %q not found", id)
+	}
+	return nil
 }
 
 // SetStatus updates an agent's persisted lifecycle status.

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -3,6 +3,7 @@
 package agent
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -15,6 +16,35 @@ const (
 	ModePaper Mode = "paper" // record decisions; no venue calls
 	ModeLive  Mode = "live"  // submit to venues
 )
+
+// Network selects which Hyperliquid environment the agent reads/writes
+// against. Per-agent so a single deployment can run e.g. a paper-mainnet
+// research agent next to a live-testnet agent under development. v1 only
+// supports mainnet | testnet.
+type Network string
+
+const (
+	NetworkMainnet Network = "mainnet"
+	NetworkTestnet Network = "testnet"
+)
+
+// Validate returns an error if n is not one of the recognised networks.
+func (n Network) Validate() error {
+	switch n {
+	case NetworkMainnet, NetworkTestnet, "":
+		return nil
+	}
+	return fmt.Errorf("agent: invalid network %q (want mainnet or testnet)", n)
+}
+
+// OrDefault returns n if non-empty, else the supplied fallback. Used by
+// the Loader and CLI when an agent record predates the network column.
+func (n Network) OrDefault(fallback Network) Network {
+	if n == "" {
+		return fallback
+	}
+	return n
+}
 
 // Status is the persisted lifecycle state.
 type Status string
@@ -31,6 +61,7 @@ type Agent struct {
 	Name           string
 	Strategy       string
 	Mode           Mode
+	Network        Network // hyperliquid environment (mainnet|testnet)
 	PerpVenue      string
 	SpotVenue      string
 	Inference      string // "provider:model"

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -35,11 +35,51 @@ func newAgentCmd() *cobra.Command {
 		newAgentStatusCmd(),
 		newAgentDecisionsCmd(),
 		newAgentSetModeCmd(),
+		newAgentSetNetworkCmd(),
 		newAgentStopCmd(),
 		newAgentTickCmd(),
 		newAgentRunCmd(),
 	)
 	return cmd
+}
+
+func newAgentSetNetworkCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set-network <id> <mainnet|testnet>",
+		Short: "Switch an agent between mainnet and testnet (Hyperliquid).",
+		Long: `Switches an agent's data source. Paper-mode agents are safe to
+run against mainnet — no orders are submitted. Live-mode agents (when
+signing lands) MUST be re-confirmed before flipping to mainnet because
+real money is at stake.
+
+The daemon picks up the change on next tick — no restart needed for
+read-only effects, but if the agent is currently running you may want
+to stop+start it so the venue client reconnects with the new endpoint.`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(c *cobra.Command, args []string) error {
+			st, db, err := openAgentStore(c)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			network := agent.Network(args[1])
+			if network != agent.NetworkMainnet && network != agent.NetworkTestnet {
+				return fmt.Errorf("network must be mainnet or testnet")
+			}
+			a, err := st.Get(c.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			if a.Mode == agent.ModeLive && network == agent.NetworkMainnet {
+				fmt.Printf("WARNING: agent %q is live-mode. Switching to mainnet means real money on the next tick.\n", a.ID)
+			}
+			if err := st.SetNetwork(c.Context(), a.ID, network); err != nil {
+				return err
+			}
+			fmt.Printf("agent %s network -> %s\n", a.ID, network)
+			return nil
+		},
+	}
 }
 
 func newAgentStopCmd() *cobra.Command {
@@ -105,15 +145,21 @@ func openAgentStore(c *cobra.Command) (*agent.Store, *store.DB, error) {
 
 func newAgentCreateCmd() *cobra.Command {
 	var (
-		id, name, strategy, perp, spot, inferenceRef, modeStr string
-		universeCSV                                            string
-		alloc                                                  string
-		tickSecs                                               int
-		configJSON                                             string
+		id, name, strategy, perp, spot, inferenceRef, modeStr, networkStr string
+		universeCSV                                                       string
+		alloc                                                             string
+		tickSecs                                                          int
+		configJSON                                                        string
 	)
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a strategy agent (paper mode by default)",
+		Short: "Create a strategy agent (paper mode + mainnet data by default)",
+		Long: `Create a new agent.
+
+Paper mode is the default and is safe — no orders are submitted. It pairs
+naturally with mainnet data so the strategy makes decisions against real
+funding rates. Use --network testnet if you specifically want sparse
+testnet data (e.g. while developing a live-mode signing flow).`,
 		RunE: func(c *cobra.Command, _ []string) error {
 			s, db, err := openAgentStore(c)
 			if err != nil {
@@ -142,6 +188,7 @@ func newAgentCreateCmd() *cobra.Command {
 				Name:           name,
 				Strategy:       strategy,
 				Mode:           agent.Mode(modeStr),
+				Network:        agent.Network(networkStr),
 				PerpVenue:      perp,
 				SpotVenue:      spot,
 				Inference:      inferenceRef,
@@ -154,8 +201,8 @@ func newAgentCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Printf("created agent id=%s name=%s strategy=%s mode=%s alloc=%s\n",
-				out.ID, out.Name, out.Strategy, out.Mode, out.AllocationUSDC)
+			fmt.Printf("created agent id=%s name=%s strategy=%s mode=%s network=%s alloc=%s\n",
+				out.ID, out.Name, out.Strategy, out.Mode, out.Network, out.AllocationUSDC)
 			return nil
 		},
 	}
@@ -166,6 +213,8 @@ func newAgentCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&spot, "spot", "jupiter", "spot venue")
 	cmd.Flags().StringVar(&inferenceRef, "inference", "", "inference provider:model (e.g. openrouter:anthropic/claude-sonnet-4.5)")
 	cmd.Flags().StringVar(&modeStr, "mode", string(agent.ModePaper), "paper | live")
+	cmd.Flags().StringVar(&networkStr, "network", string(agent.NetworkMainnet),
+		"hyperliquid network: mainnet (real funding data) | testnet (sparse / synthetic)")
 	cmd.Flags().StringVar(&universeCSV, "universe", "", "comma-separated symbols (e.g. WIF,BONK,POPCAT)")
 	cmd.Flags().StringVar(&alloc, "alloc", "", "allocation in USDC")
 	cmd.Flags().IntVar(&tickSecs, "tick-secs", 60, "tick interval seconds")
@@ -189,8 +238,8 @@ func newAgentListCmd() *cobra.Command {
 				return err
 			}
 			for _, a := range rows {
-				fmt.Printf("%-12s  %-20s  %-20s  %-7s  %-7s  alloc=%s  created=%s\n",
-					a.ID, a.Name, a.Strategy, a.Mode, a.Status, a.AllocationUSDC, a.CreatedAt.Format(time.RFC3339))
+				fmt.Printf("%-12s  %-20s  %-20s  %-7s  %-7s  %-7s  alloc=%s  created=%s\n",
+					a.ID, a.Name, a.Strategy, a.Mode, a.Network, a.Status, a.AllocationUSDC, a.CreatedAt.Format(time.RFC3339))
 			}
 			return nil
 		},
@@ -212,8 +261,8 @@ func newAgentStatusCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Printf("id:         %s\nname:       %s\nstrategy:   %s\nmode:       %s\nstatus:     %s\nperp:       %s\nspot:       %s\ninference:  %s\nuniverse:   %s\nalloc:      %s\ntick_secs:  %d\ncreated:    %s\n",
-				a.ID, a.Name, a.Strategy, a.Mode, a.Status, a.PerpVenue, a.SpotVenue,
+			fmt.Printf("id:         %s\nname:       %s\nstrategy:   %s\nmode:       %s\nnetwork:    %s\nstatus:     %s\nperp:       %s\nspot:       %s\ninference:  %s\nuniverse:   %s\nalloc:      %s\ntick_secs:  %d\ncreated:    %s\n",
+				a.ID, a.Name, a.Strategy, a.Mode, a.Network, a.Status, a.PerpVenue, a.SpotVenue,
 				a.Inference, strings.Join(a.Universe, ","), a.AllocationUSDC, a.TickSecs, a.CreatedAt.Format(time.RFC3339))
 			return nil
 		},
@@ -292,10 +341,10 @@ func newAgentSetModeCmd() *cobra.Command {
 // configured. The supervisor-driven multi-agent runner is a v1.1 concern.
 func newAgentRunCmd() *cobra.Command {
 	var (
-		network    string
-		hlAddress  string
-		maxTicks   int
-		dryRun     bool
+		networkOverride string
+		hlAddress       string
+		maxTicks        int
+		dryRun          bool
 	)
 	cmd := &cobra.Command{
 		Use:   "run <id>",
@@ -304,8 +353,9 @@ func newAgentRunCmd() *cobra.Command {
 Hyperliquid public funding-rate API. Decisions and (paper) orders/swaps are
 persisted to the database.
 
-This is the proper end-to-end paper-mode flow — equivalent to what a
-multi-agent daemon will do once supervisor-driven agent loading lands.
+By default the agent runs on its stored network (--network on agent
+create, or 'mainnet' if unspecified). Pass --network here to override
+just for this run — useful for ad-hoc testnet smoke tests.
 
 Stops on SIGINT/SIGTERM or after --ticks N (whichever comes first).`,
 		Args: cobra.ExactArgs(1),
@@ -333,8 +383,10 @@ Stops on SIGINT/SIGTERM or after --ticks N (whichever comes first).`,
 			}
 			// Keystore is best-effort here; funding rates work without one.
 			ks, _ := openKeystore(c)
+			// Empty networkOverride lets the builder fall back to a.Network
+			// (which is the operator's stored choice, default mainnet).
 			deps, err := agent.BuildDeps(a, reg, st, ks, g.Log, agent.BuildOptions{
-				HyperliquidNetwork: network,
+				HyperliquidNetwork: networkOverride,
 				HyperliquidAddress: hlAddress,
 			})
 			if err != nil {
@@ -349,10 +401,14 @@ Stops on SIGINT/SIGTERM or after --ticks N (whichever comes first).`,
 			ctx, stop := signal.NotifyContext(c.Context(), syscall.SIGINT, syscall.SIGTERM)
 			defer stop()
 
+			effectiveNet := networkOverride
+			if effectiveNet == "" {
+				effectiveNet = string(a.Network.OrDefault(agent.NetworkMainnet))
+			}
 			g.Log.Info("agent run starting",
 				"agent_id", a.ID, "strategy", a.Strategy, "mode", a.Mode,
 				"tick_secs", a.TickSecs, "universe", a.Universe,
-				"hyperliquid_network", network)
+				"hyperliquid_network", effectiveNet)
 
 			ticks := 0
 			tickInterval := a.Interval()
@@ -388,7 +444,8 @@ Stops on SIGINT/SIGTERM or after --ticks N (whichever comes first).`,
 			}
 		},
 	}
-	cmd.Flags().StringVar(&network, "network", "testnet", "hyperliquid network: mainnet | testnet")
+	cmd.Flags().StringVar(&networkOverride, "network", "",
+		"override the agent's stored network for this run (mainnet | testnet); empty = use agent record")
 	cmd.Flags().StringVar(&hlAddress, "address", "", "hyperliquid address override (default: derived from keystore)")
 	cmd.Flags().IntVar(&maxTicks, "ticks", 0, "stop after N ticks (0 = run until SIGINT)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "do not persist decisions/orders/swaps")

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -29,17 +29,22 @@ func newServeCmd() *cobra.Command {
 			if g == nil {
 				return errors.New("globals not initialised")
 			}
-			return Serve(c.Context(), g, ServeOptions{HyperliquidNetwork: hlNetwork})
+			return Serve(c.Context(), g, ServeOptions{HyperliquidNetworkOverride: hlNetwork})
 		},
 	}
-	cmd.Flags().StringVar(&hlNetwork, "hyperliquid-network", "testnet",
-		"hyperliquid network for supervised agents (mainnet | testnet)")
+	cmd.Flags().StringVar(&hlNetwork, "hyperliquid-network", "",
+		"force ALL supervised agents onto this network (emergency override; empty = use each agent's stored network)")
 	return cmd
 }
 
 // ServeOptions configures the daemon at runtime.
 type ServeOptions struct {
-	HyperliquidNetwork string
+	// HyperliquidNetworkOverride, if non-empty, forces every supervised
+	// agent onto this network regardless of the network stored on its
+	// own DB record. Useful as an emergency switch ("force everything to
+	// testnet"). Leave empty in normal operation so each agent runs on
+	// its own configured network.
+	HyperliquidNetworkOverride string
 }
 
 // Serve runs the permafrostd HTTP server, loads any agents that are
@@ -51,9 +56,11 @@ func Serve(ctx context.Context, g *Globals, opts ServeOptions) error {
 	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	g.Log.Info("permafrostd starting",
-		"env", g.Config.Env, "bind", g.Config.Server.Bind,
-		"hyperliquid_network", opts.HyperliquidNetwork)
+	startFields := []any{"env", g.Config.Env, "bind", g.Config.Server.Bind}
+	if opts.HyperliquidNetworkOverride != "" {
+		startFields = append(startFields, "hyperliquid_network_override", opts.HyperliquidNetworkOverride)
+	}
+	g.Log.Info("permafrostd starting", startFields...)
 
 	var db *store.DB
 	if g.Config.Database.URL != "" {
@@ -80,7 +87,7 @@ func Serve(ctx context.Context, g *Globals, opts ServeOptions) error {
 				Registry:   reg,
 				Keystore:   ks,
 				Logger:     g.Log,
-				BuildOpts:  agent.BuildOptions{HyperliquidNetwork: opts.HyperliquidNetwork},
+				BuildOpts:  agent.BuildOptions{HyperliquidNetwork: opts.HyperliquidNetworkOverride},
 				Supervisor: sup,
 			}
 			n, err := loader.LoadAndStartRunning(ctx)

--- a/internal/store/migrations/0006_agents_network.sql
+++ b/internal/store/migrations/0006_agents_network.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Per-agent Hyperliquid network (mainnet | testnet).
+-- Defaults to 'mainnet' so paper-mode agents see real funding rates by
+-- default — paper is safe because no real signing is wired yet, and real
+-- data is more useful than the sparse / synthetic testnet data.
+ALTER TABLE agents
+    ADD COLUMN IF NOT EXISTS network text NOT NULL DEFAULT 'mainnet';
+
+ALTER TABLE agents
+    DROP CONSTRAINT IF EXISTS agents_network_valid;
+ALTER TABLE agents
+    ADD CONSTRAINT agents_network_valid
+    CHECK (network IN ('mainnet', 'testnet'));
+
+CREATE INDEX IF NOT EXISTS agents_network_idx ON agents (network);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS agents_network_idx;
+ALTER TABLE agents DROP CONSTRAINT IF EXISTS agents_network_valid;
+ALTER TABLE agents DROP COLUMN IF EXISTS network;
+-- +goose StatementEnd


### PR DESCRIPTION
## Why

Paper mode is safe (no orders, no signing). Pairing it with mainnet data is more useful than testnet because:
- The strategy makes decisions against real funding rates.
- You can backtest your live thesis against actual market behaviour without risk.
- Testnet funding is sparse / synthetic and frequently doesn't reflect production.

Per-agent network also lets a single deployment run e.g. a paper-mainnet research agent next to a live-testnet agent under development — one daemon, mixed environments.

## Schema (migration 0006)
- \`agents.network text NOT NULL DEFAULT 'mainnet'\` with a CHECK pinning it to \`{mainnet, testnet}\`.
- Index on network for future "stop all mainnet agents" queries.

## CLI
\`\`\`
permafrost agent create --network mainnet              # default
permafrost agent create --network testnet              # opt-in
permafrost agent set-network <id> mainnet
permafrost agent list           # network column
permafrost agent status <id>    # network field

permafrost agent run <id>                # uses agent's stored network
permafrost agent run <id> --network ...  # one-shot override

permafrost serve                                       # honours per-agent
permafrost serve --hyperliquid-network testnet         # emergency override
PERMAFROST_HYPERLIQUID_NETWORK=testnet permafrostd     # env override
\`\`\`

\`agent set-network\` prints a WARNING when an agent in live mode is being switched to mainnet — real money risk surfaces when signing lands.

## Wiring
- \`agent.BuildDeps\` resolves network as: explicit \`BuildOptions\` override → \`agent.Network\` from DB → mainnet fallback. Each supervised agent gets its own Venue client pointed at its own endpoint.
- \`agent.BuildHyperliquidVenue\`'s last-resort default flipped from testnet to mainnet.
- \`agent.Loader\` picks each agent's stored network — no daemon-wide setting needed.
- \`ServeOptions.HyperliquidNetwork\` renamed to \`HyperliquidNetworkOverride\` for clarity.

## Tests
- \`Network.Validate\` / \`OrDefault\`.
- \`TestBuildDeps_PerAgentNetworkPlumbed\` covers: stored mainnet, stored testnet, empty falls back, explicit override wins.

## End-to-end verified
- Created \`paper-mainnet\` (default) and \`paper-testnet\` agents.
- Single daemon supervises both. Tick logs:
  \`\`\`
  tick agent_id=paper-mainnet network=mainnet ...
  tick agent_id=paper-testnet network=testnet ...
  \`\`\`
  Each agent hits the correct HL endpoint, with isolated \`strategy_positions\` rows.
- Override path: ran a sidecar daemon with \`PERMAFROST_HYPERLIQUID_NETWORK=testnet\`. Both agents (including the one stored as \`mainnet\`) ran on testnet:
  \`\`\`
  permafrostd starting hyperliquid_network_override=testnet
  tick agent_id=paper-mainnet network=testnet ...   # ← overridden
  tick agent_id=paper-testnet network=testnet ...
  \`\`\`

## Verify locally
\`\`\`
go test ./internal/agent/... -race -count=1
docker compose -f deploy/compose/docker-compose.yml up -d
permafrost agent create --strategy funding_arb_basic --universe WIF
permafrost agent status <id>   # network=mainnet
\`\`\`

## Next
With this in, the only remaining limitation is **Hyperliquid EIP-712 signing for live mode**. That's the next branch — needs a funded HL testnet address for byte-exact verification before shipping.