### PR TITLE
feat: close the loop — strategy spot leg → live Jupiter swap

### DIFF
--- a/internal/agent/builder.go
+++ b/internal/agent/builder.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/shopspring/decimal"
 
@@ -14,6 +15,8 @@ import (
 	"github.com/teslashibe/permafrost/internal/inference"
 	"github.com/teslashibe/permafrost/internal/strategy"
 	fab "github.com/teslashibe/permafrost/internal/strategy/funding_arb_basic"
+	"github.com/teslashibe/permafrost/internal/swap"
+	"github.com/teslashibe/permafrost/internal/swap/jupiter"
 	"github.com/teslashibe/permafrost/internal/types"
 	"github.com/teslashibe/permafrost/internal/wallet"
 )
@@ -64,26 +67,103 @@ func BuildDeps(
 	if log == nil {
 		log = slog.Default()
 	}
+
+	// Build the spot SwapVenue if Solana config is provided. We only
+	// surface the venue when both RPC and a Solana signer are available;
+	// without a signer there's nothing to sign Jupiter swap transactions
+	// with, so leaving it nil is the only safe choice (runtime falls
+	// back to paper-spot recording).
+	var swapVenue swap.SwapVenue
+	if opts.Solana.IsEnabled() {
+		v, err := BuildSolanaSwapVenue(opts.Solana, keystore)
+		switch {
+		case err == nil:
+			swapVenue = v
+		case errors.Is(err, ErrNoSolanaSigner):
+			log.Warn("solana swap disabled: no Solana signer in keystore",
+				"agent_id", a.ID)
+		default:
+			return Deps{}, fmt.Errorf("solana swap venue: %w", err)
+		}
+	}
+
 	return Deps{
 		Strategy: strat,
 		Perp:     venue,
+		Swap:     swapVenue,
 		Store:    store,
 		Logger:   log.With("agent_id", a.ID, "network", network, "mode", a.Mode),
 	}, nil
 }
 
+// ErrNoSolanaSigner is returned by BuildSolanaSwapVenue when the
+// supplied keystore doesn't contain a Solana key. The caller decides
+// whether to degrade (paper-spot) or fail (live-mode required).
+var ErrNoSolanaSigner = errors.New("agent: no Solana signer in keystore")
+
+// BuildSolanaSwapVenue constructs a Jupiter-backed SwapVenue from
+// SolanaSpot config + a keystore that holds a Solana signer.
+func BuildSolanaSwapVenue(cfg SolanaSpot, keystore wallet.Keystore) (swap.SwapVenue, error) {
+	if !cfg.IsEnabled() {
+		return nil, errors.New("agent: SolanaSpot is not configured")
+	}
+	if keystore == nil {
+		return nil, ErrNoSolanaSigner
+	}
+	signer, err := keystore.Signer(types.ChainSolana)
+	if err != nil {
+		return nil, ErrNoSolanaSigner
+	}
+	mode := jupiter.SubmitMode(cfg.SubmitMode)
+	if mode == "" {
+		mode = jupiter.SubmitJito
+	}
+	return jupiter.New(jupiter.Config{
+		RPCURL:                   cfg.RPCURL,
+		JupiterAPIKey:            cfg.JupiterAPIKey,
+		JupiterBaseURL:           cfg.JupiterBaseURL,
+		Mode:                     mode,
+		JitoBundleURL:            cfg.JitoBundleURL,
+		PriorityFeeMicroLamports: cfg.PriorityFeeMicroLamports,
+		PollTimeout:              time.Duration(cfg.ConfirmationTimeoutSecs) * time.Second,
+	}, signer)
+}
+
 // BuildOptions are caller-supplied OVERRIDES of fields the Agent already
 // carries on its DB record. An empty value means "use the agent's own
-// stored value". Both fields default to non-overriding empty strings.
+// stored value". Both Hyperliquid fields default to non-overriding
+// empty strings.
 //
 // HyperliquidNetwork override is mostly useful as an emergency switch
 // ("force everything to testnet for safety") or for the foreground
 // `agent run` command's --network flag. The daemon supervisor leaves it
 // empty so each agent runs on its own configured network.
+//
+// Solana enables the live spot leg. When zero, the Runtime falls back
+// to paper-spot (records intent, never quotes Jupiter, never broadcasts).
+// Required for any agent that emits SwapIntents in mode=live.
 type BuildOptions struct {
 	HyperliquidNetwork string // empty → use Agent.Network
 	HyperliquidAddress string // empty → derive from keystore (or no address)
+	Solana             SolanaSpot
 }
