### PR TITLE
fix: actually wire the risk engine — per-agent limits + intra-tick cap

### DIFF
--- a/internal/agent/builder.go
+++ b/internal/agent/builder.go
@@ -13,6 +13,7 @@ import (
 	"github.com/teslashibe/permafrost/internal/exchange"
 	"github.com/teslashibe/permafrost/internal/exchange/hyperliquid"
 	"github.com/teslashibe/permafrost/internal/inference"
+	"github.com/teslashibe/permafrost/internal/risk"
 	"github.com/teslashibe/permafrost/internal/strategy"
 	fab "github.com/teslashibe/permafrost/internal/strategy/funding_arb_basic"
 	"github.com/teslashibe/permafrost/internal/swap"
@@ -91,9 +92,71 @@ func BuildDeps(
 		Strategy: strat,
 		Perp:     venue,
 		Swap:     swapVenue,
+		Risk:     BuildRiskEngine(a),
 		Store:    store,
 		Logger:   log.With("agent_id", a.ID, "network", network, "mode", a.Mode),
 	}, nil
+}
+
+// BuildRiskEngine constructs a risk.Policy from the agent's persisted
+// risk-limit overrides (agent.Config["risk"] keys). Sensible defaults
+// fill in anything the operator omitted; passing zero everywhere
+// effectively disables checks (cap=0, exposure=0, etc.) — explicit opt-in.
+//
+// Recognised keys under agent.Config["risk"] (all optional):
+//
+//	max_concurrent_positions: int
+//	max_notional_per_leg:     decimal/string/number (USDC)
+//	max_total_basis_exposure: decimal/string/number (USDC)
+//	max_daily_loss:           decimal/string/number (USDC)
+//	max_spot_slippage_bps:    int
+//	max_drawdown:             decimal/string/number (fraction, e.g. 0.10 = 10%)
+//
+// The drawdown breaker is always installed; max_drawdown=0 disables it.
+// The daily-loss breaker is always installed; max_daily_loss=0 disables it.
+func BuildRiskEngine(a Agent) *risk.Policy {
+	limits := types.RiskLimits{}
+	maxDrawdown := decimal.Zero
+
+	if rawAny, ok := a.Config["risk"]; ok {
+		if rawMap, ok := rawAny.(map[string]any); ok {
+			if v, ok := rawMap["max_concurrent_positions"]; ok {
+				if i, err := intFromAny(v); err == nil {
+					limits.MaxConcurrentPositions = i
+				}
+			}
+			if v, ok := rawMap["max_notional_per_leg"]; ok {
+				if d, err := decimalFromAny(v); err == nil {
+					limits.MaxNotionalPerLeg = d
+				}
+			}
+			if v, ok := rawMap["max_total_basis_exposure"]; ok {
+				if d, err := decimalFromAny(v); err == nil {
+					limits.MaxTotalBasisExposure = d
+				}
+			}
+			if v, ok := rawMap["max_daily_loss"]; ok {
+				if d, err := decimalFromAny(v); err == nil {
+					limits.MaxDailyLoss = d
+				}
+			}
+			if v, ok := rawMap["max_spot_slippage_bps"]; ok {
+				if i, err := intFromAny(v); err == nil {
+					limits.MaxSpotSlippageBps = i
+				}
+			}
+			if v, ok := rawMap["max_drawdown"]; ok {
+				if d, err := decimalFromAny(v); err == nil {
+					maxDrawdown = d
+				}
+			}
+		}
+	}
+
+	return risk.NewPolicy(limits,
+		risk.MaxDrawdownBreaker{MaxFraction: maxDrawdown},
+		risk.DailyLossBreaker{},
+	)
 }
 
 // ErrNoSolanaSigner is returned by BuildSolanaSwapVenue when the

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -253,24 +253,83 @@ func (r *Runtime) persistDecision(ctx context.Context, now time.Time, decisionID
 // status but does not produce a basis-position row — leaving the strategy
 // free to retry on the next tick instead of believing it already has the
 // position.
+//
+// Risk PreTrade is evaluated per intent against a fresh PortfolioSnapshot
+// that includes any in-flight opens accepted earlier in this tick. This
+// matters for MaxConcurrentPositions: with cap=2 and the strategy
+// emitting 5 opens, the first 2 pass and the 3rd-5th get blocked.
+//
+// Inflight is tracked per-symbol (not just a count) so the perp order leg
+// for an already-accepted spot leg doesn't double-count against the cap —
+// they're two legs of one basis.
 func (r *Runtime) executeSwapsThenOrders(ctx context.Context, now time.Time, decisionID string, _ strategy.DecisionInput, dec strategy.Decision) {
-	swapOK := map[string]bool{}  // keyed by uppercased OUT-token symbol
-	orderOK := map[string]bool{} // keyed by uppercased perp symbol
+	swapOK := map[string]bool{}        // keyed by uppercased OUT-token symbol
+	orderOK := map[string]bool{}       // keyed by uppercased perp symbol
+	inflightOpens := map[string]bool{} // symbols whose open was accepted this tick
 
 	for i, s := range dec.Swaps {
-		if r.executeSwap(ctx, now, decisionID, i, s) {
-			swapOK[strings.ToUpper(s.OutToken.Symbol)] = true
+		snap := r.riskSnapshot(inflightOpens, "")
+		if r.executeSwap(ctx, now, decisionID, i, s, snap) {
+			key := strings.ToUpper(s.OutToken.Symbol)
+			swapOK[key] = true
+			if isOpeningSwap(s) {
+				inflightOpens[key] = true
+			}
 		}
 	}
 	for i, o := range dec.Orders {
-		if r.executeOrder(ctx, now, decisionID, i, o) {
-			orderOK[strings.ToUpper(o.Symbol)] = true
+		// If this order's perp leg is paired with a swap already accepted
+		// in this tick, exclude its symbol from the inflight count — the
+		// swap leg already claimed the cap slot for this basis.
+		key := strings.ToUpper(o.Symbol)
+		exclude := ""
+		if !o.ReduceOnly && o.Side == types.SideSell && inflightOpens[key] {
+			exclude = key
+		}
+		snap := r.riskSnapshot(inflightOpens, exclude)
+		if r.executeOrder(ctx, now, decisionID, i, o, snap) {
+			orderOK[key] = true
+			// If this order opened WITHOUT a paired swap (no inflight
+			// match), it counts as a brand-new open for subsequent
+			// intents in this tick.
+			if !o.ReduceOnly && o.Side == types.SideSell && !swapOK[key] {
+				inflightOpens[key] = true
+			}
 		}
 	}
 	for _, c := range dec.Cancels {
 		r.executeCancel(ctx, c)
 	}
 	r.reconcileOpenBasis(ctx, now, decisionID, dec, swapOK, orderOK)
+}
+
+// riskSnapshot builds a PortfolioSnapshot for risk evaluation. It includes
+// the runtime's currently-tracked open basis positions PLUS phantom
+// "opening" entries for symbols accepted earlier in this tick, so
+// MaxConcurrentPositions accumulates intra-tick. excludeSymbol (uppercase)
+// lets the perp leg of a paired open avoid double-counting its own swap.
+func (r *Runtime) riskSnapshot(inflightOpens map[string]bool, excludeSymbol string) types.PortfolioSnapshot {
+	snap := types.PortfolioSnapshot{
+		Time:      r.now(),
+		OpenBasis: r.snapshotOpenBasis(),
+	}
+	for sym := range inflightOpens {
+		if sym == excludeSymbol {
+			continue
+		}
+		snap.OpenBasis = append(snap.OpenBasis, types.BasisPosition{
+			Underlying: sym,
+			State:      types.BasisStateOpening,
+		})
+	}
+	return snap
+}
+
+// isOpeningSwap reports whether a SwapIntent represents the spot leg of
+// opening a new basis (USDC → non-USDC). Mirrors the helper in
+// risk/policy.go so the runtime can count opens consistently.
+func isOpeningSwap(s types.SwapIntent) bool {
+	return s.InToken.Symbol == "USDC" && s.OutToken.Symbol != "USDC"
 }
 
 // reconcileOpenBasis maintains the runtime's in-memory view of open basis
@@ -373,14 +432,18 @@ func (r *Runtime) reconcileOpenBasis(ctx context.Context, now time.Time, decisio
 // or confirmed on chain (live). A return of false means the basis pair
 // MUST NOT be reconciled into the open-basis set — the position would be
 // half-open at best, which is worse than retrying on the next tick.
-func (r *Runtime) executeSwap(ctx context.Context, now time.Time, decisionID string, slot int, s types.SwapIntent) bool {
+func (r *Runtime) executeSwap(ctx context.Context, now time.Time, decisionID string, slot int, s types.SwapIntent, snap types.PortfolioSnapshot) bool {
 	if s.ClientID == "" {
 		s.ClientID = clientIDFromSwap(r.agent.ID, decisionID, slot, s)
 	}
 	if r.deps.Risk != nil {
-		v := r.deps.Risk.PreTrade(ctx, r.agent.ID, s, types.PortfolioSnapshot{})
+		v := r.deps.Risk.PreTrade(ctx, r.agent.ID, s, snap)
 		if v.IsBlock() {
-			r.deps.Logger.Warn("swap blocked by risk", "agent_id", r.agent.ID, "reason", v.Reason)
+			r.deps.Logger.Warn("swap blocked by risk",
+				"agent_id", r.agent.ID,
+				"reason", v.Reason,
+				"detail", v.Detail,
+				"out_token", s.OutToken.Symbol)
 			return false
 		}
 	}
@@ -416,16 +479,20 @@ func (r *Runtime) executeSwap(ctx context.Context, now time.Time, decisionID str
 // executeOrder returns true iff the order was accepted (paper "open" or
 // live ack with non-rejected status). False means the basis pair must
 // not be reconciled.
-func (r *Runtime) executeOrder(ctx context.Context, now time.Time, decisionID string, slot int, o types.OrderIntent) bool {
+func (r *Runtime) executeOrder(ctx context.Context, now time.Time, decisionID string, slot int, o types.OrderIntent, snap types.PortfolioSnapshot) bool {
 	if o.ClientID == "" {
 		o.ClientID = types.DeriveClientID(r.agent.ID, decisionID, slot, o.Venue, o.Symbol, o.Side, o.Size)
 	}
 	o.DecisionID = decisionID
 	o.Slot = slot
 	if r.deps.Risk != nil {
-		v := r.deps.Risk.PreTrade(ctx, r.agent.ID, o, types.PortfolioSnapshot{})
+		v := r.deps.Risk.PreTrade(ctx, r.agent.ID, o, snap)
 		if v.IsBlock() {
-			r.deps.Logger.Warn("order blocked by risk", "agent_id", r.agent.ID, "reason", v.Reason)
+			r.deps.Logger.Warn("order blocked by risk",
+				"agent_id", r.agent.ID,
+				"reason", v.Reason,
+				"detail", v.Detail,
+				"symbol", o.Symbol)
 			return false
 		}
 	}

--- a/internal/agent/runtime_test.go
+++ b/internal/agent/runtime_test.go
@@ -8,10 +8,18 @@ import (
 	"github.com/shopspring/decimal"
 
 	exchangenoop "github.com/teslashibe/permafrost/internal/exchange/noop"
+	"github.com/teslashibe/permafrost/internal/risk"
 	"github.com/teslashibe/permafrost/internal/strategy"
 	swapnoop "github.com/teslashibe/permafrost/internal/swap/noop"
 	"github.com/teslashibe/permafrost/internal/types"
 )
+
+// risknew is a small helper for runtime tests: builds a risk.Policy with
+// just MaxConcurrentPositions set and no breakers (zero drawdown
+// disables it).
+func risknew(maxConcurrent int) *risk.Policy {
+	return risk.NewPolicy(types.RiskLimits{MaxConcurrentPositions: maxConcurrent})
+}
 
 // scriptedStrategy returns the same Decision every tick.
 type scriptedStrategy struct {
@@ -217,6 +225,92 @@ func TestReconcileOpenBasis_SkipsHalfOpenAfterFailedSwap(t *testing.T) {
 		map[string]bool{"WIF": true})       // orderOK: WIF placed
 	if got := len(r.snapshotOpenBasis()); got != 0 {
 		t.Errorf("expected NO basis when swap failed, got %d", got)
+	}
+}
+
+// TestTickOnce_RiskCapBlocksThirdOpenInSameTick is the integration
+// proof for the new wiring. Strategy emits 3 paired opens in one tick
+// with MaxConcurrentPositions=2 — only the first 2 should reach the
+// venue; the 3rd is blocked at the risk gate.
+func TestTickOnce_RiskCapBlocksThirdOpenInSameTick(t *testing.T) {
+	mk := func(sym string) (types.SwapIntent, types.OrderIntent) {
+		return types.SwapIntent{
+				Chain:    types.ChainSolana,
+				InToken:  types.Asset{Symbol: "USDC", Chain: types.ChainSolana},
+				OutToken: types.Asset{Symbol: sym, Chain: types.ChainSolana, Mint: sym + "_mint"},
+				InAmount: decimal.NewFromInt(100),
+			},
+			types.OrderIntent{
+				Venue: "hyperliquid", Symbol: sym, Side: types.SideSell,
+				Type: types.OrderTypeLimit, Price: decimal.NewFromInt(1), Size: decimal.NewFromInt(100),
+			}
+	}
+	swapWIF, orderWIF := mk("WIF")
+	swapBONK, orderBONK := mk("BONK")
+	swapPOPCAT, orderPOPCAT := mk("POPCAT")
+
+	dec := strategy.Decision{
+		Notes:  "open 3",
+		Swaps:  []types.SwapIntent{swapWIF, swapBONK, swapPOPCAT},
+		Orders: []types.OrderIntent{orderWIF, orderBONK, orderPOPCAT},
+	}
+
+	perp := exchangenoop.New()
+	swp := swapnoop.New()
+	a := Agent{ID: "a", Strategy: "x", Mode: ModeLive}
+
+	// Cap at 2 concurrent positions. No drawdown breaker (zero MaxFraction).
+	policy := risknew(2)
+
+	rt := NewRuntime(a, Deps{
+		Strategy: &scriptedStrategy{name: "x", decision: dec},
+		Perp:     perp,
+		Swap:     swp,
+		Risk:     policy,
+	})
+
+	if _, err := rt.TickOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Two pairs (WIF, BONK) should have hit the venues; POPCAT blocked.
+	if got := len(swp.Submitted()); got != 2 {
+		t.Errorf("swaps submitted: got %d want 2", got)
+	}
+	if got := len(perp.Placed()); got != 2 {
+		t.Errorf("orders placed: got %d want 2", got)
+	}
+
+	// Open basis (after reconcile) should be exactly 2.
+	if got := len(rt.snapshotOpenBasis()); got != 2 {
+		t.Errorf("open basis after tick: got %d want 2", got)
+	}
+}
+
+// TestTickOnce_RiskAllowsCloseAtCap: at cap, a reduce-only close MUST
+// still pass even though MaxConcurrentPositions is hit.
+func TestTickOnce_RiskAllowsCloseAtCap(t *testing.T) {
+	perp := exchangenoop.New()
+	a := Agent{ID: "a", Strategy: "x", Mode: ModeLive}
+
+	rt := NewRuntime(a, Deps{
+		Strategy: &scriptedStrategy{name: "x", decision: strategy.Decision{
+			Orders: []types.OrderIntent{{
+				Venue: "hyperliquid", Symbol: "WIF", Side: types.SideBuy,
+				ReduceOnly: true, Type: types.OrderTypeMarket, Size: decimal.NewFromInt(100),
+			}},
+		}},
+		Perp: perp,
+		Risk: risknew(1),
+	})
+	// Pre-fill openBasis to cap.
+	rt.openBasis["WIF"] = types.BasisPosition{Underlying: "WIF", State: types.BasisStateOpen}
+
+	if _, err := rt.TickOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(perp.Placed()); got != 1 {
+		t.Errorf("close should pass risk; got %d placed", got)
 	}
 }
 

--- a/internal/risk/policy.go
+++ b/internal/risk/policy.go
@@ -45,10 +45,15 @@ func (p *Policy) PreTrade(_ context.Context, _ string, intent any, snap types.Po
 }
 
 func (p *Policy) checkOrder(o types.OrderIntent, snap types.PortfolioSnapshot) types.Verdict {
-	// Per-leg notional ceiling
+	// Per-leg notional ceiling — applies to BOTH opens and closes.
 	if !p.limits.MaxNotionalPerLeg.IsZero() && o.Notional().GreaterThan(p.limits.MaxNotionalPerLeg) {
 		return block("max_notional_per_leg",
 			fmt.Sprintf("order notional %s > limit %s", o.Notional(), p.limits.MaxNotionalPerLeg))
+	}
+	// Closes (reduce-only) bypass the position-count and exposure caps —
+	// you must always be able to unwind, even if you're at the cap.
+	if o.ReduceOnly {
+		return allow()
 	}
 	// Total exposure ceiling
 	if !p.limits.MaxTotalBasisExposure.IsZero() {
@@ -58,7 +63,10 @@ func (p *Policy) checkOrder(o types.OrderIntent, snap types.PortfolioSnapshot) t
 				fmt.Sprintf("after-order exposure %s > limit %s", nextExposure, p.limits.MaxTotalBasisExposure))
 		}
 	}
-	// Concurrent positions ceiling (count distinct underlyings)
+	// Concurrent positions ceiling (count distinct underlyings).
+	// Only fires on NEW opens — and snap.OpenBasis is expected to include
+	// any in-flight opens accepted earlier in the same tick (the runtime
+	// is responsible for that bookkeeping).
 	if p.limits.MaxConcurrentPositions > 0 && len(snap.OpenBasis) >= p.limits.MaxConcurrentPositions {
 		return block("max_concurrent_positions",
 			fmt.Sprintf("open=%d limit=%d", len(snap.OpenBasis), p.limits.MaxConcurrentPositions))
@@ -66,7 +74,7 @@ func (p *Policy) checkOrder(o types.OrderIntent, snap types.PortfolioSnapshot) t
 	return allow()
 }
 
-func (p *Policy) checkSwap(s types.SwapIntent, _ types.PortfolioSnapshot) types.Verdict {
+func (p *Policy) checkSwap(s types.SwapIntent, snap types.PortfolioSnapshot) types.Verdict {
 	if p.limits.MaxSpotSlippageBps > 0 && s.SlippageBps > p.limits.MaxSpotSlippageBps {
 		return block("max_spot_slippage_bps",
 			fmt.Sprintf("requested %dbps > limit %dbps", s.SlippageBps, p.limits.MaxSpotSlippageBps))
@@ -79,7 +87,22 @@ func (p *Policy) checkSwap(s types.SwapIntent, _ types.PortfolioSnapshot) types.
 				fmt.Sprintf("swap in_amount %s > limit %s", notional, p.limits.MaxNotionalPerLeg))
 		}
 	}
+	// The opening leg of a basis is USDC→token. Closing is token→USDC.
+	// Only opening legs participate in the concurrent-positions cap so
+	// the runtime can always unwind even at cap.
+	if isOpeningSwap(s) && p.limits.MaxConcurrentPositions > 0 &&
+		len(snap.OpenBasis) >= p.limits.MaxConcurrentPositions {
+		return block("max_concurrent_positions",
+			fmt.Sprintf("open=%d limit=%d", len(snap.OpenBasis), p.limits.MaxConcurrentPositions))
+	}
 	return allow()
+}
+
+// isOpeningSwap reports whether a SwapIntent represents the spot leg of
+// opening a new basis position (USDC → non-USDC). Closing legs go the
+// other way and are never blocked by the position cap.
+func isOpeningSwap(s types.SwapIntent) bool {
+	return s.InToken.Symbol == "USDC" && s.OutToken.Symbol != "USDC"
 }
 
 // Portfolio walks the configured circuit breakers; any block stops the

--- a/internal/risk/policy_test.go
+++ b/internal/risk/policy_test.go
@@ -48,6 +48,44 @@ func TestPolicy_PreTrade_ConcurrentPositions(t *testing.T) {
 	}
 }
 
+// TestPolicy_PreTrade_ClosesAlwaysAllowed: even at cap, reduce-only
+// orders MUST pass — you have to be able to unwind.
+func TestPolicy_PreTrade_ClosesAlwaysAllowed(t *testing.T) {
+	p := NewPolicy(types.RiskLimits{MaxConcurrentPositions: 2})
+	snap := types.PortfolioSnapshot{
+		OpenBasis: []types.BasisPosition{{ID: "1"}, {ID: "2"}, {ID: "3"}}, // even over cap
+	}
+	close := types.OrderIntent{ReduceOnly: true}
+	v := p.PreTrade(context.Background(), "a", close, snap)
+	if v.IsBlock() {
+		t.Errorf("reduce-only order must pass at any open count, got %+v", v)
+	}
+}
+
+// TestPolicy_PreTrade_ClosingSwapAllowed: token→USDC swap is closing,
+// shouldn't be blocked by the position cap.
+func TestPolicy_PreTrade_ClosingSwapAllowed(t *testing.T) {
+	p := NewPolicy(types.RiskLimits{MaxConcurrentPositions: 1})
+	snap := types.PortfolioSnapshot{OpenBasis: []types.BasisPosition{{ID: "1"}}}
+	closingSwap := types.SwapIntent{
+		InToken:  types.Asset{Symbol: "WIF"},
+		OutToken: types.Asset{Symbol: "USDC"},
+		InAmount: d("100"),
+	}
+	if v := p.PreTrade(context.Background(), "a", closingSwap, snap); v.IsBlock() {
+		t.Errorf("closing swap must pass at cap, got %+v", v)
+	}
+
+	openingSwap := types.SwapIntent{
+		InToken:  types.Asset{Symbol: "USDC"},
+		OutToken: types.Asset{Symbol: "WIF"},
+		InAmount: d("100"),
+	}
+	if v := p.PreTrade(context.Background(), "a", openingSwap, snap); !v.IsBlock() {
+		t.Errorf("opening swap MUST be blocked at cap, got %+v", v)
+	}
+}
+
 func TestPolicy_PreTrade_SwapSlippage(t *testing.T) {
 	p := NewPolicy(types.RiskLimits{MaxSpotSlippageBps: 50})
 	intent := types.SwapIntent{SlippageBps: 100, InAmount: d("100")}


### PR DESCRIPTION
## Why

The \`MaxConcurrentPositions\` cap (and every other \`RiskLimits\` field) had been quietly inert since M9. \`agent.BuildDeps\` never populated \`Deps.Risk\`, so the runtime's nil-checked \`PreTrade\` calls were silent no-ops. Found during a code review prompted by the question "how many pairs can we have open?".

## Builder
- \`agent.BuildRiskEngine\` reads \`agent.Config["risk"]\` (jsonb) and constructs a \`risk.Policy\` per agent. Recognised keys:

| Key | Meaning |
|---|---|
| \`max_concurrent_positions\` | hard cap on distinct underlyings open at once |
| \`max_notional_per_leg\` | USDC ceiling per swap or order |
| \`max_total_basis_exposure\` | USDC ceiling on aggregate open exposure |
| \`max_daily_loss\` | drives the DailyLossBreaker |
| \`max_spot_slippage_bps\` | rejects swaps requesting > X bps |
| \`max_drawdown\` | drives the MaxDrawdownBreaker |

- \`BuildDeps\` populates \`Deps.Risk\` so the runtime's PreTrade calls actually fire.

## Risk policy
- **Closes (reduce-only orders + token→USDC swaps) bypass the cap.** You must always be able to unwind.
- **Opening swaps (USDC → non-USDC) participate in the cap** so the spot leg of a basis is gated even if the perp leg comes first.
- Per-leg notional ceiling still applies to both opens and closes.

## Runtime intra-tick accounting
- \`riskSnapshot\` includes the runtime's open basis PLUS phantom "opening" entries for symbols whose leg was accepted earlier in this tick. With cap=2 and the strategy emitting 5 opens, the first two pass and the 3rd–5th get blocked at both legs.
- \`inflightOpens\` is tracked per-symbol (not just a count) so the perp order leg of an already-accepted spot leg doesn't double-count — they're two legs of one basis. The \`riskSnapshot\` call for the order excludes its own symbol from the inflight set.
- Warnings now include \`reason\` + \`detail\` + affected symbol.

## Tests
- \`TestPolicy_PreTrade_ClosesAlwaysAllowed\` — at cap, reduce-only passes (3 OpenBasis vs cap=2 still allowed).
- \`TestPolicy_PreTrade_ClosingSwapAllowed\` — token→USDC passes at cap; USDC→token blocks at cap. Same snapshot, opposite verdict.
- \`TestTickOnce_RiskCapBlocksThirdOpenInSameTick\` — scripted 3 paired opens, cap=2 → only first 2 hit the venues, 3rd blocked at both swap and order legs. Final \`open_basis = 2\`.
- \`TestTickOnce_RiskAllowsCloseAtCap\` — at cap with one open, a reduce-only close still reaches the venue.

## End-to-end verified

Configured a paper agent with universe of 5 + risk cap = 2:

\`\`\`
$ permafrost agent run risk-cap-test --ticks 1
WARN swap blocked by risk reason=max_concurrent_positions detail="open=2 limit=2" out_token=GOAT
WARN swap blocked by risk reason=max_concurrent_positions detail="open=2 limit=2" out_token=FARTCOIN
WARN swap blocked by risk reason=max_concurrent_positions detail="open=2 limit=2" out_token=MOODENG
WARN order blocked by risk reason=max_concurrent_positions detail="open=2 limit=2" symbol=GOAT
WARN order blocked by risk reason=max_concurrent_positions detail="open=2 limit=2" symbol=FARTCOIN
WARN order blocked by risk reason=max_concurrent_positions detail="open=2 limit=2" symbol=MOODENG

DB: orders=2 (WIF, POPCAT), swaps=2, strategy_positions=2 (WIF, POPCAT)
\`\`\`

Then flipped the strategy's exit threshold to force closes:
\`\`\`
DB: 0 open / 2 closed   ← both closes passed risk even at cap
\`\`\`

## CLI ergonomics

Set risk on agent create with the existing \`--config-json\` flag:
\`\`\`
permafrost agent create \\
  --strategy funding_arb_basic --universe WIF,POPCAT,GOAT \\
  --config-json '{
    "entry_annualised_funding": 0.50,
    "position_cap_usdc": 100,
    "risk": {
      "max_concurrent_positions": 3,
      "max_notional_per_leg":     200,
      "max_total_basis_exposure": 500,
      "max_drawdown":             0.10,
      "max_daily_loss":           50
    }
  }'
\`\`\`

## Verify locally
\`\`\`
go test ./internal/agent/... ./internal/risk/... -count=1 -v
\`\`\`