### PR TITLE
feat: multi-chain EVM spot legs via 1inch v6 (Ethereum, Base, Avalanche, BSC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ See [`SCOPE.md`](SCOPE.md) for the full architectural specification.
 | Config | [`viper`](https://github.com/spf13/viper) (yaml + env) |
 | Logging | [`log/slog`](https://pkg.go.dev/log/slog) (stdlib) |
 | Perp venue | [Hyperliquid](https://hyperliquid.xyz/) |
-| Spot venue | [Solana](https://solana.com/) via [Jupiter](https://jup.ag/) aggregator |
-| MEV protection | [Jito](https://www.jito.wtf/) bundles |
+| Spot venues | [Solana](https://solana.com/) via [Jupiter](https://jup.ag/); EVM (Ethereum, Base, Avalanche, BSC) via [1inch](https://1inch.io/) v6 |
+| MEV protection | [Jito](https://www.jito.wtf/) bundles (Solana) |
 | Inference | OpenAI-compatible (works with OpenAI, OpenRouter, Groq, Together, vLLM, Ollama, etc.) |
 | Deploy | Docker + docker-compose |
 

--- a/SCOPE.md
+++ b/SCOPE.md
@@ -28,9 +28,11 @@ The whole MVP is built so a single operator can run it locally with `docker-comp
 | Config | `viper` (yaml + env) |
 | Logging | `log/slog` (stdlib, structured; JSON in prod, text in dev) |
 | Perp venue | Hyperliquid Go SDK |
-| Spot venue (v1) | Solana, via Jupiter aggregator |
+| Spot venues | Solana via Jupiter, EVM chains via 1inch v6 |
+| EVM chains (v1) | Ethereum, Base, Avalanche C-Chain, BNB Smart Chain |
 | Solana RPC | Helius (paid) or Triton |
-| MEV protection | Jito bundles (Solana) |
+| EVM RPC | Per-chain in `evm.chains.{name}.rpc_url`; public defaults work |
+| MEV protection | Jito bundles (Solana); private mempool deferred for EVM |
 | Inference | Single OpenAI-compatible client (works with OpenAI, OpenRouter, Groq, Together, Fireworks, vLLM, Ollama, LM Studio) |
 | Key management | Local encrypted JSON keystore, env-loaded passphrase |
 | Deploy | Docker + docker-compose, runs locally |
@@ -181,6 +183,17 @@ type QuoteRequest struct {
 ```
 
 Solana implementation routes through Jupiter and submits via Jito bundles for MEV protection.
+
+**Multi-chain (M19+):** the runtime carries a `map[ChainID]SwapVenue` rather than one venue, and routes each `SwapIntent` to the venue keyed by its `Chain` field. v1 ships with two adapters:
+
+| Chain | Adapter | Submission | MEV |
+|---|---|---|---|
+| Solana | Jupiter | Jito bundle (default) or RPC | bundle private mempool |
+| Ethereum / Base / Avalanche / BSC | 1inch v6 | EIP-1559 (ETH/Base) / legacy (AVAX/BSC) raw tx | none in v1; private mempools deferred |
+
+The 1inch adapter is one Go package (`internal/swap/oneinch`) that constructs one `Venue` per EVM chain. All four EVM venues share the same secp256k1 keypair (the one already used to sign Hyperliquid actions) — operators manage one secret across all five chains. ERC-20 approvals follow a plain `approve(MAX)` pattern, cached per `(chain, token)` pair so subsequent swaps skip the on-chain check.
+
+Native gas-token swaps (ETH/AVAX/BNB ↔ ERC-20) are deferred — v1 routes only ERC-20 ↔ ERC-20.
 
 ### 4.4 Inference provider
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -48,3 +48,23 @@ solana:
   jito_bundle_url: https://mainnet.block-engine.jito.wtf/api/v1/bundles
   priority_fee_micro_lamports: 0                       # 0 = no priority fee
   confirmation_timeout_secs: 90
+
+evm:
+  # Multi-chain spot legs via 1inch v6. One free API key works across
+  # every chain — get one at https://portal.1inch.dev .
+  oneinch_api_key_env: ONEINCH_API_KEY    # env var name; takes precedence over oneinch_api_key below
+  oneinch_api_key: ""                     # inline (avoid; prefer the env var)
+  oneinch_base_url: ""                    # leave empty for the public api.1inch.dev
+  default_slippage_bps: 50                # 0.5% — applied when SwapIntent.SlippageBps is unset
+  confirmation_timeout_secs: 90
+  chains:
+    # Omit a chain to disable it. The runtime falls back to paper-spot
+    # (records intent, never broadcasts) for any chain not listed here.
+    ethereum:
+      rpc_url: https://ethereum-rpc.publicnode.com
+    base:
+      rpc_url: https://mainnet.base.org
+    avalanche:
+      rpc_url: https://api.avax.network/ext/bc/C/rpc
+    bsc:
+      rpc_url: https://bsc-rpc.publicnode.com

--- a/internal/agent/builder.go
+++ b/internal/agent/builder.go
@@ -18,6 +18,7 @@ import (
 	fab "github.com/teslashibe/permafrost/internal/strategy/funding_arb_basic"
 	"github.com/teslashibe/permafrost/internal/swap"
 	"github.com/teslashibe/permafrost/internal/swap/jupiter"
+	"github.com/teslashibe/permafrost/internal/swap/oneinch"
 	"github.com/teslashibe/permafrost/internal/types"
 	"github.com/teslashibe/permafrost/internal/wallet"
 )
@@ -69,17 +70,18 @@ func BuildDeps(
 		log = slog.Default()
 	}
 
-	// Build the spot SwapVenue if Solana config is provided. We only
-	// surface the venue when both RPC and a Solana signer are available;
-	// without a signer there's nothing to sign Jupiter swap transactions
-	// with, so leaving it nil is the only safe choice (runtime falls
-	// back to paper-spot recording).
-	var swapVenue swap.SwapVenue
+	// Build per-chain SwapVenues. A chain is wired iff:
+	//   1) the operator supplied the chain config (RPC URL etc.), AND
+	//   2) the keystore has the appropriate signer.
+	// Missing chains downgrade to paper-spot bookkeeping (the runtime
+	// records the swap intent but doesn't broadcast).
+	swaps := map[types.ChainID]swap.SwapVenue{}
+
 	if opts.Solana.IsEnabled() {
 		v, err := BuildSolanaSwapVenue(opts.Solana, keystore)
 		switch {
 		case err == nil:
-			swapVenue = v
+			swaps[types.ChainSolana] = v
 		case errors.Is(err, ErrNoSolanaSigner):
 			log.Warn("solana swap disabled: no Solana signer in keystore",
 				"agent_id", a.ID)
@@ -88,10 +90,26 @@ func BuildDeps(
 		}
 	}
 
+	for chainID, ec := range opts.EVM {
+		if !ec.IsEnabled() {
+			continue
+		}
+		v, err := BuildEVMSwapVenue(chainID, ec, keystore)
+		switch {
+		case err == nil:
+			swaps[chainID] = v
+		case errors.Is(err, wallet.ErrNoEVMSigner):
+			log.Warn("evm swap disabled: no EVM-capable signer in keystore",
+				"agent_id", a.ID, "chain", chainID)
+		default:
+			return Deps{}, fmt.Errorf("evm swap venue %s: %w", chainID, err)
+		}
+	}
+
 	return Deps{
 		Strategy: strat,
 		Perp:     venue,
-		Swap:     swapVenue,
+		Swaps:    swaps,
 		Risk:     BuildRiskEngine(a),
 		Store:    store,
 		Logger:   log.With("agent_id", a.ID, "network", network, "mode", a.Mode),
@@ -202,13 +220,18 @@ func BuildSolanaSwapVenue(cfg SolanaSpot, keystore wallet.Keystore) (swap.SwapVe
 // `agent run` command's --network flag. The daemon supervisor leaves it
 // empty so each agent runs on its own configured network.
 //
-// Solana enables the live spot leg. When zero, the Runtime falls back
-// to paper-spot (records intent, never quotes Jupiter, never broadcasts).
-// Required for any agent that emits SwapIntents in mode=live.
+// Solana enables the live spot leg on Solana via Jupiter.
+// EVM enables live spot legs on EVM chains via 1inch — keyed by
+// ChainEthereum / ChainBase / ChainAvalanche / ChainBSC.
+//
+// When a chain's config is missing or its IsEnabled() is false the
+// Runtime falls back to paper-spot for that chain (records intent,
+// never quotes/broadcasts).
 type BuildOptions struct {
 	HyperliquidNetwork string // empty → use Agent.Network
 	HyperliquidAddress string // empty → derive from keystore (or no address)
 	Solana             SolanaSpot
+	EVM                map[types.ChainID]EVMSpot
 }
 
 // SolanaSpot captures everything the Jupiter SwapVenue needs to settle
@@ -227,6 +250,42 @@ type SolanaSpot struct {
 // IsEnabled reports whether the operator has provided enough config for
 // the SwapVenue to be constructed. RPCURL is the bare minimum.
 func (s SolanaSpot) IsEnabled() bool { return s.RPCURL != "" }
+
+// EVMSpot captures one EVM chain's swap configuration: an RPC endpoint
+// + 1inch API key. The signer is sourced from the keystore (the same
+// secp256k1 key as Hyperliquid).
+type EVMSpot struct {
+	RPCURL                  string
+	OneInchAPIKey           string
+	OneInchBaseURL          string // optional override (proxy)
+	DefaultSlippageBps      int    // default slippage if SwapIntent doesn't set one (0 ⇒ 50)
+	ConfirmationTimeoutSecs int    // 0 ⇒ 90s
+}
+
+// IsEnabled reports whether the operator has provided enough config for
+// the EVM SwapVenue to be constructed.
+func (e EVMSpot) IsEnabled() bool { return e.RPCURL != "" && e.OneInchAPIKey != "" }
+
+// BuildEVMSwapVenue constructs a 1inch-backed SwapVenue for one EVM
+// chain. Returns wallet.ErrNoEVMSigner if the keystore has no
+// EVM-capable key.
+func BuildEVMSwapVenue(chain types.ChainID, cfg EVMSpot, keystore wallet.Keystore) (swap.SwapVenue, error) {
+	if !cfg.IsEnabled() {
+		return nil, fmt.Errorf("agent: EVMSpot for %s is not configured", chain)
+	}
+	signer, err := wallet.EVMSignerFromKeystore(keystore, chain)
+	if err != nil {
+		return nil, err
+	}
+	return oneinch.New(oneinch.Config{
+		OneInchAPIKey:   cfg.OneInchAPIKey,
+		OneInchBaseURL:  cfg.OneInchBaseURL,
+		RPCURL:          cfg.RPCURL,
+		Chain:           chain,
+		DefaultSlippage: cfg.DefaultSlippageBps,
+		PollTimeout:     time.Duration(cfg.ConfirmationTimeoutSecs) * time.Second,
+	}, signer)
+}
 
 // BuildStrategy is the strategy-construction switch shared between the
 // foreground CLI and the supervisor. Currently funding_arb_basic is the

--- a/internal/agent/builder_test.go
+++ b/internal/agent/builder_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/teslashibe/permafrost/internal/assets"
+	"github.com/teslashibe/permafrost/internal/types"
 	walletnoop "github.com/teslashibe/permafrost/internal/wallet/noop"
 )
 
@@ -200,8 +201,8 @@ func TestBuildDeps_PopulatesSwapWhenSolanaConfigured(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if deps.Swap == nil {
-		t.Fatal("expected Deps.Swap to be populated")
+	if deps.SwapVenueForChain(types.ChainSolana) == nil {
+		t.Fatal("expected Deps.Swaps[solana] to be populated")
 	}
 	if deps.Perp == nil {
 		t.Fatal("expected Deps.Perp to be populated")
@@ -215,8 +216,11 @@ func TestBuildDeps_LeavesSwapNilWhenSolanaUnconfigured(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if deps.Swap != nil {
-		t.Error("Swap should be nil when Solana is unconfigured (paper-spot fallback)")
+	if deps.SwapVenueForChain(types.ChainSolana) != nil {
+		t.Error("Solana venue should be nil when unconfigured (paper-spot fallback)")
+	}
+	if len(deps.Swaps) != 0 {
+		t.Errorf("Swaps map should be empty, got %d entries", len(deps.Swaps))
 	}
 }
 
@@ -229,8 +233,27 @@ func TestBuildDeps_DegradesWhenSolanaConfiguredButNoSigner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildDeps should not error when degrading to paper-spot: %v", err)
 	}
-	if deps.Swap != nil {
-		t.Error("Swap should be nil when no Solana signer available")
+	if deps.SwapVenueForChain(types.ChainSolana) != nil {
+		t.Error("Solana venue should be nil when no Solana signer available")
+	}
+}
+
+// TestBuildDeps_DegradesWhenEVMConfiguredButNoSigner verifies the same
+// graceful-degradation pattern for EVM chains: configured but no
+// keystore = warn + skip, never error.
+func TestBuildDeps_DegradesWhenEVMConfiguredButNoSigner(t *testing.T) {
+	reg, _ := assets.LoadEmbedded()
+	a := Agent{ID: "ag", Strategy: "funding_arb_basic", Universe: []string{"WIF"}}
+	deps, err := BuildDeps(a, reg, nil, nil, nil, BuildOptions{
+		EVM: map[types.ChainID]EVMSpot{
+			types.ChainBase: {RPCURL: "https://mainnet.base.org", OneInchAPIKey: "stub"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildDeps should not error when degrading EVM to paper-spot: %v", err)
+	}
+	if deps.SwapVenueForChain(types.ChainBase) != nil {
+		t.Error("Base venue should be nil when no EVM signer available")
 	}
 }
 
@@ -240,6 +263,21 @@ func TestSolanaSpot_IsEnabled(t *testing.T) {
 	}
 	if !(SolanaSpot{RPCURL: "x"}).IsEnabled() {
 		t.Error("RPCURL alone must enable")
+	}
+}
+
+func TestEVMSpot_IsEnabled(t *testing.T) {
+	if (EVMSpot{}).IsEnabled() {
+		t.Error("zero EVMSpot must be disabled")
+	}
+	if (EVMSpot{RPCURL: "x"}).IsEnabled() {
+		t.Error("RPCURL alone is not enough; need API key")
+	}
+	if (EVMSpot{OneInchAPIKey: "k"}).IsEnabled() {
+		t.Error("API key alone is not enough; need RPC URL")
+	}
+	if !(EVMSpot{RPCURL: "x", OneInchAPIKey: "k"}).IsEnabled() {
+		t.Error("RPCURL + API key must enable")
 	}
 }
 

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -26,13 +26,33 @@ import (
 // The intention is one Runtime per Agent; the Supervisor builds Deps from
 // the global registries (venues, inference, etc.).
 type Deps struct {
-	Strategy   strategy.Strategy
-	Perp       exchange.Venue
-	Swap       swap.SwapVenue
-	Inference  inference.Provider
-	Risk       risk.Engine
-	Store      *Store
-	Logger     *slog.Logger
+	Strategy strategy.Strategy
+	Perp     exchange.Venue
+
+	// Swaps routes a SwapIntent to the appropriate on-chain venue by
+	// the intent's Chain field. v1 supports:
+	//   - types.ChainSolana    → Jupiter (internal/swap/jupiter)
+	//   - types.ChainEthereum  → 1inch
+	//   - types.ChainBase      → 1inch
+	//   - types.ChainAvalanche → 1inch
+	//   - types.ChainBSC       → 1inch
+	// Empty map / missing entry for a given chain → the runtime
+	// downgrades that intent to paper-spot bookkeeping.
+	Swaps map[types.ChainID]swap.SwapVenue
+
+	Inference inference.Provider
+	Risk      risk.Engine
+	Store     *Store
+	Logger    *slog.Logger
+}
+
+// SwapVenueForChain returns the venue routed for the given chain or nil
+// if none is configured.
+func (d Deps) SwapVenueForChain(c types.ChainID) swap.SwapVenue {
+	if d.Swaps == nil {
+		return nil
+	}
+	return d.Swaps[c]
 }
 
 // Runtime drives the tick loop for one Agent.
@@ -172,13 +192,16 @@ func (r *Runtime) tickOnce(ctx context.Context) (strategy.Decision, error) {
 
 	// One concise per-tick log so operators can see the daemon working
 	// without enabling debug. This is the only INFO line emitted per tick.
+	// open_basis is the post-tick count (after reconcile), not the
+	// pre-tick snapshot — operators care about "what state did this tick
+	// leave us in".
 	r.deps.Logger.Info("tick",
 		"agent_id", r.agent.ID,
 		"decision_id", decisionID,
 		"swaps", len(dec.Swaps),
 		"orders", len(dec.Orders),
 		"cancels", len(dec.Cancels),
-		"open_basis", len(in.BasisPositions),
+		"open_basis", len(r.snapshotOpenBasis()),
 	)
 	return dec, nil
 }
@@ -259,18 +282,20 @@ func (r *Runtime) persistDecision(ctx context.Context, now time.Time, decisionID
 // matters for MaxConcurrentPositions: with cap=2 and the strategy
 // emitting 5 opens, the first 2 pass and the 3rd-5th get blocked.
 //
-// Inflight is tracked per-symbol (not just a count) so the perp order leg
-// for an already-accepted spot leg doesn't double-count against the cap —
-// they're two legs of one basis.
+// Inflight + success are tracked per BasisKey when the strategy supplies
+// it (multi-chain pairs like ETH-BASE need an explicit key because the
+// spot OutToken.Symbol differs from the perp Symbol). Falls back to the
+// symbol-based key for legacy/single-chain strategies that don't set
+// BasisKey.
 func (r *Runtime) executeSwapsThenOrders(ctx context.Context, now time.Time, decisionID string, _ strategy.DecisionInput, dec strategy.Decision) {
-	swapOK := map[string]bool{}        // keyed by uppercased OUT-token symbol
-	orderOK := map[string]bool{}       // keyed by uppercased perp symbol
-	inflightOpens := map[string]bool{} // symbols whose open was accepted this tick
+	swapOK := map[string]bool{}        // keyed by basis key (or out-token symbol if missing)
+	orderOK := map[string]bool{}       // keyed by basis key (or perp symbol if missing)
+	inflightOpens := map[string]bool{} // basis keys (or symbols) accepted this tick
 
 	for i, s := range dec.Swaps {
 		snap := r.riskSnapshot(inflightOpens, "")
 		if r.executeSwap(ctx, now, decisionID, i, s, snap) {
-			key := strings.ToUpper(s.OutToken.Symbol)
+			key := swapBasisKey(s)
 			swapOK[key] = true
 			if isOpeningSwap(s) {
 				inflightOpens[key] = true
@@ -279,9 +304,9 @@ func (r *Runtime) executeSwapsThenOrders(ctx context.Context, now time.Time, dec
 	}
 	for i, o := range dec.Orders {
 		// If this order's perp leg is paired with a swap already accepted
-		// in this tick, exclude its symbol from the inflight count — the
-		// swap leg already claimed the cap slot for this basis.
-		key := strings.ToUpper(o.Symbol)
+		// in this tick (same BasisKey), exclude that key from the inflight
+		// count — the swap leg already claimed the cap slot for this basis.
+		key := orderBasisKey(o)
 		exclude := ""
 		if !o.ReduceOnly && o.Side == types.SideSell && inflightOpens[key] {
 			exclude = key
@@ -301,6 +326,26 @@ func (r *Runtime) executeSwapsThenOrders(ctx context.Context, now time.Time, dec
 		r.executeCancel(ctx, c)
 	}
 	r.reconcileOpenBasis(ctx, now, decisionID, dec, swapOK, orderOK)
+}
+
+// swapBasisKey returns the canonical basis-pair key for a swap intent.
+// Strategies that emit paired swap+order intents set BasisKey; we
+// fall back to OutToken.Symbol so older single-chain code still works.
+func swapBasisKey(s types.SwapIntent) string {
+	if s.BasisKey != "" {
+		return strings.ToUpper(s.BasisKey)
+	}
+	return strings.ToUpper(s.OutToken.Symbol)
+}
+
+// orderBasisKey returns the canonical basis-pair key for an order intent.
+// Strategies that emit paired swap+order intents set BasisKey; we fall
+// back to Symbol so single-symbol-equals-everything strategies still work.
+func orderBasisKey(o types.OrderIntent) string {
+	if o.BasisKey != "" {
+		return strings.ToUpper(o.BasisKey)
+	}
+	return strings.ToUpper(o.Symbol)
 }
 
 // riskSnapshot builds a PortfolioSnapshot for risk evaluation. It includes
@@ -348,14 +393,16 @@ func (r *Runtime) reconcileOpenBasis(ctx context.Context, now time.Time, decisio
 	defer r.posMu.Unlock()
 
 	// Closes first — for any reduce-only order where we already track an
-	// open basis on that symbol, drop it. This matches funding_arb_basic's
-	// closeIntents shape (reduce-only buy + spot→USDC swap).
+	// open basis on that BasisKey (or perp symbol fallback), drop it.
+	// This matches funding_arb_basic's closeIntents shape (reduce-only
+	// buy + spot→USDC swap).
 	for _, o := range dec.Orders {
 		if !o.ReduceOnly {
 			continue
 		}
-		key := strings.ToUpper(o.Symbol)
-		if _, ok := r.openBasis[key]; !ok {
+		key := orderBasisKey(o)
+		bp, ok := r.openBasis[key]
+		if !ok {
 			continue
 		}
 		// Only close on a successful reduce-only order; a failed close
@@ -363,32 +410,34 @@ func (r *Runtime) reconcileOpenBasis(ctx context.Context, now time.Time, decisio
 		// drop our local view.
 		if orderOK != nil && !orderOK[key] {
 			r.deps.Logger.Warn("close intent failed; basis remains open in our view",
-				"agent_id", r.agent.ID, "underlying", o.Symbol)
+				"agent_id", r.agent.ID, "underlying", bp.Underlying)
 			continue
 		}
 		delete(r.openBasis, key)
 		if r.deps.Store != nil {
-			if err := r.deps.Store.CloseBasis(ctx, r.agent.ID, o.Symbol); err != nil && !errors.Is(err, ErrNoOpenBasis) {
+			if err := r.deps.Store.CloseBasis(ctx, r.agent.ID, bp.Underlying); err != nil && !errors.Is(err, ErrNoOpenBasis) {
 				r.deps.Logger.Warn("persist close basis failed",
-					"agent_id", r.agent.ID, "underlying", o.Symbol, "err", err)
+					"agent_id", r.agent.ID, "underlying", bp.Underlying, "err", err)
 			}
 		}
 	}
 
-	// Opens — pair non-reduce-only sell orders with USDC→token swaps in the
-	// same Decision.
-	swapsByOut := map[string]types.SwapIntent{}
+	// Opens — pair USDC→token swaps with non-reduce-only sell orders by
+	// BasisKey. Strategies that don't set BasisKey fall back to symbol
+	// matching (out-token symbol == perp symbol), which still works for
+	// single-chain Solana entries where they coincide.
+	swapsByKey := map[string]types.SwapIntent{}
 	for _, s := range dec.Swaps {
 		if s.InToken.Symbol == "USDC" && s.OutToken.Symbol != "USDC" {
-			swapsByOut[strings.ToUpper(s.OutToken.Symbol)] = s
+			swapsByKey[swapBasisKey(s)] = s
 		}
 	}
 	for _, o := range dec.Orders {
 		if o.ReduceOnly || o.Side != types.SideSell {
 			continue
 		}
-		key := strings.ToUpper(o.Symbol)
-		s, ok := swapsByOut[key]
+		key := orderBasisKey(o)
+		s, ok := swapsByKey[key]
 		if !ok {
 			continue
 		}
@@ -403,14 +452,21 @@ func (r *Runtime) reconcileOpenBasis(ctx context.Context, now time.Time, decisio
 		perpSucceeded := orderOK == nil || orderOK[key]
 		if !spotSucceeded || !perpSucceeded {
 			r.deps.Logger.Warn("partial open; skipping basis reconcile",
-				"agent_id", r.agent.ID, "underlying", o.Symbol,
+				"agent_id", r.agent.ID, "basis_key", key,
 				"spot_ok", spotSucceeded, "perp_ok", perpSucceeded)
 			continue
+		}
+		// underlying is the BasisKey when the strategy supplied one
+		// (so multi-chain entries are uniquely named like ETH-BASE);
+		// otherwise the perp symbol, preserving v1 behaviour.
+		underlying := o.Symbol
+		if o.BasisKey != "" {
+			underlying = o.BasisKey
 		}
 		bp := types.BasisPosition{
 			ID:         "bp:" + r.agent.ID + ":" + key + ":" + safeShortID(decisionID),
 			AgentID:    r.agent.ID,
-			Underlying: o.Symbol,
+			Underlying: underlying,
 			State:      types.BasisStateOpen,
 			OpenedAt:   now,
 			Legs: []types.BasisLeg{
@@ -447,32 +503,37 @@ func (r *Runtime) executeSwap(ctx context.Context, now time.Time, decisionID str
 			return false
 		}
 	}
-	if r.agent.Mode == ModePaper || r.deps.Swap == nil {
-		r.recordSwap(ctx, now, decisionID, s, "", types.SwapStatusConfirmed, true, s.InAmount, decimal.Zero)
+	venue := r.deps.SwapVenueForChain(s.Chain)
+	if r.agent.Mode == ModePaper || venue == nil {
+		dex := ""
+		if venue != nil {
+			dex = venue.Name()
+		}
+		r.recordSwapWithDEX(ctx, now, decisionID, s, dex, "", types.SwapStatusConfirmed, true, s.InAmount, decimal.Zero)
 		return true
 	}
 
-	q, err := r.deps.Swap.Quote(ctx, types.QuoteRequest{
+	q, err := venue.Quote(ctx, types.QuoteRequest{
 		InToken: s.InToken, OutToken: s.OutToken, Amount: s.InAmount, Mode: types.QuoteExactIn,
 	})
 	if err != nil {
-		r.deps.Logger.Error("swap quote failed", "err", err)
-		r.recordSwap(ctx, now, decisionID, s, "", types.SwapStatusFailed, false, decimal.Zero, decimal.Zero)
+		r.deps.Logger.Error("swap quote failed", "chain", s.Chain, "err", err)
+		r.recordSwapWithDEX(ctx, now, decisionID, s, venue.Name(), "", types.SwapStatusFailed, false, decimal.Zero, decimal.Zero)
 		return false
 	}
-	tx, err := r.deps.Swap.Swap(ctx, q, s.SlippageBps)
+	tx, err := venue.Swap(ctx, q, s.SlippageBps)
 	if err != nil {
-		r.deps.Logger.Error("swap submit failed", "err", err)
-		r.recordSwap(ctx, now, decisionID, s, "", types.SwapStatusFailed, false, decimal.Zero, decimal.Zero)
+		r.deps.Logger.Error("swap submit failed", "chain", s.Chain, "err", err)
+		r.recordSwapWithDEX(ctx, now, decisionID, s, venue.Name(), "", types.SwapStatusFailed, false, decimal.Zero, decimal.Zero)
 		return false
 	}
-	res, err := r.deps.Swap.WaitConfirm(ctx, tx)
+	res, err := venue.WaitConfirm(ctx, tx)
 	if err != nil {
-		r.deps.Logger.Error("swap confirm failed", "err", err)
-		r.recordSwap(ctx, now, decisionID, s, string(tx), types.SwapStatusFailed, false, decimal.Zero, decimal.Zero)
+		r.deps.Logger.Error("swap confirm failed", "chain", s.Chain, "err", err)
+		r.recordSwapWithDEX(ctx, now, decisionID, s, venue.Name(), string(tx), types.SwapStatusFailed, false, decimal.Zero, decimal.Zero)
 		return false
 	}
-	r.recordSwap(ctx, now, decisionID, s, string(res.TxHash), res.Status, false, res.OutAmount, res.GasNative)
+	r.recordSwapWithDEX(ctx, now, decisionID, s, venue.Name(), string(res.TxHash), res.Status, false, res.OutAmount, res.GasNative)
 	return res.Status == types.SwapStatusConfirmed
 }
 
@@ -520,12 +581,19 @@ func (r *Runtime) executeCancel(ctx context.Context, id types.OrderID) {
 }
 
 func (r *Runtime) recordSwap(ctx context.Context, now time.Time, decisionID string, s types.SwapIntent, txHash string, status types.SwapStatus, paper bool, outAmt, gas decimal.Decimal) {
+	r.recordSwapWithDEX(ctx, now, decisionID, s, "", txHash, status, paper, outAmt, gas)
+}
+
+// recordSwapWithDEX persists a swap with an explicit DEX label (the
+// venue's Name() if known). The variant exists so multi-chain routing
+// can record the right venue per chain instead of always pointing at
+// the first one in the map.
+func (r *Runtime) recordSwapWithDEX(ctx context.Context, now time.Time, decisionID string, s types.SwapIntent, dex, txHash string, status types.SwapStatus, paper bool, outAmt, gas decimal.Decimal) {
 	if r.deps.Store == nil {
 		return
 	}
-	dex := "noop"
-	if r.deps.Swap != nil {
-		dex = r.deps.Swap.Name()
+	if dex == "" {
+		dex = "noop"
 	}
 	if err := r.deps.Store.PersistSwap(ctx, PersistSwapInput{
 		Time:        now,

--- a/internal/agent/runtime_test.go
+++ b/internal/agent/runtime_test.go
@@ -10,6 +10,7 @@ import (
 	exchangenoop "github.com/teslashibe/permafrost/internal/exchange/noop"
 	"github.com/teslashibe/permafrost/internal/risk"
 	"github.com/teslashibe/permafrost/internal/strategy"
+	"github.com/teslashibe/permafrost/internal/swap"
 	swapnoop "github.com/teslashibe/permafrost/internal/swap/noop"
 	"github.com/teslashibe/permafrost/internal/types"
 )
@@ -56,7 +57,7 @@ func TestTickOnce_PaperMode_RecordsButDoesNotCallVenues(t *testing.T) {
 	r := NewRuntime(a, Deps{
 		Strategy: strat,
 		Perp:     perp,
-		Swap:     swp,
+		Swaps:    map[types.ChainID]swap.SwapVenue{types.ChainSolana: swp},
 	})
 	r.SetClock(func() time.Time { return time.Unix(1_700_000_000, 0).UTC() })
 
@@ -97,7 +98,7 @@ func TestTickOnce_LiveMode_CallsVenues(t *testing.T) {
 	r := NewRuntime(a, Deps{
 		Strategy: strat,
 		Perp:     perp,
-		Swap:     swp,
+		Swaps:    map[types.ChainID]swap.SwapVenue{types.ChainSolana: swp},
 	})
 
 	if _, err := r.TickOnce(context.Background()); err != nil {
@@ -265,7 +266,7 @@ func TestTickOnce_RiskCapBlocksThirdOpenInSameTick(t *testing.T) {
 	rt := NewRuntime(a, Deps{
 		Strategy: &scriptedStrategy{name: "x", decision: dec},
 		Perp:     perp,
-		Swap:     swp,
+		Swaps:    map[types.ChainID]swap.SwapVenue{types.ChainSolana: swp},
 		Risk:     policy,
 	})
 

--- a/internal/assets/registry.yaml
+++ b/internal/assets/registry.yaml
@@ -102,3 +102,59 @@ assets:
       mint: Df6yfrKC8kZE3KNkrHERKzAetSxbrWeniQfyJY4Jpump
       decimals: 6
     notes: Just a chill guy.
+
+  # ─── EVM-spot entries (paired with Hyperliquid perps) ──────────────────
+  # Naming convention: <PERP>-<CHAIN-SHORT>. The strategy uses the
+  # symbol's spot.chain field to pick which SwapVenue to route through,
+  # so an agent can hedge HL's ETH perp via either ETH-mainnet spot or
+  # ETH-base spot depending on which has fewer fees.
+
+  - symbol: ETH-MAINNET
+    perp:
+      venue: hyperliquid
+      symbol: ETH
+    spot:
+      chain: ethereum
+      mint: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"  # WETH (1inch wraps native automatically)
+      decimals: 18
+    notes: Hedge HL ETH perp via WETH on Ethereum mainnet.
+
+  - symbol: ETH-BASE
+    perp:
+      venue: hyperliquid
+      symbol: ETH
+    spot:
+      chain: base
+      mint: "0x4200000000000000000000000000000000000006"  # WETH on Base
+      decimals: 18
+    notes: Hedge HL ETH perp via WETH on Base — typically 100x cheaper gas.
+
+  - symbol: BTC-MAINNET
+    perp:
+      venue: hyperliquid
+      symbol: BTC
+    spot:
+      chain: ethereum
+      mint: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"  # WBTC
+      decimals: 8
+    notes: Hedge HL BTC perp via WBTC on Ethereum mainnet.
+
+  - symbol: AVAX-MAINNET
+    perp:
+      venue: hyperliquid
+      symbol: AVAX
+    spot:
+      chain: avalanche
+      mint: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7"  # WAVAX
+      decimals: 18
+    notes: Hedge HL AVAX perp via WAVAX on Avalanche C-Chain.
+
+  - symbol: BNB-MAINNET
+    perp:
+      venue: hyperliquid
+      symbol: BNB
+    spot:
+      chain: bsc
+      mint: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c"  # WBNB
+      decimals: 18
+    notes: Hedge HL BNB perp via WBNB on BSC.

--- a/internal/chain/evm/chains.go
+++ b/internal/chain/evm/chains.go
@@ -1,0 +1,116 @@
+// Package evm wraps the JSON-RPC, signing, and ERC-20 calldata pieces
+// that Permafrost needs to settle spot legs on EVM chains via DEX
+// aggregators (1inch, 0x, etc.).
+//
+// Design rule: this package speaks raw JSON-RPC and produces hex-encoded
+// calldata only. It does NOT pull in go-ethereum's full client/abi
+// machinery — calldata for the few ERC-20 selectors we use is hand-built
+// in erc20.go. This keeps the dependency surface small and matches the
+// philosophy of internal/chain/solana.
+package evm
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// Chain captures the static metadata for one EVM chain.
+type Chain struct {
+	ID          types.ChainID // permafrost-internal name (e.g. "base")
+	NumericID   uint64        // EIP-155 chain id (e.g. 8453 for Base)
+	Native      string        // native gas token ticker (e.g. "ETH", "BNB")
+	NativeDec   int32         // native token decimals (always 18 for the chains we support today)
+	Explorer    string        // human-readable tx explorer (with %s for the hash)
+	GasModel    GasModel      // EIP-1559 vs legacy
+	IsTestnet   bool          // true for Sepolia/Fuji/etc.
+	DisplayName string        // for logs and UI ("Base mainnet")
+}
+
+// GasModel selects the transaction format used when sending raw txs.
+type GasModel string
+
+const (
+	// GasModelEIP1559 uses (maxFeePerGas, maxPriorityFeePerGas) — the
+	// post-London fee market. ETH mainnet, Base, Sepolia, Base Sepolia.
+	GasModelEIP1559 GasModel = "eip1559"
+	// GasModelLegacy uses gasPrice. AVAX C-chain and BSC still prefer
+	// legacy (BSC supports 1559 but most RPCs and wallets default to
+	// legacy; sticking with legacy avoids surprises on those chains).
+	GasModelLegacy GasModel = "legacy"
+)
+
+// Chains is the registry of supported EVM chains. Mainnets first, then
+// the canonical testnet for each.
+var Chains = map[types.ChainID]Chain{
+	types.ChainEthereum: {
+		ID: types.ChainEthereum, NumericID: 1, Native: "ETH", NativeDec: 18,
+		Explorer: "https://etherscan.io/tx/%s",
+		GasModel: GasModelEIP1559, DisplayName: "Ethereum mainnet",
+	},
+	types.ChainBase: {
+		ID: types.ChainBase, NumericID: 8453, Native: "ETH", NativeDec: 18,
+		Explorer: "https://basescan.org/tx/%s",
+		GasModel: GasModelEIP1559, DisplayName: "Base mainnet",
+	},
+	types.ChainAvalanche: {
+		ID: types.ChainAvalanche, NumericID: 43114, Native: "AVAX", NativeDec: 18,
+		Explorer: "https://snowtrace.io/tx/%s",
+		GasModel: GasModelLegacy, DisplayName: "Avalanche C-Chain",
+	},
+	types.ChainBSC: {
+		ID: types.ChainBSC, NumericID: 56, Native: "BNB", NativeDec: 18,
+		Explorer: "https://bscscan.com/tx/%s",
+		GasModel: GasModelLegacy, DisplayName: "BNB Smart Chain",
+	},
+}
+
+// Testnets is a separate map so production code can't accidentally swap
+// in a testnet by typoing a config value. The signer + RPC + ERC-20
+// pieces work identically on testnets — only the aggregator (1inch) is
+// mainnet-only, which is why we test signing/RPC on testnets and
+// aggregator e2e on mainnet with hard caps.
+var Testnets = map[string]Chain{
+	"sepolia": {
+		ID: "sepolia", NumericID: 11155111, Native: "ETH", NativeDec: 18,
+		Explorer: "https://sepolia.etherscan.io/tx/%s",
+		GasModel: GasModelEIP1559, IsTestnet: true, DisplayName: "Ethereum Sepolia",
+	},
+	"base-sepolia": {
+		ID: "base-sepolia", NumericID: 84532, Native: "ETH", NativeDec: 18,
+		Explorer: "https://sepolia.basescan.org/tx/%s",
+		GasModel: GasModelEIP1559, IsTestnet: true, DisplayName: "Base Sepolia",
+	},
+	"fuji": {
+		ID: "fuji", NumericID: 43113, Native: "AVAX", NativeDec: 18,
+		Explorer: "https://testnet.snowtrace.io/tx/%s",
+		GasModel: GasModelLegacy, IsTestnet: true, DisplayName: "Avalanche Fuji",
+	},
+	"bsc-testnet": {
+		ID: "bsc-testnet", NumericID: 97, Native: "BNB", NativeDec: 18,
+		Explorer: "https://testnet.bscscan.com/tx/%s",
+		GasModel: GasModelLegacy, IsTestnet: true, DisplayName: "BSC testnet",
+	},
+}
+
+// LookupChain returns the Chain for an internal ChainID. It accepts both
+// canonical mainnet names and the testnet shorthand keys above.
+func LookupChain(id types.ChainID) (Chain, error) {
+	if c, ok := Chains[id]; ok {
+		return c, nil
+	}
+	if c, ok := Testnets[strings.ToLower(string(id))]; ok {
+		return c, nil
+	}
+	return Chain{}, fmt.Errorf("evm: unknown chain %q", id)
+}
+
+// ExplorerURL formats a tx URL for the chain. Empty if no explorer is
+// configured.
+func (c Chain) ExplorerURL(txHash string) string {
+	if c.Explorer == "" {
+		return ""
+	}
+	return fmt.Sprintf(c.Explorer, txHash)
+}

--- a/internal/chain/evm/erc20.go
+++ b/internal/chain/evm/erc20.go
@@ -1,0 +1,128 @@
+package evm
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strings"
+)
+
+// ERC-20 selectors (4-byte function signatures, big-endian).
+//
+//	balanceOf(address)              0x70a08231
+//	allowance(address,address)      0xdd62ed3e
+//	approve(address,uint256)        0x095ea7b3
+//	transfer(address,uint256)       0xa9059cbb
+//	decimals()                      0x313ce567
+const (
+	selBalanceOf = "70a08231"
+	selAllowance = "dd62ed3e"
+	selApprove   = "095ea7b3"
+	selTransfer  = "a9059cbb"
+	selDecimals  = "313ce567"
+)
+
+// MaxUint256 is the canonical "infinite approval" amount.
+var MaxUint256 = func() *big.Int {
+	n := new(big.Int).Lsh(big.NewInt(1), 256)
+	return n.Sub(n, big.NewInt(1))
+}()
+
+// ERC20Token is a thin reader/writer over a single ERC-20 contract.
+type ERC20Token struct {
+	rpc      *Client
+	contract string // 0x-prefixed lowercase
+}
+
+// NewERC20Token constructs a token handle. The contract address is
+// stored lowercased for stable comparison.
+func NewERC20Token(rpc *Client, contract string) *ERC20Token {
+	return &ERC20Token{rpc: rpc, contract: strings.ToLower(contract)}
+}
+
+// Address returns the underlying contract address.
+func (t *ERC20Token) Address() string { return t.contract }
+
+// BalanceOf returns the ERC-20 balance of owner (in base units — the
+// caller is responsible for token decimals).
+func (t *ERC20Token) BalanceOf(ctx context.Context, owner string) (*big.Int, error) {
+	data := "0x" + selBalanceOf + padAddress(owner)
+	out, err := t.rpc.Call(ctx, CallParams{To: t.contract, Data: data})
+	if err != nil {
+		return nil, fmt.Errorf("erc20.balanceOf: %w", err)
+	}
+	return new(big.Int).SetBytes(out), nil
+}
+
+// Allowance returns how much spender is allowed to pull from owner.
+func (t *ERC20Token) Allowance(ctx context.Context, owner, spender string) (*big.Int, error) {
+	data := "0x" + selAllowance + padAddress(owner) + padAddress(spender)
+	out, err := t.rpc.Call(ctx, CallParams{To: t.contract, Data: data})
+	if err != nil {
+		return nil, fmt.Errorf("erc20.allowance: %w", err)
+	}
+	return new(big.Int).SetBytes(out), nil
+}
+
+// Decimals returns the on-chain decimals() value.
+func (t *ERC20Token) Decimals(ctx context.Context) (uint8, error) {
+	data := "0x" + selDecimals
+	out, err := t.rpc.Call(ctx, CallParams{To: t.contract, Data: data})
+	if err != nil {
+		return 0, fmt.Errorf("erc20.decimals: %w", err)
+	}
+	if len(out) == 0 {
+		return 0, fmt.Errorf("erc20.decimals: empty response")
+	}
+	n := new(big.Int).SetBytes(out)
+	return uint8(n.Uint64()), nil
+}
+
+// EncodeApprove builds calldata for `approve(spender, amount)`. Returns
+// the 0x-prefixed hex string ready to drop into a tx.
+func EncodeApprove(spender string, amount *big.Int) string {
+	return "0x" + selApprove + padAddress(spender) + padUint256(amount)
+}
+
+// EncodeTransfer builds calldata for `transfer(to, amount)`.
+func EncodeTransfer(to string, amount *big.Int) string {
+	return "0x" + selTransfer + padAddress(to) + padUint256(amount)
+}
+
+// EncodeBalanceOf builds calldata for `balanceOf(owner)`. Exposed for
+// callers that want to stage a manual eth_call.
+func EncodeBalanceOf(owner string) string {
+	return "0x" + selBalanceOf + padAddress(owner)
+}
+
+// EncodeAllowance builds calldata for `allowance(owner, spender)`.
+func EncodeAllowance(owner, spender string) string {
+	return "0x" + selAllowance + padAddress(owner) + padAddress(spender)
+}
+
+// padAddress formats a 0x-prefixed address as a 32-byte left-zero-padded
+// hex string (the EVM ABI calling convention for `address` arguments).
+func padAddress(addr string) string {
+	clean := strings.ToLower(strings.TrimPrefix(addr, "0x"))
+	if len(clean) > 40 {
+		clean = clean[len(clean)-40:]
+	}
+	return strings.Repeat("0", 64-len(clean)) + clean
+}
+
+// padUint256 formats a *big.Int as a 32-byte left-zero-padded hex string.
+// Negative values panic — uint256 has no negatives.
+func padUint256(n *big.Int) string {
+	if n == nil {
+		return strings.Repeat("0", 64)
+	}
+	if n.Sign() < 0 {
+		panic("evm: uint256 cannot be negative")
+	}
+	h := hex.EncodeToString(n.Bytes())
+	if len(h) > 64 {
+		panic(fmt.Sprintf("evm: uint256 overflow: %d bytes", len(n.Bytes())))
+	}
+	return strings.Repeat("0", 64-len(h)) + h
+}

--- a/internal/chain/evm/erc20_test.go
+++ b/internal/chain/evm/erc20_test.go
@@ -1,0 +1,83 @@
+package evm
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+)
+
+// Vectors below were generated against go-ethereum's
+// abi.Pack to make sure our hand-rolled calldata matches the
+// canonical encoding bit-for-bit.
+
+func TestEncodeApprove_KnownVector(t *testing.T) {
+	// approve(0x111000000000000000000000000000000000aaa, MaxUint256)
+	got := EncodeApprove("0x111000000000000000000000000000000000aaaa", MaxUint256)
+	want := "0x095ea7b3" +
+		"000000000000000000000000111000000000000000000000000000000000aaaa" +
+		"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	if !strings.EqualFold(got, want) {
+		t.Errorf("approve calldata mismatch\n got=%s\nwant=%s", got, want)
+	}
+}
+
+func TestEncodeApprove_FixedAmount(t *testing.T) {
+	// approve(spender, 100_000_000) — 100 USDC at 6 decimals
+	got := EncodeApprove("0x000000000000000000000000000000000000dEaD", big.NewInt(100_000_000))
+	want := "0x095ea7b3" +
+		"000000000000000000000000000000000000000000000000000000000000dead" +
+		"0000000000000000000000000000000000000000000000000000000005f5e100"
+	if !strings.EqualFold(got, want) {
+		t.Errorf("approve(amount) calldata mismatch\n got=%s\nwant=%s", got, want)
+	}
+}
+
+func TestEncodeBalanceOf(t *testing.T) {
+	got := EncodeBalanceOf("0x0000000000000000000000000000000000000001")
+	want := "0x70a082310000000000000000000000000000000000000000000000000000000000000001"
+	if !strings.EqualFold(got, want) {
+		t.Errorf("balanceOf calldata mismatch\n got=%s\nwant=%s", got, want)
+	}
+}
+
+func TestEncodeAllowance(t *testing.T) {
+	got := EncodeAllowance(
+		"0x0000000000000000000000000000000000000001",
+		"0x0000000000000000000000000000000000000002")
+	want := "0xdd62ed3e" +
+		"0000000000000000000000000000000000000000000000000000000000000001" +
+		"0000000000000000000000000000000000000000000000000000000000000002"
+	if !strings.EqualFold(got, want) {
+		t.Errorf("allowance calldata mismatch\n got=%s\nwant=%s", got, want)
+	}
+}
+
+func TestEncodeTransfer(t *testing.T) {
+	got := EncodeTransfer("0x000000000000000000000000000000000000bEEF", big.NewInt(1))
+	want := "0xa9059cbb" +
+		"000000000000000000000000000000000000000000000000000000000000beef" +
+		"0000000000000000000000000000000000000000000000000000000000000001"
+	if !strings.EqualFold(got, want) {
+		t.Errorf("transfer calldata mismatch\n got=%s\nwant=%s", got, want)
+	}
+}
+
+func TestPadAddress_StripsPrefix_Lowercases(t *testing.T) {
+	got := padAddress("0xABCDEFabcdef")
+	want := "0000000000000000000000000000000000000000000000000000abcdefabcdef"
+	if got != want {
+		t.Errorf("padAddress\n got=%s\nwant=%s", got, want)
+	}
+	if len(got) != 64 {
+		t.Errorf("padAddress should always be 64 hex chars, got %d", len(got))
+	}
+}
+
+func TestPadUint256_Negative_Panics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on negative uint256")
+		}
+	}()
+	_ = padUint256(big.NewInt(-1))
+}

--- a/internal/chain/evm/probe_mainnets_test.go
+++ b/internal/chain/evm/probe_mainnets_test.go
@@ -1,0 +1,65 @@
+//go:build live
+
+package evm
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// rpcURLForMainnet picks the RPC URL from env or a free public endpoint.
+// Operators can override with PERMAFROST_TEST_RPC_<NAME>.
+func rpcURLForMainnet(c types.ChainID) string {
+	envKey := "PERMAFROST_TEST_RPC_" + strings.ToUpper(string(c))
+	if v := os.Getenv(envKey); v != "" {
+		return v
+	}
+	switch c {
+	case types.ChainEthereum:
+		return "https://ethereum-rpc.publicnode.com"
+	case types.ChainBase:
+		return "https://mainnet.base.org"
+	case types.ChainAvalanche:
+		return "https://api.avax.network/ext/bc/C/rpc"
+	case types.ChainBSC:
+		return "https://bsc-rpc.publicnode.com"
+	}
+	return ""
+}
+
+// TestProbeMainnets_RPCRoundtrip is the mainnet twin of the testnet
+// probe — same assertion (chain id matches registry + head block is
+// non-zero), all four chains.
+func TestProbeMainnets_RPCRoundtrip(t *testing.T) {
+	for id, chain := range Chains {
+		id, chain := id, chain
+		t.Run(string(id), func(t *testing.T) {
+			t.Parallel()
+			url := rpcURLForMainnet(id)
+			if url == "" {
+				t.Skipf("no RPC URL for %s", id)
+			}
+			c := NewClient(url, chain)
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+
+			gotID, err := c.ChainID(ctx)
+			if err != nil {
+				t.Fatalf("eth_chainId: %v", err)
+			}
+			if gotID != chain.NumericID {
+				t.Errorf("chain id mismatch: rpc=%d registry=%d", gotID, chain.NumericID)
+			}
+			bn, err := c.BlockNumber(ctx)
+			if err != nil {
+				t.Fatalf("eth_blockNumber: %v", err)
+			}
+			t.Logf("✓ %s (chain id %d, head block %d)", chain.DisplayName, gotID, bn)
+		})
+	}
+}

--- a/internal/chain/evm/probe_testnets_test.go
+++ b/internal/chain/evm/probe_testnets_test.go
@@ -1,0 +1,142 @@
+//go:build live
+
+// Live testnet probes. Run with:
+//
+//	go test -tags=live -v ./internal/chain/evm/... -run Probe
+//
+// These tests hit real public RPC endpoints on EVM testnets and verify
+// that our JSON-RPC client + chain registry round-trip cleanly. They do
+// NOT send transactions (that requires a funded faucet wallet); the
+// signer roundtrip is exercised by the `ProbeSignerSendsTinyTx` test
+// below, which is gated on a separately-set env var so it's opt-in.
+package evm
+
+import (
+	"context"
+	"encoding/hex"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+// rpcURLForTestnet picks the RPC URL from env or a sensible default.
+// Operators can override with PERMAFROST_TEST_RPC_<NAME>.
+func rpcURLForTestnet(name string) string {
+	envKey := "PERMAFROST_TEST_RPC_" + strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
+	if v := os.Getenv(envKey); v != "" {
+		return v
+	}
+	switch name {
+	case "sepolia":
+		return "https://ethereum-sepolia-rpc.publicnode.com"
+	case "base-sepolia":
+		return "https://sepolia.base.org"
+	case "fuji":
+		return "https://api.avax-test.network/ext/bc/C/rpc"
+	case "bsc-testnet":
+		return "https://bsc-testnet-rpc.publicnode.com"
+	}
+	return ""
+}
+
+// ProbeTestnets_RPCRoundtrip walks every testnet and asserts that the
+// chain id reported by the RPC matches what our static registry expects.
+// This is the simplest, most useful "the wiring works" check.
+func TestProbeTestnets_RPCRoundtrip(t *testing.T) {
+	for name, chain := range Testnets {
+		name, chain := name, chain
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			url := rpcURLForTestnet(name)
+			if url == "" {
+				t.Skipf("no RPC URL for %s; set PERMAFROST_TEST_RPC_%s",
+					name, strings.ToUpper(strings.ReplaceAll(name, "-", "_")))
+			}
+			c := NewClient(url, chain)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+
+			id, err := c.ChainID(ctx)
+			if err != nil {
+				t.Fatalf("eth_chainId failed: %v", err)
+			}
+			if id != chain.NumericID {
+				t.Errorf("chain id mismatch: rpc=%d registry=%d", id, chain.NumericID)
+			}
+			bn, err := c.BlockNumber(ctx)
+			if err != nil {
+				t.Fatalf("eth_blockNumber failed: %v", err)
+			}
+			if bn == 0 {
+				t.Error("block number is zero — RPC stale?")
+			}
+			t.Logf("✓ %s (chain id %d, head block %d)", chain.DisplayName, id, bn)
+		})
+	}
+}
+
+// ProbeTestnets_SignerSendsTinyTx is a more involved check: it derives
+// the wallet address from PERMAFROST_TEST_PRIVATE_KEY (32-byte hex),
+// reports the native balance on each testnet, and — if PERMAFROST_TEST_BROADCAST=1
+// — sends a 0-value self-transfer to verify end-to-end signing+broadcast.
+//
+// To run: fund the test address from a faucet (we log the address) and
+// then re-run with PERMAFROST_TEST_BROADCAST=1.
+func TestProbeTestnets_SignerSendsTinyTx(t *testing.T) {
+	keyHex := os.Getenv("PERMAFROST_TEST_PRIVATE_KEY")
+	if keyHex == "" {
+		t.Skip("set PERMAFROST_TEST_PRIVATE_KEY (32-byte hex) to run this probe")
+	}
+	keyHex = strings.TrimPrefix(keyHex, "0x")
+	raw, err := hex.DecodeString(keyHex)
+	if err != nil {
+		t.Fatalf("bad PERMAFROST_TEST_PRIVATE_KEY: %v", err)
+	}
+	priv, err := ethcrypto.ToECDSA(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := AddressFromPrivateKey(priv)
+	broadcast := os.Getenv("PERMAFROST_TEST_BROADCAST") == "1"
+
+	for name, chain := range Testnets {
+		name, chain := name, chain
+		t.Run(name, func(t *testing.T) {
+			url := rpcURLForTestnet(name)
+			if url == "" {
+				t.Skipf("no RPC URL for %s", name)
+			}
+			c := NewClient(url, chain)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			bal, err := c.GetBalance(ctx, addr)
+			if err != nil {
+				t.Fatalf("balance: %v", err)
+			}
+			t.Logf("addr=%s balance=%s wei (%s)", addr, bal, chain.Native)
+
+			if !broadcast {
+				t.Skip("set PERMAFROST_TEST_BROADCAST=1 to actually send a tx")
+			}
+			if bal.Sign() == 0 {
+				t.Skipf("address has 0 %s on %s; fund it from a faucet first", chain.Native, name)
+			}
+
+			// 0-value self-transfer. Tiny gas, easy to confirm.
+			req := TxRequest{From: addr, To: addr, Data: "0x", Value: nil}
+			r, hash, err := SendAndWait(ctx, c, req, priv, 90*time.Second)
+			if err != nil {
+				t.Fatalf("send/wait: %v", err)
+			}
+			if !r.IsSuccess() {
+				t.Fatalf("tx %s reverted: status=%s", hash, r.Status)
+			}
+			t.Logf("✓ confirmed: %s", chain.ExplorerURL(hash))
+		})
+	}
+}

--- a/internal/chain/evm/rpc.go
+++ b/internal/chain/evm/rpc.go
@@ -1,0 +1,339 @@
+package evm
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// Client is a thin JSON-RPC HTTP client for EVM chains.
+//
+// It speaks just enough RPC to (1) read balances + allowances, (2) sign
+// and broadcast txs, and (3) wait for confirmations. The intentional
+// minimum surface keeps the dependency footprint flat and matches
+// internal/chain/solana.
+type Client struct {
+	url   string
+	chain Chain
+	http  *http.Client
+	id    atomic.Uint64
+}
+
+// NewClient constructs a Client. URL must be the full RPC endpoint
+// (Alchemy, Infura, public, ...). chain identifies the chain so we can
+// validate and so callers can read its metadata back.
+func NewClient(url string, chain Chain) *Client {
+	return &Client{
+		url:   strings.TrimRight(url, "/"),
+		chain: chain,
+		http:  &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// Chain returns the chain metadata this client targets.
+func (c *Client) Chain() Chain { return c.chain }
+
+// URL returns the configured RPC URL (sans trailing slash).
+func (c *Client) URL() string { return c.url }
+
+type rpcRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      uint64 `json:"id"`
+	Method  string `json:"method"`
+	Params  []any  `json:"params"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      uint64          `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+func (e *rpcError) Error() string { return fmt.Sprintf("evm rpc %d: %s", e.Code, e.Message) }
+
+// IsNotFound reports whether the error is the chain's "no such tx /
+// receipt yet" response. We rely on this for the receipt poller.
+func IsNotFound(err error) bool {
+	var re *rpcError
+	if errors.As(err, &re) {
+		return re.Code == -32601 || re.Code == -32602
+	}
+	return false
+}
+
+func (c *Client) call(ctx context.Context, method string, params []any, out any) error {
+	id := c.id.Add(1)
+	body, err := json.Marshal(rpcRequest{JSONRPC: "2.0", ID: id, Method: method, Params: params})
+	if err != nil {
+		return fmt.Errorf("evm: marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("evm: http: %w", err)
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("evm: read body: %w", err)
+	}
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("evm: http %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	var r rpcResponse
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return fmt.Errorf("evm: parse response: %w (body=%q)", err, string(raw))
+	}
+	if r.Error != nil {
+		return r.Error
+	}
+	if out == nil || len(r.Result) == 0 || string(r.Result) == "null" {
+		return nil
+	}
+	if err := json.Unmarshal(r.Result, out); err != nil {
+		return fmt.Errorf("evm: parse result: %w", err)
+	}
+	return nil
+}
+
+// ChainID returns eth_chainId. Used to verify the configured RPC URL
+// actually points at the chain we think it does.
+func (c *Client) ChainID(ctx context.Context) (uint64, error) {
+	var hexStr string
+	if err := c.call(ctx, "eth_chainId", []any{}, &hexStr); err != nil {
+		return 0, err
+	}
+	return hexToUint64(hexStr)
+}
+
+// BlockNumber returns the latest block height.
+func (c *Client) BlockNumber(ctx context.Context) (uint64, error) {
+	var hexStr string
+	if err := c.call(ctx, "eth_blockNumber", []any{}, &hexStr); err != nil {
+		return 0, err
+	}
+	return hexToUint64(hexStr)
+}
+
+// GetBalance returns the native-token balance (in wei / equivalent) for
+// the given 0x address at the latest block.
+func (c *Client) GetBalance(ctx context.Context, address string) (*big.Int, error) {
+	var hexStr string
+	if err := c.call(ctx, "eth_getBalance", []any{address, "latest"}, &hexStr); err != nil {
+		return nil, err
+	}
+	return hexToBigInt(hexStr)
+}
+
+// GetTransactionCount returns the next nonce for address (pending). We
+// use the pending count so back-to-back txs in the same tick get
+// distinct nonces.
+func (c *Client) GetTransactionCount(ctx context.Context, address string) (uint64, error) {
+	var hexStr string
+	if err := c.call(ctx, "eth_getTransactionCount", []any{address, "pending"}, &hexStr); err != nil {
+		return 0, err
+	}
+	return hexToUint64(hexStr)
+}
+
+// GasPrice returns eth_gasPrice — used for legacy-tx chains (BSC, AVAX).
+func (c *Client) GasPrice(ctx context.Context) (*big.Int, error) {
+	var hexStr string
+	if err := c.call(ctx, "eth_gasPrice", []any{}, &hexStr); err != nil {
+		return nil, err
+	}
+	return hexToBigInt(hexStr)
+}
+
+// MaxPriorityFeePerGas returns eth_maxPriorityFeePerGas. EIP-1559 chains.
+// Falls back to a small default if the RPC does not implement it.
+func (c *Client) MaxPriorityFeePerGas(ctx context.Context) (*big.Int, error) {
+	var hexStr string
+	err := c.call(ctx, "eth_maxPriorityFeePerGas", []any{}, &hexStr)
+	if err != nil {
+		// Some RPCs don't implement this. Default to 1 gwei.
+		return new(big.Int).Mul(big.NewInt(1), big.NewInt(1_000_000_000)), nil
+	}
+	return hexToBigInt(hexStr)
+}
+
+// FeeHistory returns the base fee from the latest block, used to compute
+// maxFeePerGas as 2*baseFee + tip on EIP-1559 chains.
+type FeeHistoryResult struct {
+	BaseFeePerGas []string `json:"baseFeePerGas"`
+}
+
+func (c *Client) FeeHistory(ctx context.Context, blockCount uint64, newest string) (*FeeHistoryResult, error) {
+	var out FeeHistoryResult
+	if err := c.call(ctx, "eth_feeHistory",
+		[]any{fmt.Sprintf("0x%x", blockCount), newest, []float64{}}, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// CallParams models eth_call's input.
+type CallParams struct {
+	From string // optional
+	To   string
+	Data string // 0x-hex calldata
+}
+
+// Call performs eth_call against the latest block. data should be 0x-hex.
+func (c *Client) Call(ctx context.Context, p CallParams) ([]byte, error) {
+	in := map[string]string{"to": p.To, "data": p.Data}
+	if p.From != "" {
+		in["from"] = p.From
+	}
+	var hexStr string
+	if err := c.call(ctx, "eth_call", []any{in, "latest"}, &hexStr); err != nil {
+		return nil, err
+	}
+	return hexToBytes(hexStr)
+}
+
+// EstimateGas returns eth_estimateGas for the call.
+type EstimateGasParams struct {
+	From  string
+	To    string
+	Data  string
+	Value string // 0x-hex; "0x0" if zero
+}
+
+func (c *Client) EstimateGas(ctx context.Context, p EstimateGasParams) (uint64, error) {
+	in := map[string]string{"from": p.From, "to": p.To, "data": p.Data}
+	if p.Value != "" {
+		in["value"] = p.Value
+	}
+	var hexStr string
+	if err := c.call(ctx, "eth_estimateGas", []any{in}, &hexStr); err != nil {
+		return 0, err
+	}
+	return hexToUint64(hexStr)
+}
+
+// SendRawTransaction broadcasts a signed transaction. raw must include
+// the 0x prefix.
+func (c *Client) SendRawTransaction(ctx context.Context, raw string) (string, error) {
+	var hash string
+	if err := c.call(ctx, "eth_sendRawTransaction", []any{raw}, &hash); err != nil {
+		return "", err
+	}
+	return hash, nil
+}
+
+// Receipt is the subset of eth_getTransactionReceipt fields we use.
+type Receipt struct {
+	TransactionHash   string `json:"transactionHash"`
+	BlockNumber       string `json:"blockNumber"`
+	BlockHash         string `json:"blockHash"`
+	GasUsed           string `json:"gasUsed"`
+	EffectiveGasPrice string `json:"effectiveGasPrice"`
+	Status            string `json:"status"` // "0x1" success, "0x0" failure
+}
+
+// IsSuccess reports whether the tx executed successfully.
+func (r *Receipt) IsSuccess() bool { return r != nil && r.Status == "0x1" }
+
+// GasUsedUint returns gasUsed parsed.
+func (r *Receipt) GasUsedUint() (uint64, error) { return hexToUint64(r.GasUsed) }
+
+// EffectiveGasPriceBig returns the effective gas price parsed.
+func (r *Receipt) EffectiveGasPriceBig() (*big.Int, error) { return hexToBigInt(r.EffectiveGasPrice) }
+
+// GetTransactionReceipt returns the receipt or nil if the tx is not yet
+// mined. Returned error reflects a real RPC error; "not yet mined" is
+// signalled by (nil, nil).
+func (c *Client) GetTransactionReceipt(ctx context.Context, hash string) (*Receipt, error) {
+	var r *Receipt
+	if err := c.call(ctx, "eth_getTransactionReceipt", []any{hash}, &r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// WaitForReceipt polls eth_getTransactionReceipt until the tx is mined
+// or the context is cancelled or the budget elapses.
+func (c *Client) WaitForReceipt(ctx context.Context, hash string, budget time.Duration, interval time.Duration) (*Receipt, error) {
+	if interval == 0 {
+		interval = 2 * time.Second
+	}
+	deadline := time.Now().Add(budget)
+	tick := time.NewTicker(interval)
+	defer tick.Stop()
+	for {
+		r, err := c.GetTransactionReceipt(ctx, hash)
+		if err != nil && !IsNotFound(err) {
+			return nil, err
+		}
+		if r != nil {
+			return r, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("evm: receipt timeout for %s", hash)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-tick.C:
+		}
+	}
+}
+
+// ─── hex helpers ────────────────────────────────────────────────────────────
+
+func hexToUint64(s string) (uint64, error) {
+	s = strings.TrimPrefix(s, "0x")
+	if s == "" {
+		return 0, nil
+	}
+	n := new(big.Int)
+	if _, ok := n.SetString(s, 16); !ok {
+		return 0, fmt.Errorf("evm: bad hex uint %q", s)
+	}
+	return n.Uint64(), nil
+}
+
+func hexToBigInt(s string) (*big.Int, error) {
+	s = strings.TrimPrefix(s, "0x")
+	if s == "" {
+		return new(big.Int), nil
+	}
+	n := new(big.Int)
+	if _, ok := n.SetString(s, 16); !ok {
+		return nil, fmt.Errorf("evm: bad hex bigint %q", s)
+	}
+	return n, nil
+}
+
+func hexToBytes(s string) ([]byte, error) {
+	s = strings.TrimPrefix(s, "0x")
+	if s == "" {
+		return nil, nil
+	}
+	if len(s)%2 == 1 {
+		s = "0" + s
+	}
+	return hex.DecodeString(s)
+}

--- a/internal/chain/evm/rpc_test.go
+++ b/internal/chain/evm/rpc_test.go
@@ -1,0 +1,121 @@
+package evm
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// stubRPC starts an httptest server that pretends to be an EVM JSON-RPC
+// node. Each request is matched against the supplied responses by RPC
+// method; the first match wins. Unmatched requests return an error.
+func stubRPC(t *testing.T, responses map[string]any) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Method string `json:"method"`
+			ID     uint64 `json:"id"`
+		}
+		_ = json.Unmarshal(body, &req)
+		v, ok := responses[req.Method]
+		if !ok {
+			http.Error(w, "stub: no response for "+req.Method, http.StatusInternalServerError)
+			return
+		}
+		out := map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": v}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(out)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestClient_ChainIDAndBalance(t *testing.T) {
+	srv := stubRPC(t, map[string]any{
+		"eth_chainId":    "0x2105",                                                                  // 8453
+		"eth_getBalance": "0x16345785d8a0000",                                                       // 0.1 ETH
+		"eth_blockNumber": "0xabcd",                                                                 //
+		"eth_getTransactionCount": "0x7",                                                            //
+	})
+	c := NewClient(srv.URL, Chain{ID: types.ChainBase, NumericID: 8453, GasModel: GasModelEIP1559})
+
+	id, err := c.ChainID(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != 8453 {
+		t.Errorf("chain id: got %d want 8453", id)
+	}
+
+	bal, err := c.GetBalance(context.Background(), "0x000000000000000000000000000000000000dead")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, _ := new(big.Int).SetString("100000000000000000", 10) // 0.1 ETH in wei
+	if bal.Cmp(want) != 0 {
+		t.Errorf("balance: got %s want %s", bal, want)
+	}
+
+	bn, err := c.BlockNumber(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bn != 0xabcd {
+		t.Errorf("blocknumber: got %d want %d", bn, 0xabcd)
+	}
+
+	nonce, err := c.GetTransactionCount(context.Background(), "0xdeadbeef")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nonce != 7 {
+		t.Errorf("nonce: got %d want 7", nonce)
+	}
+}
+
+func TestClient_RPCErrorPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"insufficient funds"}}`))
+	}))
+	defer srv.Close()
+	c := NewClient(srv.URL, Chain{ID: types.ChainBase})
+
+	_, err := c.GetBalance(context.Background(), "0x0")
+	if err == nil || !strings.Contains(err.Error(), "insufficient funds") {
+		t.Errorf("expected RPC error to surface, got %v", err)
+	}
+}
+
+func TestLookupChain_KnownAndUnknown(t *testing.T) {
+	c, err := LookupChain(types.ChainBase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.NumericID != 8453 {
+		t.Errorf("base id: got %d want 8453", c.NumericID)
+	}
+	if _, err := LookupChain("nonsense"); err == nil {
+		t.Error("expected error for unknown chain")
+	}
+	// testnet shorthand also resolves
+	if _, err := LookupChain("base-sepolia"); err != nil {
+		t.Errorf("base-sepolia should resolve: %v", err)
+	}
+}
+
+func TestExplorerURL(t *testing.T) {
+	c, _ := LookupChain(types.ChainBase)
+	url := c.ExplorerURL("0xabc")
+	if !strings.Contains(url, "basescan.org") || !strings.Contains(url, "0xabc") {
+		t.Errorf("explorer url: %q", url)
+	}
+}

--- a/internal/chain/evm/tx.go
+++ b/internal/chain/evm/tx.go
@@ -1,0 +1,214 @@
+package evm
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+// TxRequest captures the inputs to building a single transaction. Gas
+// fields are filled in by EstimateAndFill if left zero.
+type TxRequest struct {
+	From  string   // 0x address (used for nonce + gas estimation)
+	To    string   // 0x address; "" for contract creation (not used today)
+	Data  string   // 0x-hex calldata
+	Value *big.Int // wei; nil treated as zero
+
+	// Optional caller-supplied overrides; left zero, the builder fills them.
+	GasLimit             uint64   // EstimateGas if 0
+	Nonce                *uint64  // pending count if nil
+	GasPriceWei          *big.Int // legacy chains; GasPrice() if nil
+	MaxFeePerGasWei      *big.Int // EIP-1559; computed from base fee if nil
+	MaxPriorityFeePerGas *big.Int // EIP-1559; MaxPriorityFeePerGas() if nil
+}
+
+// EstimateAndFill performs RPC reads to populate any unset fields on req.
+// On EIP-1559 chains we set maxFee = 2*baseFee + tip with a 25% safety
+// buffer on the base fee — this is the well-known "Alchemy/Infura"
+// recipe that survives short fee spikes without overpaying badly.
+func EstimateAndFill(ctx context.Context, c *Client, req *TxRequest) error {
+	if req.From == "" {
+		return errors.New("evm: tx From is required")
+	}
+	if req.Value == nil {
+		req.Value = new(big.Int)
+	}
+	if req.Nonce == nil {
+		n, err := c.GetTransactionCount(ctx, req.From)
+		if err != nil {
+			return fmt.Errorf("evm: nonce: %w", err)
+		}
+		req.Nonce = &n
+	}
+	if req.GasLimit == 0 {
+		valHex := "0x0"
+		if req.Value.Sign() > 0 {
+			valHex = "0x" + req.Value.Text(16)
+		}
+		gas, err := c.EstimateGas(ctx, EstimateGasParams{
+			From: req.From, To: req.To, Data: req.Data, Value: valHex,
+		})
+		if err != nil {
+			return fmt.Errorf("evm: estimate gas: %w", err)
+		}
+		// 25% safety buffer over the estimate. ERC-20 + aggregator calls
+		// are notoriously borderline on the estimate.
+		req.GasLimit = gas + (gas / 4)
+	}
+
+	switch c.chain.GasModel {
+	case GasModelEIP1559:
+		if req.MaxPriorityFeePerGas == nil {
+			tip, err := c.MaxPriorityFeePerGas(ctx)
+			if err != nil {
+				return fmt.Errorf("evm: priority fee: %w", err)
+			}
+			req.MaxPriorityFeePerGas = tip
+		}
+		if req.MaxFeePerGasWei == nil {
+			fh, err := c.FeeHistory(ctx, 1, "latest")
+			if err != nil || len(fh.BaseFeePerGas) == 0 {
+				// Fall back to gasPrice if fee history isn't available.
+				gp, gpErr := c.GasPrice(ctx)
+				if gpErr != nil {
+					return fmt.Errorf("evm: fallback gas price: %w", gpErr)
+				}
+				maxFee := new(big.Int).Mul(gp, big.NewInt(2))
+				maxFee.Add(maxFee, req.MaxPriorityFeePerGas)
+				req.MaxFeePerGasWei = maxFee
+			} else {
+				base, ok := new(big.Int).SetString(strings.TrimPrefix(fh.BaseFeePerGas[len(fh.BaseFeePerGas)-1], "0x"), 16)
+				if !ok {
+					return fmt.Errorf("evm: parse base fee: %s", fh.BaseFeePerGas[0])
+				}
+				// 2*base + tip = comfortable max for the next ~6 blocks.
+				maxFee := new(big.Int).Mul(base, big.NewInt(2))
+				maxFee.Add(maxFee, req.MaxPriorityFeePerGas)
+				req.MaxFeePerGasWei = maxFee
+			}
+		}
+	case GasModelLegacy:
+		if req.GasPriceWei == nil {
+			gp, err := c.GasPrice(ctx)
+			if err != nil {
+				return fmt.Errorf("evm: gas price: %w", err)
+			}
+			req.GasPriceWei = gp
+		}
+	default:
+		return fmt.Errorf("evm: unknown gas model %q", c.chain.GasModel)
+	}
+	return nil
+}
+
+// SignAndSend builds a transaction from req, signs it with priv, and
+// submits via eth_sendRawTransaction. Returns the tx hash.
+//
+// priv is the secp256k1 private key (32 bytes). It MUST come from the
+// wallet keystore — never from a config file or env var.
+func SignAndSend(ctx context.Context, c *Client, req TxRequest, priv *ecdsa.PrivateKey) (string, error) {
+	if priv == nil {
+		return "", errors.New("evm: private key is nil")
+	}
+	if req.Nonce == nil {
+		return "", errors.New("evm: nonce is required (call EstimateAndFill first)")
+	}
+	if req.GasLimit == 0 {
+		return "", errors.New("evm: gas limit is required (call EstimateAndFill first)")
+	}
+
+	chainID := new(big.Int).SetUint64(c.chain.NumericID)
+	to := common.HexToAddress(req.To)
+	data, err := hexToBytes(req.Data)
+	if err != nil {
+		return "", fmt.Errorf("evm: data hex: %w", err)
+	}
+	value := req.Value
+	if value == nil {
+		value = new(big.Int)
+	}
+
+	var tx *ethtypes.Transaction
+	switch c.chain.GasModel {
+	case GasModelEIP1559:
+		if req.MaxFeePerGasWei == nil || req.MaxPriorityFeePerGas == nil {
+			return "", errors.New("evm: EIP-1559 requires maxFee and tip")
+		}
+		tx = ethtypes.NewTx(&ethtypes.DynamicFeeTx{
+			ChainID:   chainID,
+			Nonce:     *req.Nonce,
+			GasTipCap: req.MaxPriorityFeePerGas,
+			GasFeeCap: req.MaxFeePerGasWei,
+			Gas:       req.GasLimit,
+			To:        &to,
+			Value:     value,
+			Data:      data,
+		})
+	case GasModelLegacy:
+		if req.GasPriceWei == nil {
+			return "", errors.New("evm: legacy requires GasPriceWei")
+		}
+		tx = ethtypes.NewTx(&ethtypes.LegacyTx{
+			Nonce:    *req.Nonce,
+			GasPrice: req.GasPriceWei,
+			Gas:      req.GasLimit,
+			To:       &to,
+			Value:    value,
+			Data:     data,
+		})
+	default:
+		return "", fmt.Errorf("evm: unknown gas model %q", c.chain.GasModel)
+	}
+
+	signer := ethtypes.LatestSignerForChainID(chainID)
+	signed, err := ethtypes.SignTx(tx, signer, priv)
+	if err != nil {
+		return "", fmt.Errorf("evm: sign: %w", err)
+	}
+	raw, err := signed.MarshalBinary()
+	if err != nil {
+		return "", fmt.Errorf("evm: marshal tx: %w", err)
+	}
+	hexRaw := "0x" + common.Bytes2Hex(raw)
+	hash, err := c.SendRawTransaction(ctx, hexRaw)
+	if err != nil {
+		return "", fmt.Errorf("evm: broadcast: %w", err)
+	}
+	return hash, nil
+}
+
+// SendAndWait is a convenience wrapper: estimate → sign → send → wait
+// for receipt. Returns the receipt (which may indicate on-chain
+// failure via Status="0x0"). budget defaults to 90s if zero.
+func SendAndWait(ctx context.Context, c *Client, req TxRequest, priv *ecdsa.PrivateKey, budget time.Duration) (*Receipt, string, error) {
+	if budget == 0 {
+		budget = 90 * time.Second
+	}
+	if err := EstimateAndFill(ctx, c, &req); err != nil {
+		return nil, "", err
+	}
+	hash, err := SignAndSend(ctx, c, req, priv)
+	if err != nil {
+		return nil, "", err
+	}
+	r, err := c.WaitForReceipt(ctx, hash, budget, 2*time.Second)
+	if err != nil {
+		return nil, hash, err
+	}
+	return r, hash, nil
+}
+
+// AddressFromPrivateKey derives the canonical 0x-prefixed lowercase EVM
+// address from a secp256k1 private key. Handy for cross-checking that
+// the loaded keystore key matches an expected address.
+func AddressFromPrivateKey(priv *ecdsa.PrivateKey) string {
+	return strings.ToLower(ethcrypto.PubkeyToAddress(priv.PublicKey).Hex())
+}

--- a/internal/chain/evm/tx_test.go
+++ b/internal/chain/evm/tx_test.go
@@ -1,0 +1,137 @@
+package evm
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// stubKey returns a deterministic test private key. Never used outside
+// tests — DO NOT reuse for real funds.
+func stubKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	raw, _ := hex.DecodeString("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80")
+	priv, err := ethcrypto.ToECDSA(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return priv
+}
+
+func TestSignAndSend_EIP1559_BroadcastsValidRawTx(t *testing.T) {
+	var capturedRaw string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Method string `json:"method"`
+			Params []any  `json:"params"`
+			ID     uint64 `json:"id"`
+		}
+		_ = json.Unmarshal(body, &req)
+		w.Header().Set("Content-Type", "application/json")
+		switch req.Method {
+		case "eth_sendRawTransaction":
+			capturedRaw = req.Params[0].(string)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0", "id": req.ID,
+				"result": "0x" + strings.Repeat("ab", 32),
+			})
+		default:
+			http.Error(w, "stub: unexpected "+req.Method, http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, Chain{ID: types.ChainBase, NumericID: 8453, GasModel: GasModelEIP1559})
+	priv := stubKey(t)
+	addr := AddressFromPrivateKey(priv)
+
+	nonce := uint64(0)
+	req := TxRequest{
+		From:                 addr,
+		To:                   "0x000000000000000000000000000000000000dead",
+		Data:                 "0x",
+		Value:                big.NewInt(0),
+		GasLimit:             21000,
+		Nonce:                &nonce,
+		MaxFeePerGasWei:      big.NewInt(2_000_000_000),
+		MaxPriorityFeePerGas: big.NewInt(1_000_000_000),
+	}
+	hash, err := SignAndSend(context.Background(), c, req, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(hash, "0x") || len(hash) != 66 {
+		t.Errorf("hash looks invalid: %q", hash)
+	}
+	// EIP-1559 envelope starts with 0x02.
+	if !strings.HasPrefix(strings.ToLower(capturedRaw), "0x02") {
+		t.Errorf("expected EIP-1559 (0x02) raw tx, got prefix %q", capturedRaw[:8])
+	}
+}
+
+func TestSignAndSend_Legacy_BroadcastsValidRawTx(t *testing.T) {
+	var capturedRaw string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Method string `json:"method"`
+			Params []any  `json:"params"`
+			ID     uint64 `json:"id"`
+		}
+		_ = json.Unmarshal(body, &req)
+		w.Header().Set("Content-Type", "application/json")
+		if req.Method == "eth_sendRawTransaction" {
+			capturedRaw = req.Params[0].(string)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0", "id": req.ID,
+			"result": "0x" + strings.Repeat("cd", 32),
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, Chain{ID: types.ChainBSC, NumericID: 56, GasModel: GasModelLegacy})
+	priv := stubKey(t)
+	addr := AddressFromPrivateKey(priv)
+
+	nonce := uint64(0)
+	req := TxRequest{
+		From:        addr,
+		To:          "0x000000000000000000000000000000000000beef",
+		Data:        "0x",
+		Value:       big.NewInt(0),
+		GasLimit:    21000,
+		Nonce:       &nonce,
+		GasPriceWei: big.NewInt(3_000_000_000),
+	}
+	if _, err := SignAndSend(context.Background(), c, req, priv); err != nil {
+		t.Fatal(err)
+	}
+	// Legacy txs do NOT start with 0x02 — they start with the RLP list prefix (0xf8/0xf9/0xeb/...).
+	if strings.HasPrefix(strings.ToLower(capturedRaw), "0x02") {
+		t.Errorf("expected legacy tx (no 0x02 prefix), got %q", capturedRaw[:8])
+	}
+}
+
+func TestAddressFromPrivateKey_Stable(t *testing.T) {
+	priv := stubKey(t)
+	addr := AddressFromPrivateKey(priv)
+	// Anvil's well-known account #0 derived from this key. Used to
+	// catch any accidental change in our derivation path.
+	want := "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+	if !strings.EqualFold(addr, want) {
+		t.Errorf("address: got %s want %s", addr, want)
+	}
+}

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/signal"
 	"strings"
 	"syscall"
@@ -415,6 +416,7 @@ Stops on SIGINT/SIGTERM or after --ticks N (whichever comes first).`,
 				HyperliquidNetwork: networkOverride,
 				HyperliquidAddress: hlAddress,
 				Solana:             solanaSpotFromConfig(g.Config.Solana),
+				EVM:                evmSpotsFromConfig(g.Config.EVM, os.Getenv),
 			})
 			if err != nil {
 				return err
@@ -584,18 +586,21 @@ func parseFundingArgs(args []string) []agentFundingArg {
 }
 
 // FundingRates implements the Venue method we override; it returns synthetic
-// per-hour rates derived from the requested annualised values.
+// per-hour rates derived from the requested annualised values. MarkPrice
+// defaults to 1.0 so the strategy can size the perp leg (cap_usdc / mark)
+// without an explicit price feed — fine for paper-mode plumbing tests.
 func (v *tickFundingVenue) FundingRates(_ context.Context, _ []string) ([]types.FundingRate, error) {
 	now := time.Now().UTC()
 	hoursPerYear := decimal.NewFromInt(24 * 365)
 	out := make([]types.FundingRate, 0, len(v.rates))
 	for _, r := range v.rates {
 		out = append(out, types.FundingRate{
-			Time:     now,
-			Venue:    "synthetic",
-			Symbol:   r.Symbol,
-			Rate:     r.Annualised.Div(hoursPerYear),
-			Interval: time.Hour,
+			Time:      now,
+			Venue:     "synthetic",
+			Symbol:    r.Symbol,
+			Rate:      r.Annualised.Div(hoursPerYear),
+			Interval:  time.Hour,
+			MarkPrice: decimal.NewFromInt(1),
 		})
 	}
 	return out, nil
@@ -629,6 +634,38 @@ func solanaSpotFromConfig(cfg config.SolanaConfig) agent.SolanaSpot {
 		PriorityFeeMicroLamports: cfg.PriorityFeeMicroLamports,
 		ConfirmationTimeoutSecs:  cfg.ConfirmationTimeoutSecs,
 	}
+}
+
+// evmSpotsFromConfig translates the cli config view into the agent
+// builder's per-chain map. Unknown chain names in evm.chains.{name}
+// are skipped with a no-op (operators are warned via a log line in
+// the supervisor — here we silently drop to keep the helper pure).
+//
+// API key resolution: env var OneInchAPIKeyEnv wins over inline
+// OneInchAPIKey; both empty disables EVM swaps entirely.
+func evmSpotsFromConfig(cfg config.EVMConfig, getenv func(string) string) map[types.ChainID]agent.EVMSpot {
+	if len(cfg.Chains) == 0 {
+		return nil
+	}
+	apiKey := cfg.ResolvedOneInchAPIKey(getenv)
+	if apiKey == "" {
+		return nil
+	}
+	out := map[types.ChainID]agent.EVMSpot{}
+	for name, c := range cfg.Chains {
+		chain := types.ChainID(strings.ToLower(name))
+		if !chain.IsEVM() {
+			continue
+		}
+		out[chain] = agent.EVMSpot{
+			RPCURL:                  c.RPCURL,
+			OneInchAPIKey:           apiKey,
+			OneInchBaseURL:          cfg.OneInchBaseURL,
+			DefaultSlippageBps:      cfg.DefaultSlippageBps,
+			ConfirmationTimeoutSecs: cfg.ConfirmationTimeoutSecs,
+		}
+	}
+	return out
 }
 
 func splitCSV(s string) []string {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -90,6 +90,7 @@ func Serve(ctx context.Context, g *Globals, opts ServeOptions) error {
 				BuildOpts: agent.BuildOptions{
 					HyperliquidNetwork: opts.HyperliquidNetworkOverride,
 					Solana:             solanaSpotFromConfig(g.Config.Solana),
+					EVM:                evmSpotsFromConfig(g.Config.EVM, os.Getenv),
 				},
 				Supervisor: sup,
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	Inference InferenceConfig `mapstructure:"inference"`
 	Wallet    WalletConfig    `mapstructure:"wallet"`
 	Solana    SolanaConfig    `mapstructure:"solana"`
+	EVM       EVMConfig       `mapstructure:"evm"`
 }
 
 type ServerConfig struct {
@@ -82,6 +83,34 @@ type SolanaConfig struct {
 	ConfirmationTimeoutSecs      int    `mapstructure:"confirmation_timeout_secs"`
 }
 
+// EVMConfig configures the EVM swap stack: a shared 1inch API key plus
+// one per-chain block (RPC URL, optional overrides). Operators omit
+// chains they don't intend to use.
+//
+// Example:
+//
+//	evm:
+//	  oneinch_api_key_env: ONEINCH_API_KEY
+//	  default_slippage_bps: 50
+//	  chains:
+//	    ethereum: { rpc_url: https://eth.llamarpc.com }
+//	    base:     { rpc_url: https://mainnet.base.org }
+//	    avalanche: { rpc_url: https://api.avax.network/ext/bc/C/rpc }
+//	    bsc:      { rpc_url: https://bsc-dataseed.binance.org }
+type EVMConfig struct {
+	OneInchAPIKey           string                       `mapstructure:"oneinch_api_key"`
+	OneInchAPIKeyEnv        string                       `mapstructure:"oneinch_api_key_env"`
+	OneInchBaseURL          string                       `mapstructure:"oneinch_base_url"`
+	DefaultSlippageBps      int                          `mapstructure:"default_slippage_bps"`
+	ConfirmationTimeoutSecs int                          `mapstructure:"confirmation_timeout_secs"`
+	Chains                  map[string]EVMChainConfig    `mapstructure:"chains"`
+}
+
+// EVMChainConfig is the per-chain block under evm.chains.{name}.
+type EVMChainConfig struct {
+	RPCURL string `mapstructure:"rpc_url"`
+}
+
 // Load reads configuration from the given path (optional) and environment.
 // If path is empty, it looks for config.yaml in the current directory.
 func Load(path string) (*Config, error) {
@@ -95,6 +124,9 @@ func Load(path string) (*Config, error) {
 	v.SetDefault("database.max_conns", int32(16))
 	v.SetDefault("database.min_conns", int32(2))
 	v.SetDefault("wallet.passphrase_env", "PERMAFROST_KEYSTORE_PASSPHRASE")
+	v.SetDefault("evm.oneinch_api_key_env", "ONEINCH_API_KEY")
+	v.SetDefault("evm.default_slippage_bps", 50)
+	v.SetDefault("evm.confirmation_timeout_secs", 90)
 
 	if path != "" {
 		v.SetConfigFile(path)
@@ -149,6 +181,18 @@ func (c *Config) validate() error {
 		return fmt.Errorf("invalid logging.format %q", c.Logging.Format)
 	}
 	return nil
+}
+
+// ResolvedOneInchAPIKey returns the 1inch API key, preferring the env
+// var named by OneInchAPIKeyEnv (if set) over the inline OneInchAPIKey.
+// Returns an empty string when nothing is configured.
+func (e EVMConfig) ResolvedOneInchAPIKey(getenv func(string) string) string {
+	if e.OneInchAPIKeyEnv != "" {
+		if v := getenv(e.OneInchAPIKeyEnv); v != "" {
+			return v
+		}
+	}
+	return e.OneInchAPIKey
 }
 
 // IsLoopback reports whether the configured bind address is a loopback

--- a/internal/strategy/funding_arb_basic/strategy.go
+++ b/internal/strategy/funding_arb_basic/strategy.go
@@ -190,12 +190,17 @@ func openIntents(c candidate, cfg Config, agentID string) (types.SwapIntent, typ
 	perpSize := cfg.PositionCapUSDC.Div(mark)
 
 	usdc := types.Asset{Symbol: "USDC", Chain: c.Asset.Spot.Chain, Mint: usdcMintFor(c.Asset.Spot.Chain), Decimals: 6}
+	// BasisKey is the registry asset symbol — uniquely identifies the
+	// (perp_symbol, spot_chain) pair so multi-chain entries (ETH-BASE vs
+	// ETH-MAINNET) reconcile correctly.
+	basisKey := c.Symbol
 	swap := types.SwapIntent{
 		Chain:       c.Asset.Spot.Chain,
 		InToken:     usdc,
 		OutToken:    c.Asset.AsAsset(),
 		InAmount:    cfg.PositionCapUSDC,
 		SlippageBps: cfg.SlippageBps,
+		BasisKey:    basisKey,
 		Tag:         "open:" + c.Symbol,
 	}
 	perp := types.OrderIntent{
@@ -207,6 +212,7 @@ func openIntents(c candidate, cfg Config, agentID string) (types.SwapIntent, typ
 		Size:       perpSize,
 		TIF:        types.TIFGTC,
 		ReduceOnly: false,
+		BasisKey:   basisKey,
 		Tag:        "open:" + c.Symbol,
 	}
 	_ = agentID
@@ -230,6 +236,7 @@ func closeIntents(p types.BasisPosition, agentID string) (types.SwapIntent, type
 		InToken:  spotLeg.Asset,
 		OutToken: usdc,
 		InAmount: spotLeg.Qty,
+		BasisKey: p.Underlying,
 		Tag:      "close:" + p.Underlying,
 	}
 	perp := types.OrderIntent{
@@ -237,6 +244,7 @@ func closeIntents(p types.BasisPosition, agentID string) (types.SwapIntent, type
 		Symbol:     perpLeg.Symbol,
 		Side:       types.SideBuy, // closing a short → buy back
 		Type:       types.OrderTypeMarket,
+		BasisKey:   p.Underlying,
 		Size:       perpLeg.Qty,
 		ReduceOnly: true,
 		Tag:        "close:" + p.Underlying,
@@ -245,12 +253,29 @@ func closeIntents(p types.BasisPosition, agentID string) (types.SwapIntent, type
 	return swap, perp
 }
 
-// usdcMintFor returns the canonical USDC mint for a chain. Hard-coded for
-// MVP; future versions can drive this off the registry.
+// usdcMintFor returns the canonical USDC mint/contract for a chain.
+// Hard-coded for MVP; future versions can drive this off the registry.
+//
+// Sources:
+//   - Solana:    Circle's native USDC mint
+//   - Ethereum:  https://www.circle.com/usdc-multichain/ethereum
+//   - Base:      Circle's native USDC on Base (NOT USDbC, which is bridged)
+//   - Avalanche: Circle's native USDC on Avalanche C-Chain
+//   - BSC:       Binance-Peg USDC (no native USDC; pegged is the de-facto liquid one)
+//
+// All EVM USDC contracts are 6-decimal; Solana USDC is also 6-decimal.
 func usdcMintFor(chain types.ChainID) string {
 	switch chain {
 	case types.ChainSolana:
 		return "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+	case types.ChainEthereum:
+		return "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+	case types.ChainBase:
+		return "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+	case types.ChainAvalanche:
+		return "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"
+	case types.ChainBSC:
+		return "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d"
 	default:
 		return ""
 	}

--- a/internal/swap/oneinch/client.go
+++ b/internal/swap/oneinch/client.go
@@ -1,0 +1,293 @@
+// Package oneinch is the SwapVenue adapter for 1inch's v6 aggregator API.
+// One Venue covers one EVM chain; spin up multiple Venues with the same
+// API key (and different chain ids) for multi-chain operation.
+//
+// API docs: https://portal.1inch.dev/documentation/swap/v6.0/
+//
+// Endpoints we use (all under /swap/v6.0/{chainId}/):
+//
+//	GET /quote                        — price discovery, no calldata
+//	GET /swap                         — full quote + signed-tx payload
+//	GET /approve/allowance            — current allowance for our wallet
+//	GET /approve/transaction          — calldata for an approve() to the router
+//
+// 1inch is mainnet-only. Testnet aggregator support does not exist;
+// see SCOPE.md for how we test (mock + mainnet-with-cap).
+package oneinch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// DefaultBaseURL is the public 1inch API base. Operators with their own
+// proxy can override via WithBaseURL.
+const DefaultBaseURL = "https://api.1inch.dev"
+
+// Client is a thin HTTP client over the 1inch swap API. Safe for
+// concurrent use.
+type Client struct {
+	baseURL string
+	apiKey  string
+	chainID uint64
+	http    *http.Client
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// WithBaseURL overrides the API base. Empty string is a no-op (keeps default).
+func WithBaseURL(u string) Option {
+	return func(c *Client) {
+		if u != "" {
+			c.baseURL = strings.TrimRight(u, "/")
+		}
+	}
+}
+
+// WithHTTPClient lets tests inject a custom *http.Client (e.g. with a
+// shorter timeout or a stubbed Transport).
+func WithHTTPClient(h *http.Client) Option {
+	return func(c *Client) {
+		if h != nil {
+			c.http = h
+		}
+	}
+}
+
+// NewClient constructs a 1inch client for chainID. apiKey is required —
+// 1inch returns 401 without one. Get a free key from
+// https://portal.1inch.dev .
+func NewClient(chainID uint64, apiKey string, opts ...Option) *Client {
+	c := &Client{
+		baseURL: DefaultBaseURL,
+		apiKey:  apiKey,
+		chainID: chainID,
+		http:    &http.Client{Timeout: 30 * time.Second},
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+// ChainID returns the chain id this client targets.
+func (c *Client) ChainID() uint64 { return c.chainID }
+
+// QuoteParams are the inputs to /quote. Amount must be in base units
+// (e.g. wei for ETH-decimaled tokens).
+type QuoteParams struct {
+	Src        string // token contract address (0x…); use 0xeeee… for native
+	Dst        string // token contract address (0x…)
+	Amount     string // base-unit amount as a decimal string
+	IncludeGas bool   // if true, response includes estimated gas
+}
+
+// QuoteResponse is the subset of fields we use.
+type QuoteResponse struct {
+	DstAmount string `json:"dstAmount"`
+	Gas       uint64 `json:"gas,omitempty"`
+}
+
+// Quote fetches a price quote.
+func (c *Client) Quote(ctx context.Context, p QuoteParams) (*QuoteResponse, error) {
+	q := url.Values{}
+	q.Set("src", p.Src)
+	q.Set("dst", p.Dst)
+	q.Set("amount", p.Amount)
+	if p.IncludeGas {
+		q.Set("includeGas", "true")
+	}
+	var out QuoteResponse
+	if err := c.get(ctx, fmt.Sprintf("/swap/v6.0/%d/quote", c.chainID), q, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// SwapParams are the inputs to /swap.
+type SwapParams struct {
+	Src      string // src token (0x…)
+	Dst      string // dst token (0x…)
+	Amount   string // base units
+	From     string // wallet address (0x…)
+	Slippage string // percent, e.g. "0.5" for 50bps. 1inch uses % not bps.
+
+	// Optional — a few of the most useful flags.
+	DisableEstimate    bool   // skip 1inch's tx simulation (we'll let RPC fail if it's bad)
+	AllowPartialFill   bool   // accept a less-than-full fill rather than revert
+	IncludeProtocols   bool   // include the route in the response (handy for logs)
+	IncludeGas         bool   // include estimated gas
+	Receiver           string // optional; default = From
+	Referrer           string // optional; for fee sharing
+	Permit             string // hex-encoded EIP-2612 permit; empty for plain approve flow
+}
+
+// SwapResponse is the subset of fields we use. tx is the executable
+// transaction calldata + target.
+type SwapResponse struct {
+	DstAmount string `json:"dstAmount"`
+	Tx        struct {
+		From     string `json:"from"`
+		To       string `json:"to"`
+		Data     string `json:"data"`
+		Value    string `json:"value"`
+		Gas      uint64 `json:"gas,omitempty"`
+		GasPrice string `json:"gasPrice,omitempty"`
+	} `json:"tx"`
+	Protocols json.RawMessage `json:"protocols,omitempty"`
+}
+
+// Swap fetches the full swap payload (quote + tx data).
+func (c *Client) Swap(ctx context.Context, p SwapParams) (*SwapResponse, error) {
+	if p.From == "" {
+		return nil, fmt.Errorf("oneinch: From is required")
+	}
+	if p.Slippage == "" {
+		p.Slippage = "0.5"
+	}
+	q := url.Values{}
+	q.Set("src", p.Src)
+	q.Set("dst", p.Dst)
+	q.Set("amount", p.Amount)
+	q.Set("from", p.From)
+	q.Set("slippage", p.Slippage)
+	if p.DisableEstimate {
+		q.Set("disableEstimate", "true")
+	}
+	if p.AllowPartialFill {
+		q.Set("allowPartialFill", "true")
+	}
+	if p.IncludeProtocols {
+		q.Set("includeProtocols", "true")
+	}
+	if p.IncludeGas {
+		q.Set("includeGas", "true")
+	}
+	if p.Receiver != "" {
+		q.Set("receiver", p.Receiver)
+	}
+	if p.Referrer != "" {
+		q.Set("referrer", p.Referrer)
+	}
+	if p.Permit != "" {
+		q.Set("permit", p.Permit)
+	}
+	var out SwapResponse
+	if err := c.get(ctx, fmt.Sprintf("/swap/v6.0/%d/swap", c.chainID), q, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Allowance returns how much the spender (1inch router) can pull from
+// owner for tokenAddress. Result is a base-unit decimal string.
+type AllowanceResponse struct {
+	Allowance string `json:"allowance"`
+}
+
+func (c *Client) Allowance(ctx context.Context, tokenAddress, walletAddress string) (string, error) {
+	q := url.Values{}
+	q.Set("tokenAddress", tokenAddress)
+	q.Set("walletAddress", walletAddress)
+	var out AllowanceResponse
+	if err := c.get(ctx, fmt.Sprintf("/swap/v6.0/%d/approve/allowance", c.chainID), q, &out); err != nil {
+		return "", err
+	}
+	return out.Allowance, nil
+}
+
+// ApproveTx returns the calldata + target for an approve(MAX) (or
+// approve(amount) if amount is non-empty) to the 1inch router.
+type ApproveTxResponse struct {
+	To       string `json:"to"`
+	Data     string `json:"data"`
+	Value    string `json:"value"`
+	GasPrice string `json:"gasPrice,omitempty"`
+}
+
+func (c *Client) ApproveTx(ctx context.Context, tokenAddress, amount string) (*ApproveTxResponse, error) {
+	q := url.Values{}
+	q.Set("tokenAddress", tokenAddress)
+	if amount != "" {
+		q.Set("amount", amount)
+	}
+	var out ApproveTxResponse
+	if err := c.get(ctx, fmt.Sprintf("/swap/v6.0/%d/approve/transaction", c.chainID), q, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Spender returns the 1inch router address — the spender that needs to
+// be approved before /swap can pull tokens. Result is cached per chain
+// inside 1inch and rarely changes, but we re-fetch on each call to be
+// safe.
+type SpenderResponse struct {
+	Address string `json:"address"`
+}
+
+func (c *Client) Spender(ctx context.Context) (string, error) {
+	var out SpenderResponse
+	if err := c.get(ctx, fmt.Sprintf("/swap/v6.0/%d/approve/spender", c.chainID), nil, &out); err != nil {
+		return "", err
+	}
+	return out.Address, nil
+}
+
+// ─── transport ──────────────────────────────────────────────────────────────
+
+func (c *Client) get(ctx context.Context, path string, q url.Values, out any) error {
+	u := c.baseURL + path
+	if len(q) > 0 {
+		u += "?" + q.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("oneinch: http: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("oneinch: read body: %w", err)
+	}
+	if resp.StatusCode/100 != 2 {
+		// 1inch returns JSON errors with description + statusCode fields.
+		var apiErr struct {
+			Description string `json:"description"`
+			Status      int    `json:"statusCode"`
+			Error       string `json:"error"`
+		}
+		_ = json.Unmarshal(body, &apiErr)
+		msg := apiErr.Description
+		if msg == "" {
+			msg = strings.TrimSpace(string(body))
+		}
+		return fmt.Errorf("oneinch %d: %s", resp.StatusCode, msg)
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("oneinch: parse response: %w (body=%q)", err, string(body))
+	}
+	return nil
+}
+
+// ParseUint parses a 1inch base-unit amount string. Helper for callers.
+func ParseUint(s string) (uint64, error) { return strconv.ParseUint(strings.TrimSpace(s), 10, 64) }

--- a/internal/swap/oneinch/client_test.go
+++ b/internal/swap/oneinch/client_test.go
@@ -1,0 +1,142 @@
+package oneinch
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// stubServer fakes the 1inch v6 API.
+func stubServer(t *testing.T, routes map[string]func(http.ResponseWriter, *http.Request)) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Match by path prefix because path includes the chainId segment.
+		for prefix, h := range routes {
+			if strings.Contains(r.URL.Path, prefix) {
+				h(w, r)
+				return
+			}
+		}
+		http.Error(w, "no route for "+r.URL.Path, http.StatusNotFound)
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+func TestClient_Quote_Happy(t *testing.T) {
+	srv := stubServer(t, map[string]func(http.ResponseWriter, *http.Request){
+		"/quote": func(w http.ResponseWriter, r *http.Request) {
+			if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+				t.Errorf("missing/incorrect auth header: %q", got)
+			}
+			if r.URL.Query().Get("amount") != "1000000" {
+				t.Errorf("amount param: %q", r.URL.Query().Get("amount"))
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"dstAmount": "999500",
+			})
+		},
+	})
+
+	c := NewClient(8453, "test-key", WithBaseURL(srv.URL))
+	q, err := c.Quote(context.Background(), QuoteParams{
+		Src:    "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+		Dst:    "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+		Amount: "1000000",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if q.DstAmount != "999500" {
+		t.Errorf("DstAmount: %q", q.DstAmount)
+	}
+}
+
+func TestClient_Swap_Happy(t *testing.T) {
+	srv := stubServer(t, map[string]func(http.ResponseWriter, *http.Request){
+		"/swap": func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("from") == "" {
+				t.Error("from param missing")
+			}
+			if r.URL.Query().Get("slippage") != "0.5" {
+				t.Errorf("slippage default: %q", r.URL.Query().Get("slippage"))
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"dstAmount": "999500",
+				"tx": map[string]any{
+					"from":  "0xfrom",
+					"to":    "0x1111111254eeb25477b68fb85ed929f73a960582", // 1inch router
+					"data":  "0xabcd",
+					"value": "0",
+					"gas":   200000,
+				},
+			})
+		},
+	})
+
+	c := NewClient(8453, "k", WithBaseURL(srv.URL))
+	resp, err := c.Swap(context.Background(), SwapParams{
+		Src:    "0xa",
+		Dst:    "0xb",
+		Amount: "1000000",
+		From:   "0xfrom",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Tx.To == "" || resp.Tx.Data == "" {
+		t.Errorf("missing tx fields in response: %+v", resp.Tx)
+	}
+}
+
+func TestClient_Allowance_AndApproveTx(t *testing.T) {
+	srv := stubServer(t, map[string]func(http.ResponseWriter, *http.Request){
+		"/approve/allowance": func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{"allowance": "0"})
+		},
+		"/approve/transaction": func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"to": "0x1111111254eeb25477b68fb85ed929f73a960582",
+				"data": "0x095ea7b3" +
+					"0000000000000000000000001111111254eeb25477b68fb85ed929f73a960582" +
+					"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+				"value": "0",
+			})
+		},
+	})
+
+	c := NewClient(8453, "k", WithBaseURL(srv.URL))
+	allow, err := c.Allowance(context.Background(), "0xtok", "0xowner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allow != "0" {
+		t.Errorf("allowance: %q", allow)
+	}
+	tx, err := c.ApproveTx(context.Background(), "0xtok", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(tx.Data, "0x095ea7b3") {
+		t.Errorf("approve calldata should start with 0x095ea7b3, got %q", tx.Data[:12])
+	}
+}
+
+func TestClient_APIErrorPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"description": "Insufficient liquidity",
+			"statusCode":  400,
+		})
+	}))
+	defer srv.Close()
+	c := NewClient(8453, "k", WithBaseURL(srv.URL))
+	_, err := c.Quote(context.Background(), QuoteParams{Src: "x", Dst: "y", Amount: "1"})
+	if err == nil || !strings.Contains(err.Error(), "Insufficient liquidity") {
+		t.Errorf("expected error to surface, got %v", err)
+	}
+}

--- a/internal/swap/oneinch/probe_aggregator_test.go
+++ b/internal/swap/oneinch/probe_aggregator_test.go
@@ -1,0 +1,132 @@
+//go:build live
+
+// Live mainnet aggregator probes. Run with:
+//
+//	export ONEINCH_API_KEY=...        # required (free key from portal.1inch.dev)
+//	export PERMAFROST_TEST_PRIVATE_KEY=...  # 32-byte hex; address must hold ~$5 USDC on Base
+//	export PERMAFROST_TEST_BROADCAST=1      # opt-in to actually swap
+//	go test -tags=live -v ./internal/swap/oneinch/... -run Probe
+//
+// Why only Base? Cheapest gas of the four chains by 100x — a $5 round
+// trip on Base costs pennies; on Ethereum mainnet it would cost more
+// than the trade.
+//
+// Without PERMAFROST_TEST_BROADCAST, the probe only fetches a quote +
+// allowance — useful for verifying the API key + signer pair without
+// touching real funds.
+package oneinch
+
+import (
+	"context"
+	"encoding/hex"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/chain/evm"
+	"github.com/teslashibe/permafrost/internal/types"
+	"github.com/teslashibe/permafrost/internal/wallet"
+)
+
+const (
+	usdcBase = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+	wethBase = "0x4200000000000000000000000000000000000006"
+)
+
+func TestProbeAggregator_BaseUSDCToWETH(t *testing.T) {
+	apiKey := os.Getenv("ONEINCH_API_KEY")
+	if apiKey == "" {
+		t.Skip("set ONEINCH_API_KEY to run the aggregator probe")
+	}
+	keyHex := os.Getenv("PERMAFROST_TEST_PRIVATE_KEY")
+	if keyHex == "" {
+		t.Skip("set PERMAFROST_TEST_PRIVATE_KEY (32-byte hex)")
+	}
+	rpcURL := os.Getenv("PERMAFROST_TEST_RPC_BASE")
+	if rpcURL == "" {
+		rpcURL = "https://mainnet.base.org" // public default; rate-limited
+	}
+
+	keyHex = strings.TrimPrefix(keyHex, "0x")
+	raw, err := hex.DecodeString(keyHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hl, err := wallet.NewHyperliquidSignerFromPrivate(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := wallet.NewEVMSigner(hl, types.ChainBase)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	v, err := New(Config{
+		OneInchAPIKey: apiKey, RPCURL: rpcURL, Chain: types.ChainBase,
+		PollTimeout: 60 * time.Second,
+	}, signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	usdc := types.Asset{Symbol: "USDC", Chain: types.ChainBase, Mint: usdcBase, Decimals: 6}
+	weth := types.Asset{Symbol: "WETH", Chain: types.ChainBase, Mint: wethBase, Decimals: 18}
+
+	// Always-safe step 1: report current balance.
+	chain, _ := evm.LookupChain(types.ChainBase)
+	rpc := evm.NewClient(rpcURL, chain)
+	usdcTok := evm.NewERC20Token(rpc, usdcBase)
+	bal, err := usdcTok.BalanceOf(ctx, signer.Address())
+	if err != nil {
+		t.Fatalf("balance: %v", err)
+	}
+	t.Logf("addr=%s usdc=%s (base units, 6dp)", signer.Address(), bal)
+
+	// Always-safe step 2: fetch a quote for $1 USDC → WETH (read-only).
+	q, err := v.Quote(ctx, types.QuoteRequest{
+		InToken: usdc, OutToken: weth, Amount: decimal.NewFromInt(1), Mode: types.QuoteExactIn,
+	})
+	if err != nil {
+		t.Fatalf("quote: %v", err)
+	}
+	t.Logf("quote: 1 USDC → %s WETH", q.OutAmount.StringFixed(8))
+
+	if os.Getenv("PERMAFROST_TEST_BROADCAST") != "1" {
+		t.Skip("set PERMAFROST_TEST_BROADCAST=1 to execute the swap (uses ~$1 of USDC)")
+	}
+
+	// HARD CAP: refuse to swap more than $5 worth.
+	const capUSDC = 5
+	tradeUSDC := big.NewInt(int64(1_000_000)) // 1 USDC base units (6dp)
+	if bal.Cmp(big.NewInt(int64(capUSDC*1_000_000))) < 0 {
+		t.Skipf("address has < %d USDC; fund it first", capUSDC)
+	}
+
+	q1, err := v.Quote(ctx, types.QuoteRequest{
+		InToken: usdc, OutToken: weth, Amount: decimal.NewFromBigInt(tradeUSDC, -6), Mode: types.QuoteExactIn,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx, err := v.Swap(ctx, q1, 100) // 1.0% slippage tolerance for safety
+	if err != nil {
+		t.Fatalf("swap: %v", err)
+	}
+	t.Logf("swap submitted: %s", chain.ExplorerURL(string(tx)))
+
+	res, err := v.WaitConfirm(ctx, tx)
+	if err != nil {
+		t.Fatalf("confirm: %v", err)
+	}
+	if res.Status != types.SwapStatusConfirmed {
+		t.Fatalf("swap failed: status=%s", res.Status)
+	}
+	t.Logf("✓ confirmed: gas_native=%s", res.GasNative)
+}

--- a/internal/swap/oneinch/venue.go
+++ b/internal/swap/oneinch/venue.go
@@ -1,0 +1,342 @@
+package oneinch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/chain/evm"
+	"github.com/teslashibe/permafrost/internal/swap"
+	"github.com/teslashibe/permafrost/internal/types"
+	"github.com/teslashibe/permafrost/internal/wallet"
+)
+
+// VenueName is the registered identifier of this SwapVenue.
+const VenueName = "oneinch"
+
+// nativeAddress is 1inch's sentinel for the native gas token (ETH on
+// ETH/Base, AVAX on Avalanche, BNB on BSC). Native swaps are deferred
+// in v1 — Quote/Swap reject any intent that uses this address until the
+// follow-up PR.
+const nativeAddress = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+
+// Venue implements swap.SwapVenue against 1inch on a single EVM chain.
+type Venue struct {
+	one         *Client
+	rpc         *evm.Client
+	signer      *wallet.EVMSigner
+	slippageBps int           // default if SwapIntent doesn't specify
+	pollTimeout time.Duration // confirmation wait budget; default 90s
+
+	// Per-(token,spender) infinite-approve cache. We hit
+	// allowance() once and trust the result for the lifetime of the
+	// process; the cache is invalidated on tx failure.
+	approvedMu sync.Mutex
+	approved   map[string]bool // key = lowercased token contract
+}
+
+// Config configures a Venue.
+type Config struct {
+	OneInchAPIKey   string
+	OneInchBaseURL  string // optional override (proxy)
+	RPCURL          string
+	Chain           types.ChainID // ChainEthereum / ChainBase / ChainAvalanche / ChainBSC
+	DefaultSlippage int           // bps; default 50 (0.5%)
+	PollTimeout     time.Duration // default 90s
+}
+
+// New constructs a Venue.
+func New(cfg Config, signer *wallet.EVMSigner) (*Venue, error) {
+	if signer == nil {
+		return nil, errors.New("oneinch: signer is required")
+	}
+	if signer.Chain() != cfg.Chain {
+		return nil, fmt.Errorf("oneinch: signer chain %q != venue chain %q",
+			signer.Chain(), cfg.Chain)
+	}
+	if cfg.RPCURL == "" {
+		return nil, errors.New("oneinch: RPCURL is required")
+	}
+	chain, err := evm.LookupChain(cfg.Chain)
+	if err != nil {
+		return nil, fmt.Errorf("oneinch: %w", err)
+	}
+	rpc := evm.NewClient(cfg.RPCURL, chain)
+
+	slip := cfg.DefaultSlippage
+	if slip <= 0 {
+		slip = 50
+	}
+	pollTO := cfg.PollTimeout
+	if pollTO == 0 {
+		pollTO = 90 * time.Second
+	}
+	return &Venue{
+		one:         NewClient(chain.NumericID, cfg.OneInchAPIKey, WithBaseURL(cfg.OneInchBaseURL)),
+		rpc:         rpc,
+		signer:      signer,
+		slippageBps: slip,
+		pollTimeout: pollTO,
+		approved:    map[string]bool{},
+	}, nil
+}
+
+// Compile-time check.
+var _ swap.SwapVenue = (*Venue)(nil)
+
+func (v *Venue) Name() string         { return VenueName }
+func (v *Venue) Chain() types.ChainID { return v.signer.Chain() }
+
+// Quote requests a price quote from 1inch. Native gas tokens are not
+// supported in v1 — see SCOPE.md.
+func (v *Venue) Quote(ctx context.Context, req types.QuoteRequest) (types.Quote, error) {
+	if err := guardNative(req.InToken, req.OutToken); err != nil {
+		return types.Quote{}, err
+	}
+	if req.Mode == types.QuoteExactOut {
+		return types.Quote{}, errors.New("oneinch: ExactOut is not supported")
+	}
+	amt := scaleAmount(req.Amount, req.InToken.Decimals)
+	q, err := v.one.Quote(ctx, QuoteParams{
+		Src:    req.InToken.Mint,
+		Dst:    req.OutToken.Mint,
+		Amount: amt.String(),
+	})
+	if err != nil {
+		return types.Quote{}, err
+	}
+	out := unscaleAmount(parseBigInt(q.DstAmount), req.OutToken.Decimals)
+	return types.Quote{
+		InToken:   req.InToken,
+		OutToken:  req.OutToken,
+		InAmount:  req.Amount,
+		OutAmount: out,
+		Route:     VenueName,
+		ExpiresAt: time.Now().Add(20 * time.Second).UTC(),
+		// Raw is intentionally empty — the /swap call is independent
+		// from /quote in 1inch v6 (unlike Jupiter), so we don't carry
+		// state forward.
+	}, nil
+}
+
+// Swap fetches the executable tx from 1inch, ensures the router has
+// allowance, signs the swap tx, broadcasts it, and returns the hash.
+//
+// The approval dance: 1inch's router needs an ERC-20 allowance from the
+// caller before it can pull tokens. We do an `approve(MAX)` once per
+// (chain, token) pair — that's the "plain infinite approve" model
+// chosen during scoping. The approval result is cached in v.approved
+// so we don't re-check on every swap.
+//
+// IMPORTANT: this method blocks until the approve tx (if needed) is
+// confirmed. We MUST NOT broadcast the swap before the approve is
+// mined, or the swap will revert on insufficient allowance.
+func (v *Venue) Swap(ctx context.Context, q types.Quote, slippageBps int) (types.TxHash, error) {
+	if time.Now().After(q.ExpiresAt) {
+		return "", swap.ErrQuoteExpired
+	}
+	if err := guardNative(q.InToken, q.OutToken); err != nil {
+		return "", err
+	}
+	if slippageBps <= 0 {
+		slippageBps = v.slippageBps
+	}
+
+	if err := v.ensureApproved(ctx, q.InToken); err != nil {
+		return "", fmt.Errorf("oneinch: approve: %w", err)
+	}
+
+	srcAmount := scaleAmount(q.InAmount, q.InToken.Decimals)
+	resp, err := v.one.Swap(ctx, SwapParams{
+		Src:              q.InToken.Mint,
+		Dst:              q.OutToken.Mint,
+		Amount:           srcAmount.String(),
+		From:             v.signer.Address(),
+		Slippage:         bpsToPercent(slippageBps),
+		DisableEstimate:  true, // we let RPC do estimation; 1inch's sim is finicky
+		AllowPartialFill: false,
+	})
+	if err != nil {
+		return "", fmt.Errorf("oneinch: /swap: %w", err)
+	}
+
+	value := new(big.Int)
+	if v, ok := new(big.Int).SetString(strings.TrimPrefix(resp.Tx.Value, "0x"), 10); ok {
+		value = v
+	}
+	req := evm.TxRequest{
+		From:     v.signer.Address(),
+		To:       resp.Tx.To,
+		Data:     ensureHexPrefix(resp.Tx.Data),
+		Value:    value,
+		GasLimit: resp.Tx.Gas, // 1inch's estimate; EstimateAndFill adds buffer if zero
+	}
+	if err := evm.EstimateAndFill(ctx, v.rpc, &req); err != nil {
+		return "", fmt.Errorf("oneinch: fill tx: %w", err)
+	}
+	hash, err := evm.SignAndSend(ctx, v.rpc, req, v.signer.PrivateKey())
+	if err != nil {
+		return "", fmt.Errorf("oneinch: send tx: %w", err)
+	}
+	return types.TxHash(hash), nil
+}
+
+// WaitConfirm polls eth_getTransactionReceipt until success/failure or
+// the budget elapses.
+func (v *Venue) WaitConfirm(ctx context.Context, tx types.TxHash) (types.SwapResult, error) {
+	r, err := v.rpc.WaitForReceipt(ctx, string(tx), v.pollTimeout, 2*time.Second)
+	if err != nil {
+		return types.SwapResult{TxHash: tx, Status: types.SwapStatusPending, Error: err.Error()}, nil
+	}
+	status := types.SwapStatusFailed
+	if r.IsSuccess() {
+		status = types.SwapStatusConfirmed
+	}
+	gasNative := decimal.Zero
+	if used, err := r.GasUsedUint(); err == nil {
+		if price, err := r.EffectiveGasPriceBig(); err == nil {
+			cost := new(big.Int).Mul(big.NewInt(int64(used)), price)
+			gasNative = decimal.NewFromBigInt(cost, -18) // wei → native units
+		}
+	}
+	return types.SwapResult{
+		TxHash:    tx,
+		Status:    status,
+		BlockTime: time.Now().UTC(),
+		GasNative: gasNative,
+	}, nil
+}
+
+// Balance reports the wallet balance of an ERC-20 (or native gas token)
+// for the configured signer address.
+func (v *Venue) Balance(ctx context.Context, asset types.Asset) (decimal.Decimal, error) {
+	if asset.Chain != v.Chain() {
+		return decimal.Zero, fmt.Errorf("oneinch: asset chain %q != venue chain %q",
+			asset.Chain, v.Chain())
+	}
+	if isNativeMint(asset.Mint) {
+		bal, err := v.rpc.GetBalance(ctx, v.signer.Address())
+		if err != nil {
+			return decimal.Zero, err
+		}
+		return decimal.NewFromBigInt(bal, -18), nil
+	}
+	tok := evm.NewERC20Token(v.rpc, asset.Mint)
+	bal, err := tok.BalanceOf(ctx, v.signer.Address())
+	if err != nil {
+		return decimal.Zero, err
+	}
+	return decimal.NewFromBigInt(bal, -asset.Decimals), nil
+}
+
+// ensureApproved checks (and if needed installs) infinite allowance
+// from the wallet to 1inch's router for token. Idempotent and cached.
+func (v *Venue) ensureApproved(ctx context.Context, token types.Asset) error {
+	if isNativeMint(token.Mint) {
+		return nil // native doesn't need approval
+	}
+	key := strings.ToLower(token.Mint)
+
+	v.approvedMu.Lock()
+	if v.approved[key] {
+		v.approvedMu.Unlock()
+		return nil
+	}
+	v.approvedMu.Unlock()
+
+	allowed, err := v.one.Allowance(ctx, token.Mint, v.signer.Address())
+	if err != nil {
+		return fmt.Errorf("oneinch: allowance: %w", err)
+	}
+	if allowed == "" || allowed == "0" {
+		approveResp, err := v.one.ApproveTx(ctx, token.Mint, "") // "" => MAX
+		if err != nil {
+			return fmt.Errorf("oneinch: approve calldata: %w", err)
+		}
+		req := evm.TxRequest{
+			From: v.signer.Address(),
+			To:   approveResp.To,
+			Data: ensureHexPrefix(approveResp.Data),
+		}
+		if err := evm.EstimateAndFill(ctx, v.rpc, &req); err != nil {
+			return fmt.Errorf("oneinch: fill approve tx: %w", err)
+		}
+		hash, err := evm.SignAndSend(ctx, v.rpc, req, v.signer.PrivateKey())
+		if err != nil {
+			return fmt.Errorf("oneinch: send approve tx: %w", err)
+		}
+		// MUST wait for the approve to confirm before we can swap.
+		r, err := v.rpc.WaitForReceipt(ctx, hash, v.pollTimeout, 2*time.Second)
+		if err != nil {
+			return fmt.Errorf("oneinch: approve receipt: %w", err)
+		}
+		if !r.IsSuccess() {
+			return fmt.Errorf("oneinch: approve tx %s reverted on chain", hash)
+		}
+	}
+
+	v.approvedMu.Lock()
+	v.approved[key] = true
+	v.approvedMu.Unlock()
+	return nil
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+func guardNative(in, out types.Asset) error {
+	if isNativeMint(in.Mint) || isNativeMint(out.Mint) {
+		return errors.New("oneinch: native gas-token swaps are not supported in v1 (see SCOPE.md)")
+	}
+	return nil
+}
+
+func isNativeMint(m string) bool { return strings.EqualFold(m, nativeAddress) }
+
+func ensureHexPrefix(s string) string {
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+		return s
+	}
+	return "0x" + s
+}
+
+func scaleAmount(amount decimal.Decimal, decimals int32) *big.Int {
+	if decimals < 0 {
+		decimals = 0
+	}
+	scaled := amount.Shift(decimals).Truncate(0)
+	if scaled.IsNegative() {
+		return new(big.Int)
+	}
+	return scaled.BigInt()
+}
+
+func unscaleAmount(units *big.Int, decimals int32) decimal.Decimal {
+	if units == nil {
+		return decimal.Zero
+	}
+	return decimal.NewFromBigInt(units, -decimals)
+}
+
+func parseBigInt(s string) *big.Int {
+	n := new(big.Int)
+	if s == "" {
+		return n
+	}
+	n.SetString(strings.TrimSpace(s), 10)
+	return n
+}
+
+// bpsToPercent converts 50 (bps) → "0.5" (percent string the 1inch
+// /swap endpoint expects).
+func bpsToPercent(bps int) string {
+	if bps <= 0 {
+		return "0.5"
+	}
+	return decimal.New(int64(bps), -2).String()
+}

--- a/internal/swap/oneinch/venue_test.go
+++ b/internal/swap/oneinch/venue_test.go
@@ -1,0 +1,239 @@
+package oneinch
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/types"
+	"github.com/teslashibe/permafrost/internal/wallet"
+)
+
+// stubKeystoreSigner returns a wallet.EVMSigner backed by a deterministic
+// secp256k1 key. Anvil account #0 — never used outside tests.
+func stubKeystoreSigner(t *testing.T, chain types.ChainID) *wallet.EVMSigner {
+	t.Helper()
+	raw, _ := hex.DecodeString("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80")
+	hl, err := wallet.NewHyperliquidSignerFromPrivate(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	es, err := wallet.NewEVMSigner(hl, chain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return es
+}
+
+// makeStubVenue stands up two HTTP stubs (1inch + RPC) and returns a
+// Venue plus the captured request counters. The RPC stub is intentionally
+// permissive — it just happily answers everything — so individual tests
+// can focus on assertions about 1inch behaviour and the runtime ordering.
+func makeStubVenue(t *testing.T, chain types.ChainID, allowance string) (*Venue, *atomic.Int32) {
+	t.Helper()
+
+	approveCalls := &atomic.Int32{}
+	swapCalls := &atomic.Int32{}
+
+	oneInch := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/quote"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"dstAmount": "999000"})
+		case strings.Contains(r.URL.Path, "/approve/allowance"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"allowance": allowance})
+		case strings.Contains(r.URL.Path, "/approve/transaction"):
+			approveCalls.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"to":    "0x1111111254eeb25477b68fb85ed929f73a960582",
+				"data":  "0x095ea7b3" + strings.Repeat("0", 64) + strings.Repeat("f", 64),
+				"value": "0",
+			})
+		case strings.Contains(r.URL.Path, "/swap"):
+			swapCalls.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"dstAmount": "999000",
+				"tx": map[string]any{
+					"from":  "0xfrom",
+					"to":    "0x1111111254eeb25477b68fb85ed929f73a960582",
+					"data":  "0xabcd",
+					"value": "0",
+				},
+			})
+		default:
+			http.Error(w, "no route "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(oneInch.Close)
+
+	rpc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Method string `json:"method"`
+			ID     uint64 `json:"id"`
+			Params []any  `json:"params"`
+		}
+		_ = json.Unmarshal(body, &req)
+		w.Header().Set("Content-Type", "application/json")
+		var result any
+		switch req.Method {
+		case "eth_chainId":
+			result = "0x2105"
+		case "eth_blockNumber":
+			result = "0x1"
+		case "eth_getBalance":
+			result = "0x16345785d8a0000" // 0.1 ETH
+		case "eth_getTransactionCount":
+			result = "0x0"
+		case "eth_gasPrice":
+			result = "0x3b9aca00" // 1 gwei
+		case "eth_maxPriorityFeePerGas":
+			result = "0x3b9aca00"
+		case "eth_feeHistory":
+			result = map[string]any{"baseFeePerGas": []string{"0x3b9aca00"}}
+		case "eth_estimateGas":
+			result = "0x30d40" // 200_000
+		case "eth_sendRawTransaction":
+			result = "0x" + strings.Repeat("ab", 32)
+		case "eth_getTransactionReceipt":
+			result = map[string]any{
+				"transactionHash":   "0x" + strings.Repeat("ab", 32),
+				"status":            "0x1",
+				"blockNumber":       "0x1",
+				"gasUsed":           "0x5208",
+				"effectiveGasPrice": "0x3b9aca00",
+			}
+		default:
+			http.Error(w, "stub: no method "+req.Method, http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0", "id": req.ID, "result": result,
+		})
+	}))
+	t.Cleanup(rpc.Close)
+
+	signer := stubKeystoreSigner(t, chain)
+	v, err := New(Config{
+		OneInchAPIKey:  "test-key",
+		OneInchBaseURL: oneInch.URL,
+		RPCURL:         rpc.URL,
+		Chain:          chain,
+		PollTimeout:    5 * time.Second,
+	}, signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return v, approveCalls
+}
+
+func TestVenue_Swap_RunsApproveOnceWhenAllowanceIsZero(t *testing.T) {
+	v, approveCalls := makeStubVenue(t, types.ChainBase, "0")
+
+	usdc := types.Asset{Symbol: "USDC", Chain: types.ChainBase, Mint: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", Decimals: 6}
+	weth := types.Asset{Symbol: "WETH", Chain: types.ChainBase, Mint: "0x4200000000000000000000000000000000000006", Decimals: 18}
+
+	q, err := v.Quote(context.Background(), types.QuoteRequest{
+		InToken: usdc, OutToken: weth, Amount: decimal.NewFromInt(1), Mode: types.QuoteExactIn,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx, err := v.Swap(context.Background(), q, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tx == "" {
+		t.Error("expected non-empty tx hash")
+	}
+	if got := approveCalls.Load(); got != 1 {
+		t.Errorf("expected exactly 1 approve calldata fetch, got %d", got)
+	}
+
+	// Second swap on the same token MUST NOT re-approve — cache hit.
+	if _, err := v.Swap(context.Background(), q, 50); err != nil {
+		t.Fatal(err)
+	}
+	if got := approveCalls.Load(); got != 1 {
+		t.Errorf("approve cache miss: got %d calldata fetches, want 1", got)
+	}
+}
+
+func TestVenue_Swap_SkipsApproveWhenAllowanceSufficient(t *testing.T) {
+	v, approveCalls := makeStubVenue(t, types.ChainAvalanche, "999999999999999999999999")
+
+	usdc := types.Asset{Symbol: "USDC", Chain: types.ChainAvalanche, Mint: "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e", Decimals: 6}
+	wavax := types.Asset{Symbol: "WAVAX", Chain: types.ChainAvalanche, Mint: "0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7", Decimals: 18}
+
+	q, err := v.Quote(context.Background(), types.QuoteRequest{
+		InToken: usdc, OutToken: wavax, Amount: decimal.NewFromInt(1), Mode: types.QuoteExactIn,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := v.Swap(context.Background(), q, 0); err != nil {
+		t.Fatal(err)
+	}
+	if got := approveCalls.Load(); got != 0 {
+		t.Errorf("expected 0 approve fetches when allowance is sufficient, got %d", got)
+	}
+}
+
+func TestVenue_Quote_RejectsNativeAsset(t *testing.T) {
+	v, _ := makeStubVenue(t, types.ChainEthereum, "0")
+	_, err := v.Quote(context.Background(), types.QuoteRequest{
+		InToken:  types.Asset{Symbol: "ETH", Chain: types.ChainEthereum, Mint: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", Decimals: 18},
+		OutToken: types.Asset{Symbol: "USDC", Chain: types.ChainEthereum, Mint: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", Decimals: 6},
+		Amount:   decimal.NewFromInt(1),
+	})
+	if err == nil || !strings.Contains(err.Error(), "native") {
+		t.Errorf("expected native-asset rejection, got %v", err)
+	}
+}
+
+func TestVenue_Quote_RejectsExactOut(t *testing.T) {
+	v, _ := makeStubVenue(t, types.ChainBase, "0")
+	_, err := v.Quote(context.Background(), types.QuoteRequest{
+		InToken:  types.Asset{Symbol: "USDC", Chain: types.ChainBase, Mint: "0x1", Decimals: 6},
+		OutToken: types.Asset{Symbol: "WETH", Chain: types.ChainBase, Mint: "0x2", Decimals: 18},
+		Amount:   decimal.NewFromInt(1),
+		Mode:     types.QuoteExactOut,
+	})
+	if err == nil || !strings.Contains(err.Error(), "ExactOut") {
+		t.Errorf("expected ExactOut rejection, got %v", err)
+	}
+}
+
+func TestVenue_NameAndChain(t *testing.T) {
+	v, _ := makeStubVenue(t, types.ChainBSC, "0")
+	if v.Name() != VenueName {
+		t.Errorf("name: %q", v.Name())
+	}
+	if v.Chain() != types.ChainBSC {
+		t.Errorf("chain: %q", v.Chain())
+	}
+}
+
+func TestBpsToPercent(t *testing.T) {
+	tests := map[int]string{
+		0:    "0.5",
+		50:   "0.5",
+		100:  "1",
+		25:   "0.25",
+		1000: "10",
+	}
+	for in, want := range tests {
+		if got := bpsToPercent(in); got != want {
+			t.Errorf("bpsToPercent(%d) = %q want %q", in, got, want)
+		}
+	}
+}

--- a/internal/types/asset.go
+++ b/internal/types/asset.go
@@ -6,12 +6,40 @@ package types
 import "fmt"
 
 // ChainID identifies a settlement venue or chain.
+//
+// Conventions:
+//   - lowercase short name
+//   - perp venues are still ChainIDs (Hyperliquid)
+//   - EVM chain ids match the human-readable name (ethereum/base/avalanche/bsc),
+//     not the numeric chain id; the numeric id lives in chain/evm/chains.go.
 type ChainID string
 
 const (
 	ChainHyperliquid ChainID = "hyperliquid"
 	ChainSolana      ChainID = "solana"
+
+	// EVM chains supported for spot legs via DEX aggregators.
+	ChainEthereum  ChainID = "ethereum"
+	ChainBase      ChainID = "base"
+	ChainAvalanche ChainID = "avalanche"
+	ChainBSC       ChainID = "bsc"
 )
+
+// IsEVM reports whether the chain settles via the EVM execution model
+// (so the EVM signer + JSON-RPC stack apply).
+func (c ChainID) IsEVM() bool {
+	switch c {
+	case ChainEthereum, ChainBase, ChainAvalanche, ChainBSC:
+		return true
+	}
+	return false
+}
+
+// IsSpotChain reports whether the chain hosts spot tokens that the
+// strategy can route through (i.e. has a SwapVenue adapter).
+func (c ChainID) IsSpotChain() bool {
+	return c == ChainSolana || c.IsEVM()
+}
 
 // Asset is a chain-bound token. For perpetual symbols traded on Hyperliquid,
 // Mint holds the perp symbol (e.g. "WIF-PERP") and Decimals holds the on-venue

--- a/internal/types/order.go
+++ b/internal/types/order.go
@@ -45,6 +45,12 @@ const (
 // OrderIntent is what a Strategy proposes. The agent runtime is responsible
 // for stamping ClientID (deterministic), validating with Risk, and submitting
 // to the Venue.
+//
+// BasisKey, when set, identifies the basis position this order belongs to.
+// Strategies that emit paired swap+order intents set the same BasisKey on
+// both legs so the runtime can reconcile them — necessary for multi-chain
+// where the spot OutToken.Symbol (e.g. "ETH-BASE") differs from the perp
+// Symbol (e.g. "ETH"). Single-chain strategies may leave it empty.
 type OrderIntent struct {
 	Venue       string          `json:"venue"`
 	Symbol      string          `json:"symbol"`
@@ -58,6 +64,7 @@ type OrderIntent struct {
 	PositionID  string          `json:"position_id"`      // links order to a strategy_position
 	DecisionID  string          `json:"decision_id"`      // links order to an agent_decision
 	Slot        int             `json:"slot"`             // ordinal within a decision
+	BasisKey    string          `json:"basis_key,omitempty"`
 	Tag         string          `json:"tag,omitempty"`    // strategy-defined annotation
 }
 

--- a/internal/types/swap.go
+++ b/internal/types/swap.go
@@ -40,6 +40,12 @@ type Quote struct {
 // on-chain asset. The agent runtime requests a Quote, validates it against
 // risk, then submits the Swap and waits for confirmation. ClientID is set by
 // the runtime for idempotency.
+//
+// BasisKey identifies the basis position this leg belongs to. Strategies
+// that emit paired swap+order intents (funding_arb_basic) set the same
+// BasisKey on both legs so the runtime can reconcile them — necessary
+// for multi-chain where the spot OutToken.Symbol (registry name like
+// "ETH-BASE") differs from the perp Symbol (HL name like "ETH").
 type SwapIntent struct {
 	Chain        ChainID         `json:"chain"`
 	InToken      Asset           `json:"in_token"`
@@ -51,6 +57,7 @@ type SwapIntent struct {
 	PositionID   string          `json:"position_id"`
 	DecisionID   string          `json:"decision_id"`
 	Slot         int             `json:"slot"`
+	BasisKey     string          `json:"basis_key,omitempty"`
 	Tag          string          `json:"tag,omitempty"`
 }
 

--- a/internal/wallet/evm.go
+++ b/internal/wallet/evm.go
@@ -1,0 +1,92 @@
+package wallet
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"errors"
+	"fmt"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// EVMSigner wraps the same secp256k1 keypair used for Hyperliquid and
+// adapts it to (1) the Signer interface (for any future generic
+// EVM-payload signing needs) and (2) a *crypto/ecdsa.PrivateKey for
+// go-ethereum's tx-signing path.
+//
+// Design rule: one secp256k1 secret → one EVM address → all four EVM
+// chains AND Hyperliquid. Operators only manage one secret; the
+// keystore stores it once under the "hyperliquid" slot.
+//
+// EVMSigner is bound to a SPECIFIC chain so deps wiring can label it
+// per-chain; the underlying key is identical across instances.
+type EVMSigner struct {
+	hl    *HyperliquidSigner
+	chain types.ChainID
+	priv  *ecdsa.PrivateKey
+}
+
+// NewEVMSigner adapts an existing HyperliquidSigner for use on any EVM
+// chain. The address is the same across all of them.
+func NewEVMSigner(hl *HyperliquidSigner, chain types.ChainID) (*EVMSigner, error) {
+	if hl == nil {
+		return nil, errors.New("evm: nil hyperliquid signer")
+	}
+	if !chain.IsEVM() {
+		return nil, fmt.Errorf("evm: chain %q is not an EVM chain", chain)
+	}
+	priv, err := ethcrypto.ToECDSA(hl.PrivateKeyBytes())
+	if err != nil {
+		return nil, fmt.Errorf("evm: bad secp256k1 secret: %w", err)
+	}
+	return &EVMSigner{hl: hl, chain: chain, priv: priv}, nil
+}
+
+// PrivateKey exposes the *ecdsa.PrivateKey for the go-ethereum tx
+// signer. The returned pointer MUST NOT be persisted, logged, or
+// shipped over the network.
+func (s *EVMSigner) PrivateKey() *ecdsa.PrivateKey { return s.priv }
+
+// Address is the same 0x-prefixed lowercase address as the underlying
+// HyperliquidSigner — cross-chain identity is intentional.
+func (s *EVMSigner) Address() string { return s.hl.Address() }
+
+// Chain is the EVM chain this signer is labelled for. Same secret can
+// back many EVMSigners with different Chain() values.
+func (s *EVMSigner) Chain() types.ChainID { return s.chain }
+
+// Sign produces a 65-byte ECDSA signature in [R || S || V] form. The
+// payload MUST be the 32-byte hash to sign. We delegate to the underlying
+// HyperliquidSigner so the signing surface is identical across HL EIP-712
+// actions and any future EVM personal_sign use case.
+func (s *EVMSigner) Sign(ctx context.Context, payload []byte) ([]byte, error) {
+	return s.hl.Sign(ctx, payload)
+}
+
+// Compile-time check.
+var _ Signer = (*EVMSigner)(nil)
+
+// EVMSignerFromKeystore resolves the Hyperliquid signer from a keystore
+// and binds it to the requested EVM chain. Returns ErrNoEVMSigner if
+// no Hyperliquid key is configured.
+func EVMSignerFromKeystore(ks Keystore, chain types.ChainID) (*EVMSigner, error) {
+	if ks == nil {
+		return nil, ErrNoEVMSigner
+	}
+	s, err := ks.Signer(types.ChainHyperliquid)
+	if err != nil {
+		return nil, ErrNoEVMSigner
+	}
+	hl, ok := s.(*HyperliquidSigner)
+	if !ok {
+		return nil, fmt.Errorf("evm: keystore signer for hyperliquid is %T, not *HyperliquidSigner", s)
+	}
+	return NewEVMSigner(hl, chain)
+}
+
+// ErrNoEVMSigner is returned when the keystore has no EVM-capable key.
+// Since we reuse the Hyperliquid secp256k1 key for EVM, this means "no
+// Hyperliquid key configured".
+var ErrNoEVMSigner = errors.New("wallet: no EVM signer in keystore (configure a Hyperliquid key)")

--- a/internal/wallet/evm_test.go
+++ b/internal/wallet/evm_test.go
@@ -1,0 +1,43 @@
+package wallet
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+func TestNewEVMSigner_DerivesSameAddressAsHL(t *testing.T) {
+	raw, _ := hex.DecodeString("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80")
+	hl, err := NewHyperliquidSignerFromPrivate(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	es, err := NewEVMSigner(hl, types.ChainBase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if es.Address() != hl.Address() {
+		t.Errorf("EVM and HL signers must share the same address; got %s vs %s",
+			es.Address(), hl.Address())
+	}
+	if es.Chain() != types.ChainBase {
+		t.Errorf("chain label: %q", es.Chain())
+	}
+}
+
+func TestNewEVMSigner_RejectsNonEVMChain(t *testing.T) {
+	raw, _ := hex.DecodeString("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80")
+	hl, _ := NewHyperliquidSignerFromPrivate(raw)
+	if _, err := NewEVMSigner(hl, types.ChainSolana); err == nil {
+		t.Error("expected error binding EVM signer to solana")
+	}
+}
+
+func TestEVMSignerFromKeystore_NoKey(t *testing.T) {
+	_, err := EVMSignerFromKeystore(nil, types.ChainBase)
+	if err == nil || err.Error() == "" || !strings.Contains(err.Error(), "no EVM signer") {
+		t.Errorf("expected ErrNoEVMSigner, got %v", err)
+	}
+}


### PR DESCRIPTION
## Why

Funding-arb candidates that don't have Solana spot liquidity (ETH, BTC, AVAX, BNB, plus most large-caps) were unreachable from v1. This PR ships the second SwapVenue family — 1inch v6 across the four EVM chains the user asked for — so the strategy can route spot legs to the cheapest chain per asset.

One free 1inch API key works across every chain. The same secp256k1 keypair already used for Hyperliquid signs every EVM tx — operators manage one secret across **five chains** (Solana + 4 EVMs).

## Stack

| Layer | Module |
|---|---|
| RPC | \`internal/chain/evm/rpc.go\` (chain id, balance, gas, estimate, sendRawTx, receipt poller) |
| Chain registry | \`internal/chain/evm/chains.go\` (4 mainnets + 4 testnets) |
| ERC-20 calldata | \`internal/chain/evm/erc20.go\` (balanceOf / allowance / approve; vectors verified vs go-ethereum's ABI packer) |
| Tx builder | \`internal/chain/evm/tx.go\` (EIP-1559 on ETH/Base, legacy gasPrice on AVAX/BSC; uses go-ethereum's signer for safety) |
| Signer | \`internal/wallet/evm.go\` (EVMSigner reuses the HL secp256k1 key, bound per chain) |
| 1inch client | \`internal/swap/oneinch/client.go\` (quote, swap, allowance, approve calldata, spender) |
| 1inch venue | \`internal/swap/oneinch/venue.go\` (\`swap.SwapVenue\` per chain) |

## Multi-chain plumbing

- \`Deps.Swap\` (single venue) → \`Deps.Swaps map[ChainID]SwapVenue\`. \`executeSwap\` routes by intent's \`Chain\` field. Missing entry = paper-spot fallback.
- \`BuildDeps\` wires Solana → Jupiter and each configured EVM chain → 1inch. Missing keystore signer for a chain logs WARN + skips that chain rather than refusing to start.
- New \`SwapIntent.BasisKey\` + \`OrderIntent.BasisKey\` fields. The funding_arb_basic strategy sets both to the registry symbol (e.g. \"ETH-BASE\") so reconcile pairs them unambiguously — without this, ETH-BASE's spot leg (\`OutToken.Symbol=\"ETH-BASE\"\`) never paired with its perp leg (\`Symbol=\"ETH\"\`, the HL perp name).

## Approval model: plain infinite \`approve(MAX)\`, cached

- One \`approve(spender, MAX)\` per (chain, token) pair on first use.
- Cache lives for the process lifetime; subsequent swaps skip the on-chain allowance check entirely.
- Approve tx MUST confirm before the swap is broadcast (otherwise the swap reverts on insufficient allowance) — implemented as a blocking \`WaitForReceipt\` in \`ensureApproved\`.

## Native gas-token swaps explicitly deferred

ETH/AVAX/BNB ↔ ERC-20 returns \"native gas-token swaps not supported in v1\" rather than silently routing bad asks. Follow-up PR.

## Asset registry — new entries

| Symbol | Perp | Spot |
|---|---|---|
| ETH-MAINNET | HL ETH | WETH on Ethereum |
| ETH-BASE | HL ETH | WETH on Base (cheaper gas) |
| BTC-MAINNET | HL BTC | WBTC on Ethereum |
| AVAX-MAINNET | HL AVAX | WAVAX on Avalanche |
| BNB-MAINNET | HL BNB | WBNB on BSC |

Naming convention is \`<PERP>-<CHAIN-SHORT>\` so the same HL perp can be hedged on multiple chains.

## Config

\`\`\`yaml
evm:
  oneinch_api_key_env: ONEINCH_API_KEY
  default_slippage_bps: 50
  chains:
    ethereum:  { rpc_url: https://ethereum-rpc.publicnode.com }
    base:      { rpc_url: https://mainnet.base.org }
    avalanche: { rpc_url: https://api.avax.network/ext/bc/C/rpc }
    bsc:       { rpc_url: https://bsc-rpc.publicnode.com }
\`\`\`

Omit a chain to disable it; the runtime falls back to paper-spot for any chain not listed here.

## Tests

**Unit:**
- ERC-20 calldata vectors verified vs known-good hex
- RPC client (stub HTTP): chain id, balance, block number, nonce, error propagation
- Tx builder (stub HTTP): EIP-1559 envelope correctness on Base, legacy on BSC, deterministic address derivation
- 1inch client (stub HTTP): auth header, /quote, /swap, allowance + approve flow, error JSON propagation
- 1inch venue (stub 1inch + stub RPC): approve runs once when allowance=0, cached on subsequent swaps, skipped when allowance is sufficient. Native + ExactOut rejected.
- EVMSigner: derives same address as HL signer; rejects non-EVM chains
- BuildDeps: degrades gracefully when EVM is configured but no signer

**Live (\`//go:build live\`):**
- \`probe_testnets_test.go\` — round-trips eth_chainId + eth_blockNumber on all 4 testnets
- \`probe_mainnets_test.go\` — same for all 4 mainnets
- \`probe_aggregator_test.go\` — \$5-cap USDC→WETH swap on Base, gated behind ONEINCH_API_KEY + PERMAFROST_TEST_BROADCAST=1

## Verified

**RPC connectivity (8/8):**
\`\`\`
$ go test -tags=live -v ./internal/chain/evm/... -run TestProbeMainnets_RPCRoundtrip
✓ Avalanche C-Chain (chain id 43114, head block 83215595)
✓ BNB Smart Chain   (chain id 56,    head block 93160103)
✓ Ethereum mainnet  (chain id 1,     head block 24903260)
✓ Base mainnet      (chain id 8453,  head block 44841961)
PASS
$ go test -tags=live -v ./internal/chain/evm/... -run TestProbeTestnets_RPCRoundtrip
✓ Ethereum Sepolia (chain id 11155111, head block 10681083)
✓ Base Sepolia     (chain id 84532,    head block 40352482)
✓ Avalanche Fuji   (chain id 43113,    head block 54272255)
✓ BSC testnet      (chain id 97,       head block 102293489)
PASS
\`\`\`

**End-to-end paper-mode multi-chain tick:**
\`\`\`
$ permafrost agent create --universe ETH-BASE,BTC-MAINNET,AVAX-MAINNET,BNB-MAINNET,WIF ...
$ permafrost agent tick multichain-test --funding 'ETH=150,BTC=120,AVAX=80,BNB=50,WIF=200'
INFO tick swaps=5 orders=5 cancels=0 open_basis=5

DB swaps grouped by chain:
  avalanche | 1
  base      | 1
  bsc       | 1
  ethereum  | 1
  solana    | 1

DB positions: 5 open (AVAX-MAINNET, BNB-MAINNET, BTC-MAINNET, ETH-BASE, WIF)
\`\`\`

**Cross-chain unwind:**
\`\`\`
$ permafrost agent tick multichain-test --funding 'ETH=10,BTC=10,AVAX=10,BNB=10,WIF=10'
DB swaps (close legs, in_token != USDC):
  avalanche | AVAX-MAINNET → USDC | 1
  base      | ETH-BASE     → USDC | 1
  bsc       | BNB-MAINNET  → USDC | 1
  ethereum  | BTC-MAINNET  → USDC | 1
  solana    | WIF          → USDC | 1

DB positions: 0 open / 5 closed
\`\`\`

## Verify locally
\`\`\`
go test ./... -count=1
go test -tags=live -v ./internal/chain/evm/... -run TestProbeMainnets
go test -tags=live -v ./internal/chain/evm/... -run TestProbeTestnets
\`\`\`

For the mainnet aggregator probe (~\$1 USDC consumed):
\`\`\`
export ONEINCH_API_KEY=...                    # free at portal.1inch.dev
export PERMAFROST_TEST_PRIVATE_KEY=...        # 32-byte hex; address holds ~\$5 USDC on Base
export PERMAFROST_TEST_BROADCAST=1
go test -tags=live -v ./internal/swap/oneinch/... -run Probe
\`\`\`