### PR TITLE
fix(strategy): size perp leg in base units via mark price

### DIFF
--- a/internal/backtest/csv.go
+++ b/internal/backtest/csv.go
@@ -13,10 +13,12 @@ import (
 
 // LoadCSV reads funding ticks from a CSV file with header columns:
 //
-//	time,symbol,rate,interval_seconds
+//	time,symbol,rate,interval_seconds[,mark_price]
 //
 // Time may be RFC3339 or epoch milliseconds. Rate is fractional
-// (0.0001 = 1bp/interval). Returns the parsed ticks in original order.
+// (0.0001 = 1bp/interval). mark_price is optional but recommended for
+// strategies that size positions in USDC; missing values fall back to the
+// MarketSnapshotAt sentinel ($1.00). Returns ticks in original order.
 func LoadCSV(path string) ([]FundingTick, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -50,6 +52,7 @@ func ReadCSV(r io.Reader) ([]FundingTick, error) {
 	if tIdx < 0 || sIdx < 0 || rIdx < 0 || iIdx < 0 {
 		return nil, fmt.Errorf("backtest: csv missing required columns time,symbol,rate,interval_seconds")
 	}
+	mIdx := idx("mark_price") // optional
 
 	out := make([]FundingTick, 0, len(rows)-1)
 	for ln, row := range rows[1:] {
@@ -68,12 +71,20 @@ func ReadCSV(r io.Reader) ([]FundingTick, error) {
 		if err != nil {
 			return nil, fmt.Errorf("backtest: csv row %d interval: %w", ln+2, err)
 		}
-		out = append(out, FundingTick{
+		tk := FundingTick{
 			Time:     t,
 			Symbol:   row[sIdx],
 			Rate:     rate,
 			Interval: time.Duration(intervalSecs) * time.Second,
-		})
+		}
+		if mIdx >= 0 && mIdx < len(row) && row[mIdx] != "" {
+			mark, err := decimal.NewFromString(row[mIdx])
+			if err != nil {
+				return nil, fmt.Errorf("backtest: csv row %d mark_price: %w", ln+2, err)
+			}
+			tk.MarkPrice = mark
+		}
+		out = append(out, tk)
 	}
 	return out, nil
 }

--- a/internal/backtest/types.go
+++ b/internal/backtest/types.go
@@ -17,11 +17,17 @@ import (
 )
 
 // FundingTick is one observation in the input series.
+//
+// MarkPrice is optional; if zero, MarketSnapshotAt fills in a sentinel
+// $1.00 mark so strategies that gate on mark price (e.g. funding_arb_basic
+// which sizes perp legs as cap_usdc / mark) keep working in synthetic
+// backtests. Real CSVs from venue history should include the mark.
 type FundingTick struct {
-	Time     time.Time
-	Symbol   string
-	Rate     decimal.Decimal // per-interval, fractional
-	Interval time.Duration   // typically 1h or 8h
+	Time      time.Time
+	Symbol    string
+	Rate      decimal.Decimal // per-interval, fractional
+	Interval  time.Duration   // typically 1h or 8h
+	MarkPrice decimal.Decimal // optional; defaults to 1.00 if zero
 }
 
 // Costs models the per-trade frictions applied during the simulation.
@@ -86,6 +92,7 @@ type NAVPoint struct {
 // time t (the most recent tick per symbol with Time <= t wins). Exposed for
 // test reuse.
 func MarketSnapshotAt(t time.Time, ticks []FundingTick) types.MarketSnapshot {
+	defaultMark := decimal.NewFromInt(1) // sentinel so strategies can size
 	snap := types.MarketSnapshot{Time: t, Symbols: map[string]types.SymbolSnap{}}
 	for _, tk := range ticks {
 		if tk.Time.After(t) {
@@ -95,9 +102,17 @@ func MarketSnapshotAt(t time.Time, ticks []FundingTick) types.MarketSnapshot {
 		if ok && tk.Time.Before(cur.Funding.Time) {
 			continue
 		}
+		mark := tk.MarkPrice
+		if mark.IsZero() {
+			mark = defaultMark
+		}
 		snap.Symbols[tk.Symbol] = types.SymbolSnap{
 			Funding: types.FundingRate{
-				Time: tk.Time, Symbol: tk.Symbol, Rate: tk.Rate, Interval: tk.Interval,
+				Time:      tk.Time,
+				Symbol:    tk.Symbol,
+				Rate:      tk.Rate,
+				Interval:  tk.Interval,
+				MarkPrice: mark,
 			},
 		}
 	}

--- a/internal/exchange/hyperliquid/probe_cancel_test.go
+++ b/internal/exchange/hyperliquid/probe_cancel_test.go
@@ -1,0 +1,42 @@
+//go:build live
+
+package hyperliquid
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/teslashibe/permafrost/internal/types"
+	"github.com/teslashibe/permafrost/internal/wallet"
+)
+
+// TestLive_CancelByOID is a one-off helper to clean up an order placed by
+// an earlier integration test. Set PERMAFROST_HL_TEST_KEY and
+// PERMAFROST_HL_CANCEL_OID + PERMAFROST_HL_CANCEL_COIN to use it.
+func TestLive_CancelByOID(t *testing.T) {
+	keyHex := os.Getenv("PERMAFROST_HL_TEST_KEY")
+	oid := os.Getenv("PERMAFROST_HL_CANCEL_OID")
+	coin := os.Getenv("PERMAFROST_HL_CANCEL_COIN")
+	if keyHex == "" || oid == "" || coin == "" {
+		t.Skip("set PERMAFROST_HL_TEST_KEY + PERMAFROST_HL_CANCEL_OID + PERMAFROST_HL_CANCEL_COIN")
+	}
+	signer, err := wallet.NewHyperliquidSignerFromHex(keyHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, err := New(Config{
+		Network: NetworkTestnet,
+		Address: signer.Address(),
+	}, WithSigner(signer))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := v.CancelWithSymbol(ctx, types.OrderID(oid), coin); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	t.Logf("cancelled %s on %s", oid, coin)
+}

--- a/internal/exchange/hyperliquid/sdk.go
+++ b/internal/exchange/hyperliquid/sdk.go
@@ -2,6 +2,8 @@ package hyperliquid
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"sync"
@@ -29,10 +31,14 @@ type sdkClient struct {
 	signer   *wallet.HyperliquidSigner
 	network  Network
 	address  string
+
+	// szLookup is a callback the venue installs so the adapter can resolve
+	// per-coin size precision (szDecimals) without importing the venue back.
+	szLookup func(ctx context.Context, coin string) (int, error)
 }
 
-func newSDKClient(s *wallet.HyperliquidSigner, network Network) *sdkClient {
-	return &sdkClient{signer: s, network: network, address: s.Address()}
+func newSDKClient(s *wallet.HyperliquidSigner, network Network, szLookup func(ctx context.Context, coin string) (int, error)) *sdkClient {
+	return &sdkClient{signer: s, network: network, address: s.Address(), szLookup: szLookup}
 }
 
 // init lazily constructs the sonirico Exchange. Done at first use so
@@ -78,7 +84,21 @@ func (c *sdkClient) Place(ctx context.Context, intent types.OrderIntent) (types.
 	}
 
 	isBuy := intent.Side == types.SideBuy
-	size, _ := intent.Size.Float64()
+
+	// Round size DOWN to the venue's size-precision (szDecimals) so HL
+	// doesn't reject for "Order has invalid size step". szLookup is best
+	// effort: if it fails we pass through unrounded and let the venue
+	// surface the error.
+	sized := intent.Size
+	if c.szLookup != nil {
+		if dec, err := c.szLookup(ctx, intent.Symbol); err == nil && dec >= 0 {
+			sized = sized.Truncate(int32(dec))
+		}
+	}
+	if !sized.IsPositive() {
+		return types.OrderAck{}, fmt.Errorf("hyperliquid: size %s rounds to zero at the venue's szDecimals", intent.Size)
+	}
+	size, _ := sized.Float64()
 	price, _ := intent.Price.Float64()
 
 	var orderType hl.OrderType
@@ -104,9 +124,15 @@ func (c *sdkClient) Place(ctx context.Context, intent types.OrderIntent) (types.
 		ReduceOnly: intent.ReduceOnly,
 		OrderType:  orderType,
 	}
+	// HL's cloid must be exactly 32 hex characters with a 0x prefix
+	// (16 bytes). Our framework's ClientID format is `pf_<24hex>` (a
+	// hash truncated for log-readability across venues), so we normalise
+	// here: deterministically widen to 16 bytes and re-encode. The
+	// translation is stable, so a network retry of the same intent
+	// produces the same HL cloid → idempotent at the venue.
 	if intent.ClientID != "" {
-		s := string(intent.ClientID)
-		req.ClientOrderID = &s
+		cloid := normaliseCloid(string(intent.ClientID))
+		req.ClientOrderID = &cloid
 	}
 
 	status, err := ex.Order(ctx, req, nil)
@@ -184,6 +210,17 @@ func decimalFromString(s string) decimal.Decimal {
 		return decimal.Zero
 	}
 	return d
+}
+
+// normaliseCloid maps any caller-supplied client-order-id into HL's
+// strict format: 0x + 32 lowercase hex characters (16 bytes).
+//
+// We sha256 the supplied id and take the first 16 bytes. This is a
+// stable function — replays of the same input produce the same output —
+// so HL's idempotency-by-cloid still works.
+func normaliseCloid(in string) string {
+	h := sha256.Sum256([]byte(in))
+	return "0x" + hex.EncodeToString(h[:16])
 }
 
 // parseOID parses a Hyperliquid order id (numeric).

--- a/internal/exchange/hyperliquid/venue.go
+++ b/internal/exchange/hyperliquid/venue.go
@@ -67,7 +67,7 @@ func New(cfg Config, opts ...Option) (*Venue, error) {
 		opt(v)
 	}
 	if hlSigner, ok := v.signer.(*wallet.HyperliquidSigner); ok {
-		v.sdk = newSDKClient(hlSigner, cfg.Network)
+		v.sdk = newSDKClient(hlSigner, cfg.Network, v.SzDecimals)
 	}
 	return v, nil
 }
@@ -165,12 +165,14 @@ func (v *Venue) FundingRates(ctx context.Context, symbols []string) ([]types.Fun
 			continue
 		}
 		rate, _ := decimal.NewFromString(snap.Ctxs[i].Funding)
+		mark, _ := decimal.NewFromString(snap.Ctxs[i].MarkPx)
 		out = append(out, types.FundingRate{
-			Time:     now,
-			Venue:    VenueName,
-			Symbol:   coin,
-			Rate:     rate,
-			Interval: time.Hour,
+			Time:      now,
+			Venue:     VenueName,
+			Symbol:    coin,
+			Rate:      rate,
+			Interval:  time.Hour,
+			MarkPrice: mark,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Symbol < out[j].Symbol })
@@ -249,6 +251,23 @@ func (v *Venue) forgetOrder(id types.OrderID) {
 	v.orderSymMu.Lock()
 	defer v.orderSymMu.Unlock()
 	delete(v.orderSym, id)
+}
+
+// SzDecimals returns the size-precision decimal count for a coin from the
+// cached metaAndAssetCtxs (refreshes lazily). Used by the SDK adapter to
+// round order sizes to the venue's accepted precision before submission.
+// Returns -1 if the symbol is unknown.
+func (v *Venue) SzDecimals(ctx context.Context, coin string) (int, error) {
+	if err := v.refreshMeta(ctx, false); err != nil {
+		return -1, err
+	}
+	v.metaMu.Lock()
+	defer v.metaMu.Unlock()
+	idx, ok := v.metaIndex[coin]
+	if !ok {
+		return -1, fmt.Errorf("hyperliquid: unknown coin %q", coin)
+	}
+	return v.metaSnapshot.Meta.Universe[idx].SzDecimals, nil
 }
 
 // refreshMeta reloads metaAndAssetCtxs if the cached snapshot is older than

--- a/internal/strategy/funding_arb_basic/strategy.go
+++ b/internal/strategy/funding_arb_basic/strategy.go
@@ -85,10 +85,16 @@ func (s *Strategy) Decide(ctx context.Context, in strategy.DecisionInput) (strat
 				continue
 			}
 		}
-		spotIntent, perpIntent := openIntents(c, s.cfg, in.AgentID)
+		spotIntent, perpIntent, err := openIntents(c, s.cfg, in.AgentID)
+		if err != nil {
+			dec.Notes = appendNote(dec.Notes, fmt.Sprintf("skip %s: %v", c.Symbol, err))
+			continue
+		}
 		dec.Swaps = append(dec.Swaps, spotIntent)
 		dec.Orders = append(dec.Orders, perpIntent)
-		dec.Notes = appendNote(dec.Notes, fmt.Sprintf("opening %s @ funding %s/yr", c.Symbol, c.Annualised))
+		dec.Notes = appendNote(dec.Notes, fmt.Sprintf(
+			"opening %s @ funding %s/yr (mark=%s size=%s)",
+			c.Symbol, c.Annualised, c.Funding.MarkPrice, perpIntent.Size))
 	}
 
 	dec.Confidence = candidateConfidence(candidates)
@@ -164,7 +170,25 @@ func openSymbolSet(positions []types.BasisPosition) map[string]bool {
 }
 
 // openIntents builds the spot-buy + perp-short pair for a candidate.
-func openIntents(c candidate, cfg Config, agentID string) (types.SwapIntent, types.OrderIntent) {
+//
+// The spot leg trades USDC for the spot mint and is naturally USDC-sized
+// (Jupiter takes InAmount in input-token units, so USDC works directly).
+//
+// The perp leg needs base-asset units (e.g. WIF tokens), not USDC notional.
+// We translate using the venue-published mark price:
+//
+//	perp.Size = position_cap_usdc / mark_price
+//
+// If the mark is unknown (zero) we cannot size safely and refuse the open
+// — callers will see "skip <SYMBOL>: no mark price" in Decision.Notes.
+func openIntents(c candidate, cfg Config, agentID string) (types.SwapIntent, types.OrderIntent, error) {
+	mark := c.Funding.MarkPrice
+	if !mark.IsPositive() {
+		return types.SwapIntent{}, types.OrderIntent{},
+			fmt.Errorf("no mark price for %s — venue cache miss?", c.Symbol)
+	}
+	perpSize := cfg.PositionCapUSDC.Div(mark)
+
 	usdc := types.Asset{Symbol: "USDC", Chain: c.Asset.Spot.Chain, Mint: usdcMintFor(c.Asset.Spot.Chain), Decimals: 6}
 	swap := types.SwapIntent{
 		Chain:       c.Asset.Spot.Chain,
@@ -178,13 +202,15 @@ func openIntents(c candidate, cfg Config, agentID string) (types.SwapIntent, typ
 		Venue:      c.Asset.Perp.Venue,
 		Symbol:     c.Asset.Perp.Symbol,
 		Side:       types.SideSell,
-		Type:       types.OrderTypeMarket,
-		Size:       cfg.PositionCapUSDC, // notional; the runtime/venue will translate to base units in M3+
+		Type:       types.OrderTypeLimit, // resting maker far from book; live tests use a price near mark
+		Price:      mark,                 // strategy submits at mark; venue rounds size to szDecimals
+		Size:       perpSize,
+		TIF:        types.TIFGTC,
 		ReduceOnly: false,
 		Tag:        "open:" + c.Symbol,
 	}
 	_ = agentID
-	return swap, perp
+	return swap, perp, nil
 }
 
 // closeIntents builds the unwind pair for an open basis position.

--- a/internal/strategy/funding_arb_basic/strategy_test.go
+++ b/internal/strategy/funding_arb_basic/strategy_test.go
@@ -27,13 +27,21 @@ func loadRegistry(t *testing.T) assets.Registry {
 func d(s string) decimal.Decimal { return decimal.RequireFromString(s) }
 
 // fundingSymbol builds a SymbolSnap with a fixed annualised funding rate.
-// The rate is per-hour, so an annual ann = rate * 24*365.
+// The rate is per-hour, so an annual ann = rate * 24*365. A default mark
+// price of $1.00 is set so openIntents can size the perp leg.
 func fundingSymbol(symbol string, hourlyRate decimal.Decimal) types.SymbolSnap {
+	return fundingSymbolWithMark(symbol, hourlyRate, d("1"))
+}
+
+// fundingSymbolWithMark is the same as fundingSymbol but with an explicit
+// mark price (USDC). Use this when a test asserts on the perp leg size.
+func fundingSymbolWithMark(symbol string, hourlyRate, mark decimal.Decimal) types.SymbolSnap {
 	return types.SymbolSnap{
 		Funding: types.FundingRate{
-			Symbol:   symbol,
-			Rate:     hourlyRate,
-			Interval: time.Hour,
+			Symbol:    symbol,
+			Rate:      hourlyRate,
+			Interval:  time.Hour,
+			MarkPrice: mark,
 		},
 	}
 }
@@ -216,6 +224,84 @@ func TestDecide_LLMVetoBlocksOpen(t *testing.T) {
 	}
 	if !strings.Contains(dec.Notes, "vetoed WIF") {
 		t.Errorf("expected veto note, got %q", dec.Notes)
+	}
+}
+
+// TestDecide_SizesPerpInBaseUnits asserts the strategy now translates
+// the USDC position cap to base units via the venue mark price. Without
+// this fix, sizing was effectively `position_cap_usdc` base tokens —
+// e.g. 100 WIF tokens (~$22) for a $100 cap, instead of 462 WIF (~$100).
+func TestDecide_SizesPerpInBaseUnits(t *testing.T) {
+	r := loadRegistry(t)
+	s, _ := New(Config{
+		EntryAnnualisedFunding: d("0.5"),
+		ExitAnnualisedFunding:  d("0.1"),
+		PositionCapUSDC:        d("100"),
+	}, r, nil)
+
+	in := strategy.DecisionInput{
+		AgentID: "ag",
+		Now:     time.Now().UTC(),
+		Market: types.MarketSnapshot{
+			Symbols: map[string]types.SymbolSnap{
+				"WIF": fundingSymbolWithMark("WIF", d("0.0001"), d("0.216")),
+			},
+		},
+	}
+	dec, err := s.Decide(context.Background(), in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dec.Orders) != 1 {
+		t.Fatalf("expected 1 order, got %d", len(dec.Orders))
+	}
+	o := dec.Orders[0]
+	if o.Type != types.OrderTypeLimit {
+		t.Errorf("expected limit order (sized at mark), got %q", o.Type)
+	}
+	if !o.Price.Equal(d("0.216")) {
+		t.Errorf("price: got %s want 0.216 (mark)", o.Price)
+	}
+	// 100 / 0.216 ≈ 462.962962…  — exact ratio
+	want := d("100").Div(d("0.216"))
+	if !o.Size.Equal(want) {
+		t.Errorf("size: got %s want %s (= 100/0.216)", o.Size, want)
+	}
+	// Notional sanity: size * price should be ≈ 100 USDC
+	notional := o.Size.Mul(o.Price)
+	if notional.Sub(d("100")).Abs().GreaterThan(d("0.01")) {
+		t.Errorf("notional: got %s want ≈100", notional)
+	}
+}
+
+// TestDecide_SkipsCandidateWithNoMarkPrice covers the safety case: an
+// asset present in the universe + above the funding threshold but with
+// no mark price published by the venue is skipped rather than blindly
+// sized.
+func TestDecide_SkipsCandidateWithNoMarkPrice(t *testing.T) {
+	r := loadRegistry(t)
+	s, _ := New(Config{
+		EntryAnnualisedFunding: d("0.5"),
+		ExitAnnualisedFunding:  d("0.1"),
+		PositionCapUSDC:        d("100"),
+	}, r, nil)
+
+	in := strategy.DecisionInput{
+		AgentID: "ag",
+		Now:     time.Now().UTC(),
+		Market: types.MarketSnapshot{
+			Symbols: map[string]types.SymbolSnap{
+				// MarkPrice deliberately zero — venue cache miss.
+				"WIF": fundingSymbolWithMark("WIF", d("0.0001"), decimal.Zero),
+			},
+		},
+	}
+	dec, _ := s.Decide(context.Background(), in)
+	if len(dec.Orders) != 0 {
+		t.Errorf("expected 0 orders without mark price, got %d", len(dec.Orders))
+	}
+	if !strings.Contains(dec.Notes, "no mark price") {
+		t.Errorf("expected skip note, got %q", dec.Notes)
 	}
 }
 

--- a/internal/types/funding.go
+++ b/internal/types/funding.go
@@ -10,6 +10,11 @@ import (
 //
 // Rate is the per-interval rate (NOT annualised). Annualise via:
 //   AnnualPct = Rate * (365*24h / Interval) * 100
+//
+// MarkPrice is the venue's published mark for the symbol at the time of
+// the observation. Strategies use it to translate USDC notional into
+// base-asset size (size = notional_usdc / MarkPrice). It may be zero if
+// the venue did not return one in the same call.
 type FundingRate struct {
 	Time          time.Time       `json:"time"`
 	Venue         string          `json:"venue"`
@@ -17,6 +22,7 @@ type FundingRate struct {
 	Rate          decimal.Decimal `json:"rate"`            // per Interval, fractional (0.0001 = 1bp)
 	Interval      time.Duration   `json:"interval"`        // typically 1h or 8h
 	PredictedNext decimal.Decimal `json:"predicted_next"`  // venue-published forecast for next interval
+	MarkPrice     decimal.Decimal `json:"mark_price"`      // mark price in USDC at observation time
 }
 
 // Annualised returns the funding rate scaled to one year. Returns zero if


### PR DESCRIPTION
## Closes the v1 sizing limitation

Previously \`funding_arb_basic\` put \`cfg.PositionCapUSDC\` directly into \`OrderIntent.Size\` — but the venue interprets Size as base-asset units (e.g. WIF tokens), not USDC. Result: a $50 cap actually traded 50 WIF tokens (~$11 at testnet mark), so notional was off by 5x or more.

## Fix

| Layer | Change |
|---|---|
| \`types.FundingRate\` | New \`MarkPrice\` field |
| HL Venue | Populates \`MarkPrice\` from existing \`metaAndAssetCtxs\` cache (no extra round-trip) |
| \`funding_arb_basic.openIntents\` | \`size = position_cap_usdc / mark_price\`, \`price = mark_price\`. Skips candidates without a mark instead of sizing blindly |
| HL SDK adapter | Rounds \`Size\` down to the venue's \`szDecimals\` (read from cached meta) — fixes "invalid size step" rejections; errors if the requested size rounds to zero |
| HL SDK adapter | Normalises \`ClientID\` to HL's required format (0x + 32 lowercase hex) via stable sha256-truncate so retries stay idempotent |

## Backtest harness
\`FundingTick\` gains optional \`MarkPrice\`; the CSV loader accepts an optional \`mark_price\` column. \`MarketSnapshotAt\` fills a \$1.00 sentinel for synthetic ticks so existing replays still trigger the strategy.

## Tests
- \`TestDecide_SizesPerpInBaseUnits\` — \$100 cap @ \$0.216 mark → 462.96 WIF, notional ≈ \$100 (within 1¢).
- \`TestDecide_SkipsCandidateWithNoMarkPrice\` — zero mark → 0 orders + "no mark price" note.
- Existing strategy + backtest tests updated for the new mark-price default; all green.

## Live verification — full agent runtime → real testnet order

\`\`\`
$ permafrost agent run live-size-01 --confirm-live --ticks 1
  agent run starting agent_id=live-size-01 mode=live network=testnet
  tick agent_id=live-size-01 swaps=1 orders=1 cancels=0

$ psql ... orders WHERE agent_id='live-size-01'
  WIF | sell | limit | paper=f | open | size=69.842 | price=0.21477 | venue_id=51646905558
\`\`\`

- Notional 69.842 × 0.21477 ≈ **\$15.00** — exactly the configured \`position_cap_usdc\`.
- \`venue_id\` populated → HL accepted the signed action with correctly-sized base units.
- The resting order was cancelled by \`TestLive_CancelByOID\` so the test wallet ends in the same state it started.

## Verify locally
\`\`\`
go test ./internal/strategy/funding_arb_basic/... -count=1 -v
go test -tags=live ./internal/exchange/hyperliquid/...   # needs PERMAFROST_HL_TEST_KEY
\`\`\`