+
+// SolanaSpot captures everything the Jupiter SwapVenue needs to settle
+// real spot legs on Solana. Mirrors config.SolanaConfig but lives in the
+// agent package so the builder doesn't import the cli/config layer.
+type SolanaSpot struct {
+	RPCURL                   string
+	JupiterBaseURL           string
+	JupiterAPIKey            string
+	SubmitMode               string // "jito" | "rpc"; "" => jito
+	JitoBundleURL            string
+	PriorityFeeMicroLamports uint64
+	ConfirmationTimeoutSecs  int
+}
+
+// IsEnabled reports whether the operator has provided enough config for
+// the SwapVenue to be constructed. RPCURL is the bare minimum.
+func (s SolanaSpot) IsEnabled() bool { return s.RPCURL != "" }
 
 // BuildStrategy is the strategy-construction switch shared between the
 // foreground CLI and the supervisor. Currently funding_arb_basic is the

--- a/internal/agent/builder_test.go
+++ b/internal/agent/builder_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/teslashibe/permafrost/internal/assets"
@@ -139,6 +140,106 @@ func TestBuildDeps_PerAgentNetworkPlumbed(t *testing.T) {
 				t.Fatal("Perp venue should be set")
 			}
 		})
+	}
+}
+
+func TestBuildSolanaSwapVenue_RequiresConfigAndSigner(t *testing.T) {
+	// No config → error.
+	if _, err := BuildSolanaSwapVenue(SolanaSpot{}, nil); err == nil {
+		t.Fatal("expected error without config")
+	}
+	// Config but no keystore → ErrNoSolanaSigner.
+	cfg := SolanaSpot{RPCURL: "http://localhost:8899"}
+	if _, err := BuildSolanaSwapVenue(cfg, nil); !errors.Is(err, ErrNoSolanaSigner) {
+		t.Fatalf("expected ErrNoSolanaSigner, got %v", err)
+	}
+	// Config + keystore without solana key → ErrNoSolanaSigner.
+	emptyKS := walletnoop.NewKeystore() // no chains registered
+	if _, err := BuildSolanaSwapVenue(cfg, emptyKS); !errors.Is(err, ErrNoSolanaSigner) {
+		t.Fatalf("expected ErrNoSolanaSigner from empty keystore, got %v", err)
+	}
+}
+
+func TestBuildSolanaSwapVenue_BuildsWithSolanaSigner(t *testing.T) {
+	ks := walletnoop.NewKeystore("solana") // type missing — let me check
+	cfg := SolanaSpot{
+		RPCURL:        "http://localhost:8899",
+		SubmitMode:    "rpc",
+		JitoBundleURL: "",
+	}
+	v, err := BuildSolanaSwapVenue(cfg, ks)
+	if err != nil {
+		t.Fatalf("BuildSolanaSwapVenue: %v", err)
+	}
+	if v == nil {
+		t.Fatal("expected swap venue")
+	}
+	if v.Name() != "jupiter" {
+		t.Errorf("Name: %q want jupiter", v.Name())
+	}
+}
+
+func TestBuildDeps_PopulatesSwapWhenSolanaConfigured(t *testing.T) {
+	reg, err := assets.LoadEmbedded()
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := Agent{
+		ID:       "ag",
+		Strategy: "funding_arb_basic",
+		Universe: []string{"WIF"},
+	}
+	ks := walletnoop.NewKeystore("solana")
+	deps, err := BuildDeps(a, reg, nil, ks, nil, BuildOptions{
+		HyperliquidNetwork: "testnet",
+		Solana: SolanaSpot{
+			RPCURL:     "http://localhost:8899",
+			SubmitMode: "rpc",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deps.Swap == nil {
+		t.Fatal("expected Deps.Swap to be populated")
+	}
+	if deps.Perp == nil {
+		t.Fatal("expected Deps.Perp to be populated")
+	}
+}
+
+func TestBuildDeps_LeavesSwapNilWhenSolanaUnconfigured(t *testing.T) {
+	reg, _ := assets.LoadEmbedded()
+	a := Agent{ID: "ag", Strategy: "funding_arb_basic", Universe: []string{"WIF"}}
+	deps, err := BuildDeps(a, reg, nil, nil, nil, BuildOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deps.Swap != nil {
+		t.Error("Swap should be nil when Solana is unconfigured (paper-spot fallback)")
+	}
+}
+
+func TestBuildDeps_DegradesWhenSolanaConfiguredButNoSigner(t *testing.T) {
+	reg, _ := assets.LoadEmbedded()
+	a := Agent{ID: "ag", Strategy: "funding_arb_basic", Universe: []string{"WIF"}}
+	deps, err := BuildDeps(a, reg, nil, nil, nil, BuildOptions{
+		Solana: SolanaSpot{RPCURL: "http://localhost:8899"},
+	})
+	if err != nil {
+		t.Fatalf("BuildDeps should not error when degrading to paper-spot: %v", err)
+	}
+	if deps.Swap != nil {
+		t.Error("Swap should be nil when no Solana signer available")
+	}
+}
+
+func TestSolanaSpot_IsEnabled(t *testing.T) {
+	if (SolanaSpot{}).IsEnabled() {
+		t.Error("zero SolanaSpot must be disabled")
+	}
+	if !(SolanaSpot{RPCURL: "x"}).IsEnabled() {
+		t.Error("RPCURL alone must enable")
 	}
 }
 

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -247,29 +247,44 @@ func (r *Runtime) persistDecision(ctx context.Context, now time.Time, decisionID
 // executeSwapsThenOrders runs swaps first (spot leg), then orders (perp leg)
 // — this is the spot-first invariant called for in SCOPE.md §11.
 //
-// After execution, the runtime's in-memory openBasis is reconciled so the
-// next tick's DecisionInput.BasisPositions reflects what just opened/closed.
-// This stops basis strategies from re-emitting opens for symbols they
-// already opened on a previous tick within the same Run.
+// Each leg's success is tracked per-symbol so reconcileOpenBasis only
+// marks a basis "open" when BOTH legs succeeded. A failed swap or order
+// is recorded in the audit ledger (orders / swaps tables) with a failed
+// status but does not produce a basis-position row — leaving the strategy
+// free to retry on the next tick instead of believing it already has the
+// position.
 func (r *Runtime) executeSwapsThenOrders(ctx context.Context, now time.Time, decisionID string, _ strategy.DecisionInput, dec strategy.Decision) {
+	swapOK := map[string]bool{}  // keyed by uppercased OUT-token symbol
+	orderOK := map[string]bool{} // keyed by uppercased perp symbol
+
 	for i, s := range dec.Swaps {
-		r.executeSwap(ctx, now, decisionID, i, s)
+		if r.executeSwap(ctx, now, decisionID, i, s) {
+			swapOK[strings.ToUpper(s.OutToken.Symbol)] = true
+		}
 	}
 	for i, o := range dec.Orders {
-		r.executeOrder(ctx, now, decisionID, i, o)
+		if r.executeOrder(ctx, now, decisionID, i, o) {
+			orderOK[strings.ToUpper(o.Symbol)] = true
+		}
 	}
 	for _, c := range dec.Cancels {
 		r.executeCancel(ctx, c)
 	}
-	r.reconcileOpenBasis(ctx, now, decisionID, dec)
+	r.reconcileOpenBasis(ctx, now, decisionID, dec, swapOK, orderOK)
 }
 
 // reconcileOpenBasis maintains the runtime's in-memory view of open basis
-// positions based on the intents this decision emitted. Pairs are matched by
-// the underlying symbol. When a Store is configured, every open is upserted
-// and every close is recorded — so a daemon restart hydrates the same
+// positions based on the intents this decision emitted AND per-leg success
+// flags from the executor. Pairs are matched by the underlying symbol;
+// only pairs where BOTH the spot swap and the perp order succeeded are
+// marked open. When a Store is configured, every open is upserted and
+// every close is recorded — so a daemon restart hydrates the same
 // position set on the next NewRuntime.
-func (r *Runtime) reconcileOpenBasis(ctx context.Context, now time.Time, decisionID string, dec strategy.Decision) {
+//
+// swapOK / orderOK are keyed by uppercased symbol (out-token for swaps,
+// perp symbol for orders). nil maps mean "treat all as success" — used
+// by tests that don't go through the executor.
+func (r *Runtime) reconcileOpenBasis(ctx context.Context, now time.Time, decisionID string, dec strategy.Decision, swapOK, orderOK map[string]bool) {
 	r.posMu.Lock()
 	defer r.posMu.Unlock()
 
@@ -282,6 +297,14 @@ func (r *Runtime) reconcileOpenBasis(ctx context.Context, now time.Time, decisio
 		}
 		key := strings.ToUpper(o.Symbol)
 		if _, ok := r.openBasis[key]; !ok {
+			continue
+		}
+		// Only close on a successful reduce-only order; a failed close
+		// means the position is still open at the venue, so we must not
+		// drop our local view.
+		if orderOK != nil && !orderOK[key] {
+			r.deps.Logger.Warn("close intent failed; basis remains open in our view",
+				"agent_id", r.agent.ID, "underlying", o.Symbol)
 			continue
 		}
 		delete(r.openBasis, key)
@@ -313,8 +336,20 @@ func (r *Runtime) reconcileOpenBasis(ctx context.Context, now time.Time, decisio
 		if _, alreadyOpen := r.openBasis[key]; alreadyOpen {
 			continue
 		}
+		// Both legs must have succeeded. A half-open basis (e.g. spot
+		// filled but perp rejected) is dangerous to record as "open" —
+		// the strategy would think it's hedged when it isn't. Log a
+		// warning so an operator can intervene.
+		spotSucceeded := swapOK == nil || swapOK[key]
+		perpSucceeded := orderOK == nil || orderOK[key]
+		if !spotSucceeded || !perpSucceeded {
+			r.deps.Logger.Warn("partial open; skipping basis reconcile",
+				"agent_id", r.agent.ID, "underlying", o.Symbol,
+				"spot_ok", spotSucceeded, "perp_ok", perpSucceeded)
+			continue
+		}
 		bp := types.BasisPosition{
-			ID:         "bp:" + r.agent.ID + ":" + key + ":" + decisionID[:8],
+			ID:         "bp:" + r.agent.ID + ":" + key + ":" + safeShortID(decisionID),
 			AgentID:    r.agent.ID,
 			Underlying: o.Symbol,
 			State:      types.BasisStateOpen,
@@ -334,7 +369,11 @@ func (r *Runtime) reconcileOpenBasis(ctx context.Context, now time.Time, decisio
 	}
 }
 
-func (r *Runtime) executeSwap(ctx context.Context, now time.Time, decisionID string, slot int, s types.SwapIntent) {
+// executeSwap returns true iff the swap was successfully recorded (paper)
+// or confirmed on chain (live). A return of false means the basis pair
+// MUST NOT be reconciled into the open-basis set — the position would be
+// half-open at best, which is worse than retrying on the next tick.
+func (r *Runtime) executeSwap(ctx context.Context, now time.Time, decisionID string, slot int, s types.SwapIntent) bool {
 	if s.ClientID == "" {
 		s.ClientID = clientIDFromSwap(r.agent.ID, decisionID, slot, s)
 	}
@@ -342,12 +381,12 @@ func (r *Runtime) executeSwap(ctx context.Context, now time.Time, decisionID str
 		v := r.deps.Risk.PreTrade(ctx, r.agent.ID, s, types.PortfolioSnapshot{})
 		if v.IsBlock() {
 			r.deps.Logger.Warn("swap blocked by risk", "agent_id", r.agent.ID, "reason", v.Reason)
-			return
+			return false
 		}
 	}
 	if r.agent.Mode == ModePaper || r.deps.Swap == nil {
 		r.recordSwap(ctx, now, decisionID, s, "", types.SwapStatusConfirmed, true, s.InAmount, decimal.Zero)
-		return
+		return true
 	}
 
 	q, err := r.deps.Swap.Quote(ctx, types.QuoteRequest{
@@ -356,24 +395,28 @@ func (r *Runtime) executeSwap(ctx context.Context, now time.Time, decisionID str
 	if err != nil {
 		r.deps.Logger.Error("swap quote failed", "err", err)
 		r.recordSwap(ctx, now, decisionID, s, "", types.SwapStatusFailed, false, decimal.Zero, decimal.Zero)
-		return
+		return false
 	}
 	tx, err := r.deps.Swap.Swap(ctx, q, s.SlippageBps)
 	if err != nil {
 		r.deps.Logger.Error("swap submit failed", "err", err)
 		r.recordSwap(ctx, now, decisionID, s, "", types.SwapStatusFailed, false, decimal.Zero, decimal.Zero)
-		return
+		return false
 	}
 	res, err := r.deps.Swap.WaitConfirm(ctx, tx)
 	if err != nil {
 		r.deps.Logger.Error("swap confirm failed", "err", err)
 		r.recordSwap(ctx, now, decisionID, s, string(tx), types.SwapStatusFailed, false, decimal.Zero, decimal.Zero)
-		return
+		return false
 	}
 	r.recordSwap(ctx, now, decisionID, s, string(res.TxHash), res.Status, false, res.OutAmount, res.GasNative)
+	return res.Status == types.SwapStatusConfirmed
 }
 
-func (r *Runtime) executeOrder(ctx context.Context, now time.Time, decisionID string, slot int, o types.OrderIntent) {
+// executeOrder returns true iff the order was accepted (paper "open" or
+// live ack with non-rejected status). False means the basis pair must
+// not be reconciled.
+func (r *Runtime) executeOrder(ctx context.Context, now time.Time, decisionID string, slot int, o types.OrderIntent) bool {
 	if o.ClientID == "" {
 		o.ClientID = types.DeriveClientID(r.agent.ID, decisionID, slot, o.Venue, o.Symbol, o.Side, o.Size)
 	}
@@ -383,20 +426,21 @@ func (r *Runtime) executeOrder(ctx context.Context, now time.Time, decisionID st
 		v := r.deps.Risk.PreTrade(ctx, r.agent.ID, o, types.PortfolioSnapshot{})
 		if v.IsBlock() {
 			r.deps.Logger.Warn("order blocked by risk", "agent_id", r.agent.ID, "reason", v.Reason)
-			return
+			return false
 		}
 	}
 	if r.agent.Mode == ModePaper || r.deps.Perp == nil {
 		r.recordOrder(ctx, now, decisionID, o, "", string(types.OrderStatusOpen), true)
-		return
+		return true
 	}
 	ack, err := r.deps.Perp.Place(ctx, o)
 	if err != nil {
 		r.deps.Logger.Error("order place failed", "err", err)
 		r.recordOrder(ctx, now, decisionID, o, "", string(types.OrderStatusRejected), false)
-		return
+		return false
 	}
 	r.recordOrder(ctx, now, decisionID, o, string(ack.ID), string(ack.Status), false)
+	return ack.Status != types.OrderStatusRejected
 }
 
 func (r *Runtime) executeCancel(ctx context.Context, id types.OrderID) {
@@ -467,6 +511,15 @@ func decisionInputHash(in strategy.DecisionInput) string {
 	h := sha256.New()
 	fmt.Fprintf(h, "%s|%d|%d|%d|%d", in.AgentID, in.Now.UnixNano(), len(in.PerpPositions), len(in.SpotBalances), len(in.BasisPositions))
 	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// safeShortID returns the first 8 chars of id, or all of id if shorter.
+// Avoids panicking on short ids during tests / unusual decisionIDs.
+func safeShortID(id string) string {
+	if len(id) >= 8 {
+		return id[:8]
+	}
+	return id
 }
 
 // clientIDFromSwap creates a deterministic client_id for a SwapIntent.

--- a/internal/agent/runtime_test.go
+++ b/internal/agent/runtime_test.go
@@ -185,9 +185,61 @@ func TestReconcileOpenBasis_ClosesOnReduceOnly(t *testing.T) {
 			Venue: "hyperliquid", Symbol: "WIF", Side: types.SideBuy,
 			ReduceOnly: true, Type: types.OrderTypeMarket, Size: decimal.NewFromInt(100),
 		}},
-	})
+	}, nil, nil) // nil success maps = treat all as success
 	if len(r.snapshotOpenBasis()) != 0 {
 		t.Errorf("reduce-only buy should have closed the basis")
+	}
+}
+
+// TestReconcileOpenBasis_SkipsHalfOpenAfterFailedSwap covers the new
+// per-leg success tracking: if the spot swap failed, the basis must NOT
+// be reconciled as open (we'd believe we're hedged when we're actually
+// directional via the perp leg only).
+func TestReconcileOpenBasis_SkipsHalfOpenAfterFailedSwap(t *testing.T) {
+	a := Agent{ID: "a", Strategy: "x", Mode: ModeLive}
+	r := NewRuntime(a, Deps{Strategy: nil})
+
+	dec := strategy.Decision{
+		Swaps: []types.SwapIntent{{
+			Chain:    types.ChainSolana,
+			InToken:  types.Asset{Symbol: "USDC"},
+			OutToken: types.Asset{Symbol: "WIF", Mint: "wif"},
+			InAmount: decimal.NewFromInt(100),
+		}},
+		Orders: []types.OrderIntent{{
+			Venue: "hyperliquid", Symbol: "WIF", Side: types.SideSell,
+			Type: types.OrderTypeMarket, Size: decimal.NewFromInt(100),
+		}},
+	}
+	// swap failed (WIF not in swapOK), order succeeded
+	r.reconcileOpenBasis(context.Background(), time.Now(), "decX", dec,
+		map[string]bool{},                  // swapOK: empty → swap failed
+		map[string]bool{"WIF": true})       // orderOK: WIF placed
+	if got := len(r.snapshotOpenBasis()); got != 0 {
+		t.Errorf("expected NO basis when swap failed, got %d", got)
+	}
+}
+
+func TestReconcileOpenBasis_OpensOnlyWhenBothLegsSucceed(t *testing.T) {
+	a := Agent{ID: "a", Strategy: "x", Mode: ModeLive}
+	r := NewRuntime(a, Deps{Strategy: nil})
+	dec := strategy.Decision{
+		Swaps: []types.SwapIntent{{
+			Chain:    types.ChainSolana,
+			InToken:  types.Asset{Symbol: "USDC"},
+			OutToken: types.Asset{Symbol: "WIF", Mint: "wif"},
+			InAmount: decimal.NewFromInt(100),
+		}},
+		Orders: []types.OrderIntent{{
+			Venue: "hyperliquid", Symbol: "WIF", Side: types.SideSell,
+			Type: types.OrderTypeMarket, Size: decimal.NewFromInt(100),
+		}},
+	}
+	r.reconcileOpenBasis(context.Background(), time.Now(), "decY", dec,
+		map[string]bool{"WIF": true},
+		map[string]bool{"WIF": true})
+	if got := len(r.snapshotOpenBasis()); got != 1 {
+		t.Errorf("expected 1 basis when both legs succeed, got %d", got)
 	}
 }
 

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -16,9 +16,11 @@ import (
 
 	"github.com/teslashibe/permafrost/internal/agent"
 	"github.com/teslashibe/permafrost/internal/assets"
+	"github.com/teslashibe/permafrost/internal/config"
 	"github.com/teslashibe/permafrost/internal/exchange"
 	exchangenoop "github.com/teslashibe/permafrost/internal/exchange/noop"
 	"github.com/teslashibe/permafrost/internal/store"
+	fab "github.com/teslashibe/permafrost/internal/strategy/funding_arb_basic"
 	"github.com/teslashibe/permafrost/internal/types"
 )
 
@@ -374,8 +376,10 @@ Stops on SIGINT/SIGTERM or after --ticks N (whichever comes first).`,
 				return err
 			}
 			// Live mode requires a Hyperliquid signer in the keystore so
-			// the runtime can sign real orders. Paper mode runs without
-			// any signer (funding-only reads).
+			// the runtime can sign real orders. Basis strategies (which
+			// hedge a perp short with a Solana spot long) ALSO require a
+			// Solana signer + Solana RPC so the spot leg can settle live.
+			// Paper mode runs without any signer (funding-only reads).
 			if a.Mode == agent.ModeLive {
 				if !confirmLive {
 					return fmt.Errorf("agent %q is mode=live; pass --confirm-live to acknowledge real-money risk", a.ID)
@@ -386,6 +390,16 @@ Stops on SIGINT/SIGTERM or after --ticks N (whichever comes first).`,
 				}
 				if _, err := ks.Signer(types.ChainHyperliquid); err != nil {
 					return fmt.Errorf("live mode requires a hyperliquid signer in the keystore: %w", err)
+				}
+				if isBasisStrategy(a.Strategy) {
+					if _, err := ks.Signer(types.ChainSolana); err != nil {
+						return fmt.Errorf("live mode for basis strategy %q requires a Solana signer: %w",
+							a.Strategy, err)
+					}
+					if g.Config.Solana.RPCURL == "" {
+						return fmt.Errorf("live mode for basis strategy %q requires solana.rpc_url in config",
+							a.Strategy)
+					}
 				}
 			}
 
@@ -400,6 +414,7 @@ Stops on SIGINT/SIGTERM or after --ticks N (whichever comes first).`,
 			deps, err := agent.BuildDeps(a, reg, st, ks, g.Log, agent.BuildOptions{
 				HyperliquidNetwork: networkOverride,
 				HyperliquidAddress: hlAddress,
+				Solana:             solanaSpotFromConfig(g.Config.Solana),
 			})
 			if err != nil {
 				return err
@@ -588,6 +603,33 @@ func (v *tickFundingVenue) FundingRates(_ context.Context, _ []string) ([]types.
 
 // Compile-time check.
 var _ exchange.Venue = (*tickFundingVenue)(nil)
+
+// isBasisStrategy reports whether a strategy emits SwapIntents (and
+// therefore needs a working spot leg in live mode). Right now
+// funding_arb_basic is the only one, but new basis strategies should
+// register here.
+func isBasisStrategy(name string) bool {
+	switch name {
+	case fab.Name:
+		return true
+	}
+	return false
+}
+
+// solanaSpotFromConfig translates the cli config view into the agent
+// builder's view (the agent package can't import config without an
+// import cycle).
+func solanaSpotFromConfig(cfg config.SolanaConfig) agent.SolanaSpot {
+	return agent.SolanaSpot{
+		RPCURL:                   cfg.RPCURL,
+		JupiterBaseURL:           cfg.JupiterBaseURL,
+		JupiterAPIKey:            cfg.JupiterAPIKey,
+		SubmitMode:               cfg.SubmitMode,
+		JitoBundleURL:            cfg.JitoBundleURL,
+		PriorityFeeMicroLamports: cfg.PriorityFeeMicroLamports,
+		ConfirmationTimeoutSecs:  cfg.ConfirmationTimeoutSecs,
+	}
+}
 
 func splitCSV(s string) []string {
 	if s == "" {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -83,11 +83,14 @@ func Serve(ctx context.Context, g *Globals, opts ServeOptions) error {
 			g.Log.Warn("supervisor: load registry failed; agents will not start", "err", err)
 		} else {
 			loader := &agent.Loader{
-				Store:      agent.NewStore(db.Pool),
-				Registry:   reg,
-				Keystore:   ks,
-				Logger:     g.Log,
-				BuildOpts:  agent.BuildOptions{HyperliquidNetwork: opts.HyperliquidNetworkOverride},
+				Store:    agent.NewStore(db.Pool),
+				Registry: reg,
+				Keystore: ks,
+				Logger:   g.Log,
+				BuildOpts: agent.BuildOptions{
+					HyperliquidNetwork: opts.HyperliquidNetworkOverride,
+					Solana:             solanaSpotFromConfig(g.Config.Solana),
+				},
 				Supervisor: sup,
 			}
 			n, err := loader.LoadAndStartRunning(ctx)

--- a/internal/exchange/hyperliquid/probe_unwind_test.go
+++ b/internal/exchange/hyperliquid/probe_unwind_test.go
@@ -1,0 +1,93 @@
+//go:build live
+
+package hyperliquid
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/teslashibe/permafrost/internal/types"
+	"github.com/teslashibe/permafrost/internal/wallet"
+)
+
+// TestLive_UnwindAllPositions closes every open position on HL testnet
+// for the configured signer. Useful as a "panic button" after a half-open
+// run leaves residual short exposure. Skips unless PERMAFROST_HL_TEST_KEY
+// is set.
+func TestLive_UnwindAllPositions(t *testing.T) {
+	keyHex := os.Getenv("PERMAFROST_HL_TEST_KEY")
+	if keyHex == "" {
+		t.Skip("PERMAFROST_HL_TEST_KEY not set")
+	}
+	signer, err := wallet.NewHyperliquidSignerFromHex(keyHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, err := New(Config{
+		Network: NetworkTestnet,
+		Address: signer.Address(),
+	}, WithSigner(signer))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	positions, err := v.Positions(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("found %d open positions on testnet", len(positions))
+
+	for _, p := range positions {
+		if p.IsFlat() {
+			continue
+		}
+		side := types.SideSell
+		size := p.Qty
+		if p.IsShort() {
+			side = types.SideBuy
+			size = p.Qty.Abs()
+		}
+		// Use a market-ish IOC limit far through the book to flatten.
+		// 5% past mark to guarantee execution.
+		rates, err := v.FundingRates(ctx, []string{p.Symbol})
+		if err != nil || len(rates) == 0 || !rates[0].MarkPrice.IsPositive() {
+			t.Errorf("no mark for %s; skipping", p.Symbol)
+			continue
+		}
+		mark := rates[0].MarkPrice
+		bump := decimalFromString("1.05")
+		drop := decimalFromString("0.95")
+		var limit = mark.Mul(drop)
+		if side == types.SideBuy {
+			limit = mark.Mul(bump)
+		}
+		intent := types.OrderIntent{
+			Venue:      VenueName,
+			Symbol:     p.Symbol,
+			Side:       side,
+			Type:       types.OrderTypeLimit,
+			TIF:        types.TIFIOC,
+			Size:       size,
+			Price:      limit,
+			ReduceOnly: true,
+		}
+		ack, err := v.Place(ctx, intent)
+		if err != nil {
+			t.Errorf("close %s: %v", p.Symbol, err)
+			continue
+		}
+		t.Logf("closed %s qty=%s ack=%+v", p.Symbol, size, ack)
+	}
+
+	// Re-check.
+	positions, _ = v.Positions(ctx)
+	for _, p := range positions {
+		if !p.IsFlat() {
+			t.Errorf("residual position: %s qty=%s", p.Symbol, p.Qty)
+		}
+	}
+}

--- a/internal/swap/jupiter/client.go
+++ b/internal/swap/jupiter/client.go
@@ -30,9 +30,16 @@ type Client struct {
 // ClientOption configures a Client.
 type ClientOption func(*Client)
 
-// WithBaseURL overrides the default https://api.jup.ag base URL.
+// WithBaseURL overrides the default https://api.jup.ag base URL. An empty
+// string is a no-op so callers that pass an unset config field don't
+// accidentally clear the default.
 func WithBaseURL(u string) ClientOption {
-	return func(c *Client) { c.base = strings.TrimRight(u, "/") }
+	return func(c *Client) {
+		if u == "" {
+			return
+		}
+		c.base = strings.TrimRight(u, "/")
+	}
 }
 
 // WithAPIKey installs an x-api-key header for authenticated tiers.


### PR DESCRIPTION
## Why

The runtime had full plumbing for \`executeSwap\` (Quote → Swap → WaitConfirm) but \`BuildDeps\` never constructed a \`SwapVenue\` — so even live mode silently faked the spot leg. This wires Jupiter into the daemon + CLI so \`funding_arb_basic\` can actually trade end-to-end live.

## Builder
- \`agent.SolanaSpot\` config struct mirrors \`config.SolanaConfig\` (avoids the agent package importing cli/config).
- \`BuildOptions.Solana\` threads it through.
- \`BuildSolanaSwapVenue\` constructs a \`jupiter.Venue\` when both RPC URL and a Solana signer are available; returns \`ErrNoSolanaSigner\` when the signer is missing.
- \`BuildDeps\` populates \`Deps.Swap\` when \`SolanaSpot\` is enabled. Missing signer → warning + paper-spot fallback (gated for production use by the CLI safety check).

## CLI
- \`agent run --confirm-live\` for a basis-strategy in live mode now **REQUIRES** both HL signer **AND** Solana signer + \`solana.rpc_url\` config. Refuses to start otherwise.
- \`isBasisStrategy(name)\` centralises the "needs both legs" rule; \`funding_arb_basic\` registers as basis. New strategies opt in here.

## Daemon
\`cli.Serve\` passes \`cfg.Solana\` to \`agent.Loader\` so supervised live agents get the same SwapVenue wiring as foreground \`agent run\`.

## Real bug surfaced + fixed: partial-open
Live testing revealed the runtime previously reconciled a basis as 'open' even when one leg failed. A failed swap with a successful order would leave the strategy thinking it was hedged when it was actually directional via the perp.

\`executeSwap\` and \`executeOrder\` now return success bools. \`reconcileOpenBasis\` only marks a basis 'open' when **both** legs succeed; a failed close leaves the local view unchanged. Logs \`"partial open; skipping basis reconcile"\` with per-leg flags.

## Real bug surfaced + fixed: Jupiter URL
\`WithBaseURL("")\` is now a no-op so callers that pass an unset config field don't accidentally clear the default \`https://api.jup.ag\`. Caught when a live-mode tick produced \`Get "/swap/v1/quote?..."\` — relative URL, no scheme.

## Tests
- \`TestBuildSolanaSwapVenue_RequiresConfigAndSigner\`
- \`TestBuildSolanaSwapVenue_BuildsWithSolanaSigner\`
- \`TestBuildDeps_PopulatesSwapWhenSolanaConfigured\`
- \`TestBuildDeps_LeavesSwapNilWhenSolanaUnconfigured\`
- \`TestBuildDeps_DegradesWhenSolanaConfiguredButNoSigner\`
- \`TestSolanaSpot_IsEnabled\`
- \`TestReconcileOpenBasis_SkipsHalfOpenAfterFailedSwap\`
- \`TestReconcileOpenBasis_OpensOnlyWhenBothLegsSucceed\`

## Live verification (HL testnet + real Jupiter mainnet)

\`\`\`
=== paper agent: 2 swaps + 2 orders persisted (paper=true) — unchanged ===

=== live basis without Solana signer: refused ===
error: live mode for basis strategy "funding_arb_basic" requires a Solana signer

=== live basis with both signers (fresh unfunded Solana wallet) ===
swap quote failed err="jupiter: ...400: TOKEN_NOT_TRADABLE for WIF"   ← real Jupiter response
swap submit failed err="solana rpc -32002: Transaction simulation failed: ..." ← real Solana RPC
WARN partial open; skipping basis reconcile underlying=WIF spot_ok=false perp_ok=true
WARN partial open; skipping basis reconcile underlying=POPCAT spot_ok=false perp_ok=true

DB strategy_positions count: 0          ← no half-hedged ghost positions
HL wallet balance: $1020 USDC unchanged
\`\`\`

## Verify locally
\`\`\`
go test ./internal/agent/... -count=1 -v
docker compose -f deploy/compose/docker-compose.yml up -d
permafrost agent create --strategy funding_arb_basic --mode paper
permafrost agent run <id> --ticks 1
\`\`\`

## Out of scope (next)
- **Auto-cancel surviving leg on partial-open.** Right now we log + skip reconcile, but if the perp leg succeeded we leave a directional position resting at the venue. The kill-switch logic (\`runtime.Trip\`) handles this for explicit halts; surfacing it for transient partial-opens is a follow-up.
- **Mark-price-aware sizing for swaps.** Spot swap is sized in USDC (correct for Jupiter); perp size is base units derived from mark (PR #17). No change needed here.
- **The probe_unwind_test.go** is a manual "panic button" for cleaning up testnet positions. Useful, but not wired into a CLI subcommand yet.