### PR TITLE
feat: per-tick NAV + P&L CLI + reconciliation tool

### DIFF
--- a/SCOPE.md
+++ b/SCOPE.md
@@ -416,6 +416,58 @@ POST   /v1/swap/quote                       # passthrough for testing
 
 ---
 
+## 10.5 P&L and reconciliation
+
+Operators need two questions answered without psql gymnastics: *is this strategy making money?* and *do my books match the venues?*. Two read-only systems answer them.
+
+### Per-tick NAV
+
+Every agent tick computes a NAV snapshot via `internal/pnl.Engine.ValueAgent` and persists it to `agent_nav_snapshots`. Each row carries:
+
+- `nav_usdc` — bottom-line equity if everything closed right now
+- `realized_pnl_usdc` — cumulative realized since agent inception (sum of `strategy_positions.realized_*` for closed rows)
+- `spot_value_usdc`, `perp_unrealized_usdc`, `funding_accrued_usdc` — components of unrealized
+- `cumulative_gas_usdc` — gas + fees across every swap/order
+- `positions` — JSONB array of per-basis valuations for ad-hoc inspection
+
+**Mark sources** (configurable per agent in v2; for v1):
+- Spot leg: live quote from the chain's SwapVenue (`token → USDC` for the held quantity), falling back to cost basis when no venue is wired.
+- Perp leg: Hyperliquid's `UnrealizedPnl` directly (it already accounts for funding-paid-during-position), falling back to zero when no Address is configured.
+- Funding accrual: cumulative `realized_funding` from the position; HL `userFunding` integration deferred.
+
+NAV computation NEVER blocks the tick — failures are logged at WARN and the tick continues.
+
+### CLI surface
+
+```
+permafrost pnl summary                     # all agents, latest snapshot
+permafrost pnl summary --live              # recompute against current marks
+permafrost pnl positions <agent>           # per-basis breakdown
+permafrost pnl history <agent> --since 7d  # NAV time series
+```
+
+### Reconciliation
+
+`internal/reconcile.Engine` walks an agent's open `BasisPositions` and verifies each leg against its venue:
+
+- **Perp leg**: HL position must exist with the right side and (within tolerance) the right size.
+- **Spot leg**: on-chain ERC-20/SPL balance must be ≥ expected (over-balance is fine — operator may have manually topped up).
+
+Findings are graded:
+- `info`     — could not verify (no venue wired); not actionable
+- `warning`  — drift within 100bps; operator should look
+- `critical` — leg missing entirely OR side flipped OR drift > 100bps; operator MUST act
+
+```
+permafrost reconcile <agent>             # human table
+permafrost reconcile --json              # machine output
+permafrost reconcile --fail-on-drift     # exit non-zero (cron / CI)
+```
+
+Default tolerance: 25bps; below = silent OK, above = warning, > 100bps = critical.
+
+---
+
 ## 11. Safety rails (non-negotiable)
 
 A leveraged AI agent will absolutely try to nuke the vault if you let it. Day-one requirements:

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/teslashibe/permafrost/internal/exchange"
 	"github.com/teslashibe/permafrost/internal/inference"
+	"github.com/teslashibe/permafrost/internal/pnl"
 	"github.com/teslashibe/permafrost/internal/risk"
 	"github.com/teslashibe/permafrost/internal/strategy"
 	"github.com/teslashibe/permafrost/internal/swap"
@@ -190,6 +192,10 @@ func (r *Runtime) tickOnce(ctx context.Context) (strategy.Decision, error) {
 
 	r.executeSwapsThenOrders(ctx, now, decisionID, in, dec)
 
+	// Persist a NAV snapshot on every tick. Failures are logged but do
+	// not bubble up — telemetry shouldn't block trading.
+	r.persistNAVSnapshot(ctx, now)
+
 	// One concise per-tick log so operators can see the daemon working
 	// without enabling debug. This is the only INFO line emitted per tick.
 	// open_basis is the post-tick count (after reconcile), not the
@@ -204,6 +210,45 @@ func (r *Runtime) tickOnce(ctx context.Context) (strategy.Decision, error) {
 		"open_basis", len(r.snapshotOpenBasis()),
 	)
 	return dec, nil
+}
+
+// persistNAVSnapshot computes a NAV snapshot using the pnl.Engine and
+// writes it to agent_nav_snapshots. Best-effort — any failure (RPC,
+// DB) is logged at WARN and does not affect the tick.
+func (r *Runtime) persistNAVSnapshot(ctx context.Context, now time.Time) {
+	if r.deps.Store == nil {
+		return
+	}
+	engine := pnl.New(r.deps.Perp, r.deps.Swaps)
+	hist, err := r.deps.Store.AggregatesForAgent(ctx, r.agent.ID)
+	if err != nil {
+		r.deps.Logger.Warn("nav: aggregates failed", "agent_id", r.agent.ID, "err", err)
+		return
+	}
+	nav, err := engine.ValueAgent(ctx, r.agent.ID, pnl.History{
+		OpenPositions:     r.snapshotOpenBasis(),
+		RealizedPnLUSDC:   hist.RealizedPnLUSDC,
+		CumulativeGasUSDC: hist.CumulativeGasUSDC,
+	})
+	if err != nil {
+		r.deps.Logger.Warn("nav: valuation failed", "agent_id", r.agent.ID, "err", err)
+		return
+	}
+	posJSON, _ := json.Marshal(nav.Positions)
+	if err := r.deps.Store.PersistNAVSnapshot(ctx, PersistNAVSnapshotInput{
+		Time:               now,
+		AgentID:            r.agent.ID,
+		NAVUSDC:            nav.NAVUSDC,
+		SpotValueUSDC:      nav.SpotValueUSDC,
+		PerpUnrealizedUSDC: nav.PerpUnrealizedUSDC,
+		FundingAccruedUSDC: nav.FundingAccruedUSDC,
+		RealizedPnLUSDC:    nav.RealizedPnLUSDC,
+		CumulativeGasUSDC:  nav.CumulativeGasUSDC,
+		OpenPositions:      nav.OpenPositions,
+		PositionsJSON:      posJSON,
+	}); err != nil {
+		r.deps.Logger.Warn("nav: persist failed", "agent_id", r.agent.ID, "err", err)
+	}
 }
 
 // buildDecisionInput pulls current state from venues + the configured

--- a/internal/agent/store.go
+++ b/internal/agent/store.go
@@ -8,11 +8,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
 
 	"github.com/teslashibe/permafrost/internal/types"
 )
+
+// errNoRowsSentinel is what pgx returns from QueryRow.Scan when no row
+// matched. Aliased here so the LatestNAVSnapshot caller doesn't have
+// to import pgx.
+var errNoRowsSentinel = pgx.ErrNoRows
 
 // Store wraps DB access for agent lifecycle and the decision/order/swap
 // audit logs.
@@ -337,6 +343,147 @@ WHERE agent_id = $1 AND underlying = $2 AND state IN ('open', 'opening', 'closin
 // ErrNoOpenBasis is returned by CloseBasis when no open row exists for the
 // supplied agent + underlying. Callers may treat this as a no-op.
 var ErrNoOpenBasis = errors.New("agent: no open basis to close")
+
+// PnLAggregates is what the runtime needs from the audit ledgers to
+// compute a NAV snapshot: cumulative realized P&L since agent inception
+// + cumulative gas + fees across every swap and order.
+type PnLAggregates struct {
+	RealizedPnLUSDC   decimal.Decimal // sum over closed strategy_positions
+	CumulativeGasUSDC decimal.Decimal // gas_paid across every swap
+}
+
+// AggregatesForAgent computes cumulative realized + gas figures for a
+// single agent. Cheap (two indexed scans) so safe to call per-tick.
+func (s *Store) AggregatesForAgent(ctx context.Context, agentID string) (PnLAggregates, error) {
+	var out PnLAggregates
+	const realizedQ = `
+SELECT COALESCE(SUM(realized_basis_pnl + realized_funding - realized_fees - realized_gas), 0)
+FROM strategy_positions
+WHERE agent_id = $1 AND state = 'closed';`
+	if err := s.pool.QueryRow(ctx, realizedQ, agentID).Scan(&out.RealizedPnLUSDC); err != nil {
+		return out, fmt.Errorf("agent: realized aggregate: %w", err)
+	}
+	const gasQ = `SELECT COALESCE(SUM(gas_paid), 0) FROM swaps WHERE agent_id = $1;`
+	if err := s.pool.QueryRow(ctx, gasQ, agentID).Scan(&out.CumulativeGasUSDC); err != nil {
+		return out, fmt.Errorf("agent: gas aggregate: %w", err)
+	}
+	return out, nil
+}
+
+// PersistNAVSnapshotInput is one row in agent_nav_snapshots.
+type PersistNAVSnapshotInput struct {
+	Time                time.Time
+	AgentID             string
+	NAVUSDC             decimal.Decimal
+	SpotValueUSDC       decimal.Decimal
+	PerpUnrealizedUSDC  decimal.Decimal
+	FundingAccruedUSDC  decimal.Decimal
+	RealizedPnLUSDC     decimal.Decimal
+	CumulativeGasUSDC   decimal.Decimal
+	OpenPositions       int
+	PositionsJSON       []byte // serialised []pnl.BasisValuation
+}
+
+// PersistNAVSnapshot inserts (or no-ops on dup) a NAV snapshot row.
+// Idempotent on (agent_id, time) — re-runs at the exact same instant
+// are silently dropped, which matches how the runtime can spam ticks
+// in tests.
+func (s *Store) PersistNAVSnapshot(ctx context.Context, in PersistNAVSnapshotInput) error {
+	const q = `
+INSERT INTO agent_nav_snapshots
+    (time, agent_id, nav_usdc, spot_value_usdc, perp_unrealized_usdc,
+     funding_accrued_usdc, realized_pnl_usdc, cumulative_gas_usdc,
+     open_positions, positions)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+ON CONFLICT (agent_id, time) DO NOTHING;`
+	if _, err := s.pool.Exec(ctx, q,
+		in.Time.UTC(), in.AgentID,
+		in.NAVUSDC, in.SpotValueUSDC, in.PerpUnrealizedUSDC,
+		in.FundingAccruedUSDC, in.RealizedPnLUSDC, in.CumulativeGasUSDC,
+		in.OpenPositions, in.PositionsJSON,
+	); err != nil {
+		return fmt.Errorf("agent: persist nav snapshot: %w", err)
+	}
+	return nil
+}
+
+// NAVSnapshotRow is a single row read back from agent_nav_snapshots.
+type NAVSnapshotRow struct {
+	Time                time.Time
+	AgentID             string
+	NAVUSDC             decimal.Decimal
+	SpotValueUSDC       decimal.Decimal
+	PerpUnrealizedUSDC  decimal.Decimal
+	FundingAccruedUSDC  decimal.Decimal
+	RealizedPnLUSDC     decimal.Decimal
+	CumulativeGasUSDC   decimal.Decimal
+	OpenPositions       int
+	PositionsJSON       []byte
+}
+
+// LatestNAVSnapshot returns the most recent NAV snapshot for an agent,
+// or (nil, nil) if none exists.
+func (s *Store) LatestNAVSnapshot(ctx context.Context, agentID string) (*NAVSnapshotRow, error) {
+	const q = `
+SELECT time, agent_id, nav_usdc, spot_value_usdc, perp_unrealized_usdc,
+       funding_accrued_usdc, realized_pnl_usdc, cumulative_gas_usdc,
+       open_positions, positions
+FROM agent_nav_snapshots
+WHERE agent_id = $1
+ORDER BY time DESC
+LIMIT 1;`
+	var r NAVSnapshotRow
+	if err := s.pool.QueryRow(ctx, q, agentID).Scan(
+		&r.Time, &r.AgentID, &r.NAVUSDC, &r.SpotValueUSDC, &r.PerpUnrealizedUSDC,
+		&r.FundingAccruedUSDC, &r.RealizedPnLUSDC, &r.CumulativeGasUSDC,
+		&r.OpenPositions, &r.PositionsJSON,
+	); err != nil {
+		if errors.Is(err, errNoRows()) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("agent: latest nav: %w", err)
+	}
+	return &r, nil
+}
+
+// NAVHistory returns NAV snapshots since `since` (oldest first), capped
+// to the configured limit. Used by the CLI for time-series printing.
+func (s *Store) NAVHistory(ctx context.Context, agentID string, since time.Time, limit int) ([]NAVSnapshotRow, error) {
+	if limit <= 0 || limit > 10_000 {
+		limit = 1_000
+	}
+	const q = `
+SELECT time, agent_id, nav_usdc, spot_value_usdc, perp_unrealized_usdc,
+       funding_accrued_usdc, realized_pnl_usdc, cumulative_gas_usdc,
+       open_positions, positions
+FROM agent_nav_snapshots
+WHERE agent_id = $1 AND time >= $2
+ORDER BY time ASC
+LIMIT $3;`
+	rows, err := s.pool.Query(ctx, q, agentID, since.UTC(), limit)
+	if err != nil {
+		return nil, fmt.Errorf("agent: nav history: %w", err)
+	}
+	defer rows.Close()
+	var out []NAVSnapshotRow
+	for rows.Next() {
+		var r NAVSnapshotRow
+		if err := rows.Scan(
+			&r.Time, &r.AgentID, &r.NAVUSDC, &r.SpotValueUSDC, &r.PerpUnrealizedUSDC,
+			&r.FundingAccruedUSDC, &r.RealizedPnLUSDC, &r.CumulativeGasUSDC,
+			&r.OpenPositions, &r.PositionsJSON,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// errNoRows is a tiny shim that returns pgx's ErrNoRows without forcing
+// every caller to import the driver. Used only by the nil-result paths
+// above.
+func errNoRows() error { return errNoRowsSentinel }
 
 // LoadOpenBasis returns all currently-open BasisPositions for the agent.
 // Used by the runtime to hydrate its in-memory view on startup.

--- a/internal/cli/pnl.go
+++ b/internal/cli/pnl.go
@@ -1,0 +1,397 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/spf13/cobra"
+
+	"github.com/teslashibe/permafrost/internal/agent"
+	"github.com/teslashibe/permafrost/internal/assets"
+	"github.com/teslashibe/permafrost/internal/pnl"
+)
+
+func init() { addCommandFactory(newPnLCmd) }
+
+func newPnLCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "pnl",
+		Short:   "Show P&L and NAV for one or all agents",
+		Aliases: []string{"pl"},
+	}
+	cmd.AddCommand(newPnLSummaryCmd())
+	cmd.AddCommand(newPnLPositionsCmd())
+	cmd.AddCommand(newPnLHistoryCmd())
+	return cmd
+}
+
+// ─── pnl summary ────────────────────────────────────────────────────────────
+
+func newPnLSummaryCmd() *cobra.Command {
+	var (
+		agentID  string
+		jsonOut  bool
+		liveMark bool
+	)
+	cmd := &cobra.Command{
+		Use:   "summary",
+		Short: "Per-agent NAV summary (one row per agent)",
+		Long: `Reads the most recent NAV snapshot for each agent and prints a
+summary table.
+
+By default uses the persisted snapshot (cheap; matches what the daemon
+last computed). Pass --live to recompute against current marks — useful
+when the daemon hasn't ticked recently or you want a fresh number.`,
+		RunE: func(c *cobra.Command, _ []string) error {
+			s, db, err := openAgentStore(c)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			ctx := c.Context()
+
+			var agents []agent.Agent
+			if agentID != "" {
+				a, err := s.Get(ctx, agentID)
+				if err != nil {
+					return err
+				}
+				agents = []agent.Agent{a}
+			} else {
+				agents, err = s.List(ctx)
+				if err != nil {
+					return err
+				}
+			}
+
+			rows := make([]pnlSummaryRow, 0, len(agents))
+			for _, a := range agents {
+				row, err := summaryFor(c, ctx, s, a, liveMark)
+				if err != nil {
+					return err
+				}
+				rows = append(rows, row)
+			}
+			sort.Slice(rows, func(i, j int) bool { return rows[i].AgentID < rows[j].AgentID })
+
+			if jsonOut {
+				return writeJSON(rows)
+			}
+			renderSummary(rows)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&agentID, "agent", "", "limit to a specific agent id (default: all agents)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSON instead of a table")
+	cmd.Flags().BoolVar(&liveMark, "live", false, "recompute NAV against live marks instead of using the latest snapshot")
+	return cmd
+}
+
+type pnlSummaryRow struct {
+	AgentID            string          `json:"agent_id"`
+	Strategy           string          `json:"strategy"`
+	Mode               string          `json:"mode"`
+	Status             string          `json:"status"`
+	OpenPositions      int             `json:"open_positions"`
+	NAVUSDC            decimal.Decimal `json:"nav_usdc"`
+	RealizedUSDC       decimal.Decimal `json:"realized_usdc"`
+	UnrealizedUSDC     decimal.Decimal `json:"unrealized_usdc"`
+	GasUSDC            decimal.Decimal `json:"gas_usdc"`
+	SnapshotAt         time.Time       `json:"snapshot_at"`
+	Source             string          `json:"source"` // "snapshot" | "live"
+}
+
+func summaryFor(c *cobra.Command, ctx context.Context, s *agent.Store, a agent.Agent, live bool) (pnlSummaryRow, error) {
+	row := pnlSummaryRow{
+		AgentID:  a.ID,
+		Strategy: a.Strategy,
+		Mode:     string(a.Mode),
+		Status:   string(a.Status),
+	}
+	if live {
+		nav, err := computeLiveNAV(c, ctx, s, a)
+		if err != nil {
+			return row, err
+		}
+		row.NAVUSDC = nav.NAVUSDC
+		row.RealizedUSDC = nav.RealizedPnLUSDC
+		row.UnrealizedUSDC = nav.NAVUSDC.Sub(nav.RealizedPnLUSDC)
+		row.GasUSDC = nav.CumulativeGasUSDC
+		row.OpenPositions = nav.OpenPositions
+		row.SnapshotAt = nav.Time
+		row.Source = "live"
+		return row, nil
+	}
+	snap, err := s.LatestNAVSnapshot(ctx, a.ID)
+	if err != nil {
+		return row, err
+	}
+	if snap == nil {
+		row.Source = "none"
+		return row, nil
+	}
+	row.NAVUSDC = snap.NAVUSDC
+	row.RealizedUSDC = snap.RealizedPnLUSDC
+	row.UnrealizedUSDC = snap.NAVUSDC.Sub(snap.RealizedPnLUSDC)
+	row.GasUSDC = snap.CumulativeGasUSDC
+	row.OpenPositions = snap.OpenPositions
+	row.SnapshotAt = snap.Time
+	row.Source = "snapshot"
+	return row, nil
+}
+
+func renderSummary(rows []pnlSummaryRow) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "AGENT\tSTRATEGY\tMODE\tSTATUS\tOPEN\tREALIZED\tUNREALIZED\tNAV\tGAS\tSOURCE\tAGE")
+	for _, r := range rows {
+		age := "—"
+		if !r.SnapshotAt.IsZero() {
+			age = humanAge(time.Since(r.SnapshotAt))
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			r.AgentID, r.Strategy, r.Mode, r.Status, r.OpenPositions,
+			fmtUSDC(r.RealizedUSDC), fmtUSDC(r.UnrealizedUSDC),
+			fmtUSDC(r.NAVUSDC), fmtUSDC(r.GasUSDC), r.Source, age,
+		)
+	}
+	_ = w.Flush()
+}
+
+// ─── pnl positions ──────────────────────────────────────────────────────────
+
+func newPnLPositionsCmd() *cobra.Command {
+	var (
+		agentID string
+		jsonOut bool
+		live    bool
+	)
+	cmd := &cobra.Command{
+		Use:   "positions <agent-id>",
+		Short: "Per-position breakdown for an agent (open basis positions)",
+		RunE: func(c *cobra.Command, args []string) error {
+			if agentID == "" && len(args) == 1 {
+				agentID = args[0]
+			}
+			if agentID == "" {
+				return errors.New("provide --agent or pass the agent id as an argument")
+			}
+			s, db, err := openAgentStore(c)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			ctx := c.Context()
+
+			a, err := s.Get(ctx, agentID)
+			if err != nil {
+				return err
+			}
+
+			var positions []pnl.BasisValuation
+			if live {
+				nav, err := computeLiveNAV(c, ctx, s, a)
+				if err != nil {
+					return err
+				}
+				positions = nav.Positions
+			} else {
+				snap, err := s.LatestNAVSnapshot(ctx, agentID)
+				if err != nil {
+					return err
+				}
+				if snap == nil {
+					fmt.Println("no NAV snapshot yet — run a tick or use --live")
+					return nil
+				}
+				_ = json.Unmarshal(snap.PositionsJSON, &positions)
+			}
+
+			if jsonOut {
+				return writeJSON(positions)
+			}
+			renderPositions(positions)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&agentID, "agent", "", "agent id (alias for positional arg)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSON instead of a table")
+	cmd.Flags().BoolVar(&live, "live", false, "recompute against live marks")
+	return cmd
+}
+
+func renderPositions(positions []pnl.BasisValuation) {
+	if len(positions) == 0 {
+		fmt.Println("(no open positions)")
+		return
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "BASIS\tCHAIN\tSPOT QTY\tCOST USDC\tSPOT VAL\tPERP UPNL\tFUNDING\tGAS\tNET P&L\tSTATUS")
+	for _, p := range positions {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			p.Underlying, p.Chain,
+			fmtAmount(p.SpotQty),
+			fmtUSDC(p.SpotCostBasisUSDC),
+			fmtUSDC(p.SpotValueUSDC),
+			fmtUSDC(p.PerpUnrealizedUSDC),
+			fmtUSDC(p.FundingAccruedUSDC),
+			fmtUSDC(p.GasPaidUSDC),
+			fmtUSDC(p.NetUnrealizedUSDC),
+			p.Status,
+		)
+	}
+	_ = w.Flush()
+}
+
+// ─── pnl history ────────────────────────────────────────────────────────────
+
+func newPnLHistoryCmd() *cobra.Command {
+	var (
+		agentID string
+		since   string
+		limit   int
+		jsonOut bool
+	)
+	cmd := &cobra.Command{
+		Use:   "history <agent-id>",
+		Short: "NAV time series for an agent",
+		RunE: func(c *cobra.Command, args []string) error {
+			if agentID == "" && len(args) == 1 {
+				agentID = args[0]
+			}
+			if agentID == "" {
+				return errors.New("provide --agent or pass the agent id")
+			}
+			d, err := time.ParseDuration(since)
+			if err != nil {
+				return fmt.Errorf("--since: %w", err)
+			}
+			s, db, err := openAgentStore(c)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			rows, err := s.NAVHistory(c.Context(), agentID, time.Now().Add(-d), limit)
+			if err != nil {
+				return err
+			}
+			if jsonOut {
+				return writeJSON(rows)
+			}
+			if len(rows) == 0 {
+				fmt.Println("(no NAV snapshots in window)")
+				return nil
+			}
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(w, "TIME\tNAV\tREALIZED\tUNREALIZED\tOPEN\tGAS")
+			for _, r := range rows {
+				unrealized := r.NAVUSDC.Sub(r.RealizedPnLUSDC)
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\n",
+					r.Time.Format(time.RFC3339),
+					fmtUSDC(r.NAVUSDC),
+					fmtUSDC(r.RealizedPnLUSDC),
+					fmtUSDC(unrealized),
+					r.OpenPositions,
+					fmtUSDC(r.CumulativeGasUSDC),
+				)
+			}
+			_ = w.Flush()
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&agentID, "agent", "", "agent id (alias for positional arg)")
+	cmd.Flags().StringVar(&since, "since", "24h", "lookback window (Go duration)")
+	cmd.Flags().IntVar(&limit, "limit", 1_000, "max rows")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSON")
+	return cmd
+}
+
+// ─── shared helpers ─────────────────────────────────────────────────────────
+
+// computeLiveNAV runs the same valuation the runtime persists, but
+// against current state. Used by --live flags so operators can get a
+// fresh number without waiting for the next tick.
+func computeLiveNAV(c *cobra.Command, ctx context.Context, s *agent.Store, a agent.Agent) (pnl.AgentNAV, error) {
+	g := FromContext(ctx)
+	if g == nil {
+		return pnl.AgentNAV{}, errors.New("globals not initialised")
+	}
+	reg, err := assets.LoadEmbedded()
+	if err != nil {
+		return pnl.AgentNAV{}, err
+	}
+	ks, _ := openKeystore(c) // best-effort
+	deps, err := agent.BuildDeps(a, reg, s, ks, g.Log, agent.BuildOptions{
+		Solana: solanaSpotFromConfig(g.Config.Solana),
+		EVM:    evmSpotsFromConfig(g.Config.EVM, os.Getenv),
+	})
+	if err != nil {
+		return pnl.AgentNAV{}, err
+	}
+	hist, err := s.AggregatesForAgent(ctx, a.ID)
+	if err != nil {
+		return pnl.AgentNAV{}, err
+	}
+	open, err := s.LoadOpenBasis(ctx, a.ID)
+	if err != nil {
+		return pnl.AgentNAV{}, err
+	}
+	return pnl.New(deps.Perp, deps.Swaps).ValueAgent(ctx, a.ID, pnl.History{
+		OpenPositions:     open,
+		RealizedPnLUSDC:   hist.RealizedPnLUSDC,
+		CumulativeGasUSDC: hist.CumulativeGasUSDC,
+	})
+}
+
+// fmtUSDC renders a decimal as a $-prefixed 4dp string with sign for
+// negative values. Zero shows as "$0.0000".
+func fmtUSDC(d decimal.Decimal) string {
+	if d.IsZero() {
+		return "$0.0000"
+	}
+	sign := ""
+	if d.IsNegative() {
+		sign = "-"
+		d = d.Abs()
+	}
+	return sign + "$" + d.StringFixed(4)
+}
+
+// fmtAmount renders a non-USDC amount with adaptive precision.
+func fmtAmount(d decimal.Decimal) string {
+	if d.IsZero() {
+		return "0"
+	}
+	s := d.StringFixed(8)
+	s = strings.TrimRight(s, "0")
+	s = strings.TrimRight(s, ".")
+	return s
+}
+
+// humanAge condenses a Duration for the SOURCE column.
+func humanAge(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}
+
+func writeJSON(v any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -1,0 +1,148 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/teslashibe/permafrost/internal/agent"
+	"github.com/teslashibe/permafrost/internal/assets"
+	"github.com/teslashibe/permafrost/internal/reconcile"
+)
+
+func init() { addCommandFactory(newReconcileCmd) }
+
+func newReconcileCmd() *cobra.Command {
+	var (
+		agentID   string
+		jsonOut   bool
+		failOnDrift bool
+	)
+	cmd := &cobra.Command{
+		Use:   "reconcile [agent-id]",
+		Short: "Verify the agent's books match what the venues actually report",
+		Long: `Walks each open basis position and checks both legs against the
+venues. Catches half-open positions, missed fills, and bookkeeping
+bugs early — before they bleed money.
+
+Without an agent id, reconciles every agent. Returns a non-zero exit
+code (when --fail-on-drift is set) so this can be wired into a cron or
+CI job.`,
+		RunE: func(c *cobra.Command, args []string) error {
+			if agentID == "" && len(args) == 1 {
+				agentID = args[0]
+			}
+			s, db, err := openAgentStore(c)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			ctx := c.Context()
+
+			var agents []agent.Agent
+			if agentID != "" {
+				a, err := s.Get(ctx, agentID)
+				if err != nil {
+					return err
+				}
+				agents = []agent.Agent{a}
+			} else {
+				agents, err = s.List(ctx)
+				if err != nil {
+					return err
+				}
+			}
+
+			g := FromContext(ctx)
+			if g == nil {
+				return errors.New("globals not initialised")
+			}
+			reg, err := assets.LoadEmbedded()
+			if err != nil {
+				return err
+			}
+			ks, _ := openKeystore(c) // best-effort
+
+			combined := reconcile.Report{}
+			for _, a := range agents {
+				deps, err := agent.BuildDeps(a, reg, s, ks, g.Log, agent.BuildOptions{
+					Solana: solanaSpotFromConfig(g.Config.Solana),
+					EVM:    evmSpotsFromConfig(g.Config.EVM, os.Getenv),
+				})
+				if err != nil {
+					return fmt.Errorf("build deps for %s: %w", a.ID, err)
+				}
+				open, err := s.LoadOpenBasis(ctx, a.ID)
+				if err != nil {
+					return err
+				}
+				eng := reconcile.New(deps.Perp, deps.Swaps)
+				rep, err := eng.Reconcile(ctx, a.ID, open)
+				if err != nil {
+					return err
+				}
+				combined.OpenBasis += rep.OpenBasis
+				combined.OK += rep.OK
+				combined.Drifts = append(combined.Drifts, rep.Drifts...)
+				combined.AgentsCount++
+			}
+			combined.GeneratedAt = time.Now().UTC()
+
+			if jsonOut {
+				return writeJSON(combined)
+			}
+			renderReconcileReport(combined)
+			if failOnDrift && combined.HasIssues() {
+				return errors.New("reconcile: drift detected")
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&agentID, "agent", "", "agent id (alias for positional arg)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSON report")
+	cmd.Flags().BoolVar(&failOnDrift, "fail-on-drift", false, "exit non-zero when warnings/critical drift is found (cron-friendly)")
+	return cmd
+}
+
+func renderReconcileReport(r reconcile.Report) {
+	fmt.Printf("Reconciled %d agents — %d open positions — %d clean — %d drift entries\n\n",
+		r.AgentsCount, r.OpenBasis, r.OK, len(r.Drifts))
+	if len(r.Drifts) == 0 {
+		fmt.Println("All clean.")
+		return
+	}
+	sort.Slice(r.Drifts, func(i, j int) bool {
+		// Critical first, then warning, then info; tiebreak by basis name.
+		si := severityRank(r.Drifts[i].Severity)
+		sj := severityRank(r.Drifts[j].Severity)
+		if si != sj {
+			return si < sj
+		}
+		return r.Drifts[i].BasisKey < r.Drifts[j].BasisKey
+	})
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "SEV\tAGENT\tBASIS\tLEG\tFIELD\tEXPECTED\tACTUAL\tNOTE")
+	for _, d := range r.Drifts {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			d.Severity, d.AgentID, d.BasisKey, d.Leg, d.Field,
+			d.Expected.String(), d.Actual.String(), d.Note,
+		)
+	}
+	_ = w.Flush()
+}
+
+func severityRank(s reconcile.Severity) int {
+	switch s {
+	case reconcile.SeverityCritical:
+		return 0
+	case reconcile.SeverityWarning:
+		return 1
+	default:
+		return 2
+	}
+}

--- a/internal/pnl/pnl.go
+++ b/internal/pnl/pnl.go
@@ -1,0 +1,281 @@
+// Package pnl values open basis positions at the current market and
+// produces per-agent NAV snapshots.
+//
+// Design rule: this package is read-only with respect to chain state —
+// it never broadcasts. The Engine pulls live marks from the configured
+// venues (HL for perps, SwapVenue for spot) and combines them with
+// historical state from the agent.Store to produce a single AgentNAV.
+//
+// For paper-mode agents that don't have live venues wired, the Engine
+// degrades gracefully: spot legs are valued at cost basis and perp
+// unrealized is zero. The numbers are honest about what we don't know.
+package pnl
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/exchange"
+	"github.com/teslashibe/permafrost/internal/swap"
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// Engine values open basis positions and aggregates per-agent NAV.
+//
+// Perp / Swaps are optional. When a venue is missing, the Engine
+// fills the corresponding fields with zero (NOT an error) and sets
+// the appropriate ValuationStatus on the per-position result.
+type Engine struct {
+	Perp  exchange.Venue
+	Swaps map[types.ChainID]swap.SwapVenue
+}
+
+// New constructs an Engine. Both fields may be nil for fully degraded
+// (paper-mode) operation.
+func New(perp exchange.Venue, swaps map[types.ChainID]swap.SwapVenue) *Engine {
+	return &Engine{Perp: perp, Swaps: swaps}
+}
+
+// SwapVenueFor returns the venue routed for the given chain or nil.
+func (e *Engine) SwapVenueFor(c types.ChainID) swap.SwapVenue {
+	if e == nil || e.Swaps == nil {
+		return nil
+	}
+	return e.Swaps[c]
+}
+
+// ValuationStatus describes how confident we are in a Valuation.
+type ValuationStatus string
+
+const (
+	// ValuationOK means both legs were marked at live venues.
+	ValuationOK ValuationStatus = "ok"
+	// ValuationDegradedSpot means we couldn't quote the spot leg
+	// (no SwapVenue or quote failed) and used cost basis instead.
+	ValuationDegradedSpot ValuationStatus = "spot_at_cost"
+	// ValuationDegradedPerp means we couldn't fetch HL position data
+	// (no Perp venue or no Address) and used zero unrealized.
+	ValuationDegradedPerp ValuationStatus = "perp_no_unrealized"
+	// ValuationDegradedBoth means neither leg could be marked.
+	ValuationDegradedBoth ValuationStatus = "both_at_cost"
+)
+
+// BasisValuation values one open basis position at the current market.
+//
+// Sign conventions (USDC, all):
+//   - SpotValueUSDC      ≥ 0
+//   - SpotCostBasisUSDC  ≥ 0
+//   - PerpUnrealizedUSDC may be positive or negative (for a short, positive
+//     when the mark dropped below entry)
+//   - FundingAccruedUSDC may be positive (received) or negative (paid)
+//   - GasPaidUSDC        ≥ 0  (always a cost)
+//   - NetUnrealizedUSDC  may be positive or negative — the bottom line if
+//     the position closed RIGHT NOW
+//     = (SpotValue − SpotCostBasis) + PerpUnrealized + FundingAccrued − GasPaid
+type BasisValuation struct {
+	BasisKey            string          `json:"basis_key"`
+	Underlying          string          `json:"underlying"`
+	Chain               types.ChainID   `json:"chain"`
+	OpenedAt            time.Time       `json:"opened_at"`
+	SpotQty             decimal.Decimal `json:"spot_qty"`
+	SpotMarkUSDC        decimal.Decimal `json:"spot_mark_usdc"`
+	SpotValueUSDC       decimal.Decimal `json:"spot_value_usdc"`
+	SpotCostBasisUSDC   decimal.Decimal `json:"spot_cost_basis_usdc"`
+	PerpSize            decimal.Decimal `json:"perp_size"`
+	PerpEntryPrice      decimal.Decimal `json:"perp_entry_price"`
+	PerpMarkUSDC        decimal.Decimal `json:"perp_mark_usdc"`
+	PerpUnrealizedUSDC  decimal.Decimal `json:"perp_unrealized_usdc"`
+	FundingAccruedUSDC  decimal.Decimal `json:"funding_accrued_usdc"`
+	GasPaidUSDC         decimal.Decimal `json:"gas_paid_usdc"`
+	NetUnrealizedUSDC   decimal.Decimal `json:"net_unrealized_usdc"`
+	Status              ValuationStatus `json:"status"`
+}
+
+// AgentNAV is the snapshot persisted to agent_nav_snapshots.
+type AgentNAV struct {
+	Time                 time.Time        `json:"time"`
+	AgentID              string           `json:"agent_id"`
+	NAVUSDC              decimal.Decimal  `json:"nav_usdc"`
+	SpotValueUSDC        decimal.Decimal  `json:"spot_value_usdc"`
+	PerpUnrealizedUSDC   decimal.Decimal  `json:"perp_unrealized_usdc"`
+	FundingAccruedUSDC   decimal.Decimal  `json:"funding_accrued_usdc"`
+	RealizedPnLUSDC      decimal.Decimal  `json:"realized_pnl_usdc"`
+	CumulativeGasUSDC    decimal.Decimal  `json:"cumulative_gas_usdc"`
+	OpenPositions        int              `json:"open_positions"`
+	Positions            []BasisValuation `json:"positions"`
+}
+
+// History is the input the Engine needs from the agent.Store: cumulative
+// realized numbers plus the open positions to value. Decoupled here so
+// the engine doesn't import internal/agent (avoids cycle: agent → pnl
+// for runtime hookup; pnl → agent for store would loop).
+type History struct {
+	OpenPositions     []types.BasisPosition
+	RealizedPnLUSDC   decimal.Decimal // cumulative since agent inception
+	CumulativeGasUSDC decimal.Decimal // gas + fees on every swap/order ever
+}
+
+// ValueAgent computes per-position valuations and the aggregate NAV.
+// Errors only when an underlying RPC fails; missing venues are treated
+// as a degraded (but successful) result.
+func (e *Engine) ValueAgent(ctx context.Context, agentID string, hist History) (AgentNAV, error) {
+	now := time.Now().UTC()
+	out := AgentNAV{
+		Time:              now,
+		AgentID:           agentID,
+		RealizedPnLUSDC:   hist.RealizedPnLUSDC,
+		CumulativeGasUSDC: hist.CumulativeGasUSDC,
+		OpenPositions:     len(hist.OpenPositions),
+		Positions:         make([]BasisValuation, 0, len(hist.OpenPositions)),
+	}
+
+	// Pull HL positions once per call so we don't hammer the API per basis.
+	// Map perp_symbol → HL position. nil map means "no perp data available".
+	perpBySymbol := map[string]types.Position{}
+	if e != nil && e.Perp != nil {
+		positions, err := e.Perp.Positions(ctx)
+		if err == nil {
+			for _, p := range positions {
+				perpBySymbol[p.Symbol] = p
+			}
+		}
+		// silently ignore err — degraded valuation is fine
+	}
+
+	for _, p := range hist.OpenPositions {
+		v, err := e.valueOne(ctx, p, perpBySymbol)
+		if err != nil {
+			return AgentNAV{}, fmt.Errorf("value basis %s: %w", p.Underlying, err)
+		}
+		out.Positions = append(out.Positions, v)
+		out.SpotValueUSDC = out.SpotValueUSDC.Add(v.SpotValueUSDC)
+		out.PerpUnrealizedUSDC = out.PerpUnrealizedUSDC.Add(v.PerpUnrealizedUSDC)
+		out.FundingAccruedUSDC = out.FundingAccruedUSDC.Add(v.FundingAccruedUSDC)
+	}
+
+	// NAV = realized + unrealized + funding − gas + spot value held
+	// We DON'T add SpotValueUSDC to NAV directly because it includes the
+	// cost basis we already spent — that's not new equity. Instead NAV
+	// reflects the marked value of the open positions (spot value −
+	// cost basis = unrealized spot P&L) plus the perp unrealized.
+	openUnrealized := decimal.Zero
+	for _, v := range out.Positions {
+		openUnrealized = openUnrealized.Add(v.NetUnrealizedUSDC)
+	}
+	out.NAVUSDC = hist.RealizedPnLUSDC.Add(openUnrealized)
+
+	// Stable per-position ordering for predictable JSONB and CLI output.
+	sort.Slice(out.Positions, func(i, j int) bool {
+		return out.Positions[i].Underlying < out.Positions[j].Underlying
+	})
+	return out, nil
+}
+
+func (e *Engine) valueOne(ctx context.Context, p types.BasisPosition, perpBySymbol map[string]types.Position) (BasisValuation, error) {
+	v := BasisValuation{
+		BasisKey:   p.Underlying,
+		Underlying: p.Underlying,
+		OpenedAt:   p.OpenedAt,
+		GasPaidUSDC: p.RealizedGas,
+		FundingAccruedUSDC: p.RealizedFunding,
+	}
+
+	spotLeg, perpLeg, ok := splitLegs(p.Legs)
+	if !ok {
+		return v, errors.New("basis position must have spot + perp legs")
+	}
+	v.Chain = spotLeg.Asset.Chain
+	v.SpotCostBasisUSDC = spotLeg.Qty // USDC committed
+	v.PerpSize = perpLeg.Qty
+	v.PerpEntryPrice = perpLeg.AvgPrice
+
+	// Spot leg valuation: quote token → USDC at current price.
+	// Spot quantity (in tokens) is approximated as the perp leg's size,
+	// matching funding_arb_basic's delta-neutral 1:1 sizing. The strategy
+	// always holds spot_qty ≈ perp_size; if they diverge in future
+	// strategies we'll thread a real BaseQty through BasisLeg.
+	v.SpotQty = perpLeg.Qty
+	swapVenue := e.SwapVenueFor(spotLeg.Asset.Chain)
+	gotSpotMark := false
+	if swapVenue != nil && v.SpotQty.IsPositive() {
+		usdc := types.Asset{Symbol: "USDC", Chain: spotLeg.Asset.Chain, Decimals: 6}
+		q, err := swapVenue.Quote(ctx, types.QuoteRequest{
+			InToken:  spotLeg.Asset,
+			OutToken: usdc,
+			Amount:   v.SpotQty,
+			Mode:     types.QuoteExactIn,
+		})
+		if err == nil && q.OutAmount.IsPositive() {
+			v.SpotValueUSDC = q.OutAmount
+			if v.SpotQty.IsPositive() {
+				v.SpotMarkUSDC = q.OutAmount.Div(v.SpotQty)
+			}
+			gotSpotMark = true
+		}
+	}
+	if !gotSpotMark {
+		// Degraded: assume spot is worth what we paid.
+		v.SpotValueUSDC = v.SpotCostBasisUSDC
+		if v.SpotQty.IsPositive() {
+			v.SpotMarkUSDC = v.SpotCostBasisUSDC.Div(v.SpotQty)
+		}
+	}
+
+	// Perp leg valuation: prefer HL's UnrealizedPnl (it accounts for
+	// funding-paid-during-position correctly). Fall back to entry−mark
+	// math if no HL data is available.
+	gotPerp := false
+	if hp, ok := perpBySymbol[perpLeg.Symbol]; ok {
+		v.PerpMarkUSDC = markFromPosition(hp)
+		v.PerpUnrealizedUSDC = hp.UnrealizedPx
+		gotPerp = true
+	}
+
+	v.Status = decideStatus(gotSpotMark, gotPerp)
+
+	v.NetUnrealizedUSDC = v.SpotValueUSDC.Sub(v.SpotCostBasisUSDC).
+		Add(v.PerpUnrealizedUSDC).
+		Add(v.FundingAccruedUSDC).
+		Sub(v.GasPaidUSDC)
+	return v, nil
+}
+
+// markFromPosition extracts the implied mark from a HL position:
+// mark = entry + (unrealized / qty). Returns the entry price if qty is
+// zero (defensive — shouldn't happen for an open position).
+func markFromPosition(p types.Position) decimal.Decimal {
+	if p.Qty.IsZero() {
+		return p.EntryPrice
+	}
+	return p.EntryPrice.Add(p.UnrealizedPx.Div(p.Qty))
+}
+
+func splitLegs(legs []types.BasisLeg) (spot, perp types.BasisLeg, ok bool) {
+	for _, l := range legs {
+		switch l.Kind {
+		case types.BasisLegSpot:
+			spot = l
+		case types.BasisLegPerp:
+			perp = l
+		}
+	}
+	return spot, perp, !spot.Asset.Chain.IsSpotChain() == false || perp.Symbol != ""
+}
+
+func decideStatus(gotSpot, gotPerp bool) ValuationStatus {
+	switch {
+	case gotSpot && gotPerp:
+		return ValuationOK
+	case gotSpot && !gotPerp:
+		return ValuationDegradedPerp
+	case !gotSpot && gotPerp:
+		return ValuationDegradedSpot
+	default:
+		return ValuationDegradedBoth
+	}
+}

--- a/internal/pnl/pnl_test.go
+++ b/internal/pnl/pnl_test.go
@@ -1,0 +1,245 @@
+package pnl
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/swap"
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+func d(s string) decimal.Decimal {
+	v, err := decimal.NewFromString(s)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// stubPerp implements just enough of exchange.Venue for ValueAgent's
+// Positions() call. The other methods aren't exercised by the engine.
+type stubPerp struct {
+	positions []types.Position
+	err       error
+}
+
+func (s *stubPerp) Name() string { return "stub" }
+func (s *stubPerp) FundingRates(_ context.Context, _ []string) ([]types.FundingRate, error) {
+	return nil, nil
+}
+func (s *stubPerp) Subscribe(_ context.Context, _ []string) (<-chan types.MarketEvent, error) {
+	return nil, nil
+}
+func (s *stubPerp) Positions(_ context.Context) ([]types.Position, error) {
+	return s.positions, s.err
+}
+func (s *stubPerp) Balances(_ context.Context) ([]types.Balance, error) { return nil, nil }
+func (s *stubPerp) Place(_ context.Context, _ types.OrderIntent) (types.OrderAck, error) {
+	return types.OrderAck{}, nil
+}
+func (s *stubPerp) Cancel(_ context.Context, _ types.OrderID) error { return nil }
+
+// stubSwap implements just enough of swap.SwapVenue for the spot leg
+// quote in valueOne. quote is the OUT amount returned for any input.
+type stubSwap struct {
+	chain     types.ChainID
+	outAmount decimal.Decimal
+	err       error
+}
+
+func (s *stubSwap) Name() string         { return "stubswap" }
+func (s *stubSwap) Chain() types.ChainID { return s.chain }
+func (s *stubSwap) Quote(_ context.Context, req types.QuoteRequest) (types.Quote, error) {
+	if s.err != nil {
+		return types.Quote{}, s.err
+	}
+	return types.Quote{
+		InToken: req.InToken, OutToken: req.OutToken,
+		InAmount: req.Amount, OutAmount: s.outAmount,
+		ExpiresAt: time.Now().Add(20 * time.Second),
+	}, nil
+}
+func (s *stubSwap) Swap(_ context.Context, _ types.Quote, _ int) (types.TxHash, error) {
+	return "stub-tx", nil
+}
+func (s *stubSwap) WaitConfirm(_ context.Context, tx types.TxHash) (types.SwapResult, error) {
+	return types.SwapResult{TxHash: tx, Status: types.SwapStatusConfirmed}, nil
+}
+func (s *stubSwap) Balance(_ context.Context, _ types.Asset) (decimal.Decimal, error) {
+	return decimal.Zero, nil
+}
+
+// makeBasis builds a synthetic open basis position. spotCost is what
+// we paid in USDC; perpSize is the perp short size; entryPx is the
+// perp entry price.
+func makeBasis(underlying, perpSym string, chain types.ChainID, spotCostUSDC, perpSize, entryPx decimal.Decimal) types.BasisPosition {
+	return types.BasisPosition{
+		ID:         "bp:test:" + underlying,
+		AgentID:    "test-agent",
+		Underlying: underlying,
+		State:      types.BasisStateOpen,
+		OpenedAt:   time.Now().Add(-time.Hour).UTC(),
+		Legs: []types.BasisLeg{
+			{Kind: types.BasisLegSpot, Asset: types.Asset{
+				Symbol: underlying, Chain: chain, Mint: "stub-mint", Decimals: 6,
+			}, Qty: spotCostUSDC},
+			{Kind: types.BasisLegPerp, Symbol: perpSym, Qty: perpSize, AvgPrice: entryPx},
+		},
+	}
+}
+
+func TestValueAgent_NoVenues_DegradedBoth(t *testing.T) {
+	bp := makeBasis("WIF", "WIF", types.ChainSolana, d("100"), d("100"), d("1.0"))
+	e := New(nil, nil)
+	nav, err := e.ValueAgent(context.Background(), "a", History{
+		OpenPositions: []types.BasisPosition{bp},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nav.OpenPositions != 1 {
+		t.Errorf("open positions: %d", nav.OpenPositions)
+	}
+	got := nav.Positions[0]
+	if got.Status != ValuationDegradedBoth {
+		t.Errorf("status: %q", got.Status)
+	}
+	if !got.SpotValueUSDC.Equal(d("100")) {
+		t.Errorf("spot value: %s want 100", got.SpotValueUSDC)
+	}
+	if !got.PerpUnrealizedUSDC.IsZero() {
+		t.Errorf("perp unrealized should be 0 without HL: %s", got.PerpUnrealizedUSDC)
+	}
+	if !got.NetUnrealizedUSDC.IsZero() {
+		t.Errorf("net unrealized should be 0 without venue marks: %s", got.NetUnrealizedUSDC)
+	}
+}
+
+// TestValueAgent_PerpUnrealized: HL reports +5 USDC unrealized → flows
+// straight through to NetUnrealized (assuming no spot drift).
+func TestValueAgent_PerpUnrealized(t *testing.T) {
+	bp := makeBasis("WIF", "WIF", types.ChainSolana, d("100"), d("100"), d("1.0"))
+	perp := &stubPerp{positions: []types.Position{
+		{
+			Venue:        "stub",
+			Symbol:       "WIF",
+			Qty:          d("-100"), // SHORT
+			EntryPrice:   d("1.0"),
+			UnrealizedPx: d("5.0"), // funding rate moved in our favour
+		},
+	}}
+	e := New(perp, nil)
+	nav, err := e.ValueAgent(context.Background(), "a", History{
+		OpenPositions: []types.BasisPosition{bp},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := nav.Positions[0]
+	if !got.PerpUnrealizedUSDC.Equal(d("5")) {
+		t.Errorf("perp unrealized: %s want 5", got.PerpUnrealizedUSDC)
+	}
+	if got.Status != ValuationDegradedSpot {
+		t.Errorf("status: %q want spot_at_cost", got.Status)
+	}
+	// Spot at cost (no swap venue), perp +5, no funding/gas → net = 5
+	if !got.NetUnrealizedUSDC.Equal(d("5")) {
+		t.Errorf("net unrealized: %s want 5", got.NetUnrealizedUSDC)
+	}
+	if !nav.NAVUSDC.Equal(d("5")) {
+		t.Errorf("nav: %s want 5", nav.NAVUSDC)
+	}
+}
+
+// TestValueAgent_SpotMarkUp: spot leg appreciated +2 USDC, perp moved
+// against us −2 USDC → net delta-neutral by design.
+func TestValueAgent_SpotMarkUp(t *testing.T) {
+	bp := makeBasis("WIF", "WIF", types.ChainSolana, d("100"), d("100"), d("1.0"))
+	perp := &stubPerp{positions: []types.Position{
+		{Venue: "s", Symbol: "WIF", Qty: d("-100"), EntryPrice: d("1.0"),
+			UnrealizedPx: d("-2.0")},
+	}}
+	swp := &stubSwap{chain: types.ChainSolana, outAmount: d("102")} // 100 tokens worth $102 now
+	e := New(perp, map[types.ChainID]swap.SwapVenue{types.ChainSolana: swp})
+
+	nav, err := e.ValueAgent(context.Background(), "a", History{
+		OpenPositions: []types.BasisPosition{bp},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := nav.Positions[0]
+	if got.Status != ValuationOK {
+		t.Errorf("status: %q want ok", got.Status)
+	}
+	if !got.SpotValueUSDC.Equal(d("102")) {
+		t.Errorf("spot value: %s want 102", got.SpotValueUSDC)
+	}
+	// Spot +2, perp -2 → net 0 (perfect hedge)
+	if !got.NetUnrealizedUSDC.IsZero() {
+		t.Errorf("net unrealized should be 0 (delta-neutral): %s", got.NetUnrealizedUSDC)
+	}
+}
+
+// TestValueAgent_RealizedAndGas: history aggregates flow into NAV.
+func TestValueAgent_RealizedAndGas(t *testing.T) {
+	e := New(nil, nil)
+	nav, err := e.ValueAgent(context.Background(), "a", History{
+		RealizedPnLUSDC:   d("12.50"),
+		CumulativeGasUSDC: d("3.20"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !nav.RealizedPnLUSDC.Equal(d("12.5")) {
+		t.Errorf("realized: %s", nav.RealizedPnLUSDC)
+	}
+	// No open positions, no unrealized; NAV == realized.
+	if !nav.NAVUSDC.Equal(d("12.5")) {
+		t.Errorf("nav: %s want 12.5", nav.NAVUSDC)
+	}
+	if nav.OpenPositions != 0 {
+		t.Errorf("open positions: %d", nav.OpenPositions)
+	}
+}
+
+// TestValueAgent_PerpRPCError_DegradesGracefully: a venue error must NOT
+// fail the whole valuation — it should degrade to "spot_at_cost"-style
+// status. The runtime can't be allowed to crash because HL is flaky.
+func TestValueAgent_PerpRPCError_DegradesGracefully(t *testing.T) {
+	bp := makeBasis("WIF", "WIF", types.ChainSolana, d("100"), d("100"), d("1.0"))
+	perp := &stubPerp{err: errors.New("rpc down")}
+	e := New(perp, nil)
+	nav, err := e.ValueAgent(context.Background(), "a", History{
+		OpenPositions: []types.BasisPosition{bp},
+	})
+	if err != nil {
+		t.Fatalf("ValueAgent must not fail on perp RPC error: %v", err)
+	}
+	if nav.Positions[0].Status != ValuationDegradedBoth {
+		t.Errorf("status: %q (expected both — perp errored, no swap venue)",
+			nav.Positions[0].Status)
+	}
+}
+
+// TestValueAgent_DeterministicOrdering keeps the JSONB stable so DB
+// queries can compare snapshots cleanly.
+func TestValueAgent_DeterministicOrdering(t *testing.T) {
+	bps := []types.BasisPosition{
+		makeBasis("WIF", "WIF", types.ChainSolana, d("100"), d("100"), d("1")),
+		makeBasis("BONK", "BONK", types.ChainSolana, d("100"), d("100"), d("0.001")),
+		makeBasis("AVAX", "AVAX", types.ChainAvalanche, d("100"), d("3"), d("30")),
+	}
+	e := New(nil, nil)
+	nav, _ := e.ValueAgent(context.Background(), "a", History{OpenPositions: bps})
+	want := []string{"AVAX", "BONK", "WIF"}
+	for i, p := range nav.Positions {
+		if p.Underlying != want[i] {
+			t.Errorf("position %d: got %s want %s", i, p.Underlying, want[i])
+		}
+	}
+}

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -1,0 +1,306 @@
+// Package reconcile compares the agent's persisted view of the world
+// (strategy_positions, swap/order ledgers) against what the venues
+// actually report on chain or via API. Drift is the early-warning signal
+// for half-open positions, missed fills, and bookkeeping bugs — the
+// kind of issue that bleeds money quietly until someone notices.
+//
+// Two reconciliation modes:
+//
+//   - Per-agent: for ONE agent, walk its open BasisPositions and verify
+//     each leg against its venue. Reports drift per leg.
+//   - Global: walk every running agent and produce a unified report.
+//
+// Drift severity is split into three buckets so callers (CLI, future
+// alerting) can decide what to escalate:
+//
+//   - Info    — mark moved, balance changed within tolerance, etc.
+//   - Warning — quantity mismatch within configurable tolerance.
+//   - Critical — leg missing entirely (we think we're hedged but aren't).
+package reconcile
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/exchange"
+	"github.com/teslashibe/permafrost/internal/swap"
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+// Severity is how loud the operator should hear about a discrepancy.
+type Severity string
+
+const (
+	SeverityInfo     Severity = "info"
+	SeverityWarning  Severity = "warning"
+	SeverityCritical Severity = "critical"
+)
+
+// Drift is one discrepancy between book and venue.
+type Drift struct {
+	AgentID    string          `json:"agent_id"`
+	BasisKey   string          `json:"basis_key"`
+	Underlying string          `json:"underlying"`
+	Leg        string          `json:"leg"`        // "spot" | "perp"
+	Field      string          `json:"field"`      // "qty" | "exists" | "side"
+	Expected   decimal.Decimal `json:"expected"`
+	Actual     decimal.Decimal `json:"actual"`
+	Diff       decimal.Decimal `json:"diff"`
+	Severity   Severity        `json:"severity"`
+	Note       string          `json:"note"`
+}
+
+// Report is the result of one reconciliation pass.
+type Report struct {
+	GeneratedAt time.Time `json:"generated_at"`
+	AgentsCount int       `json:"agents_count"`
+	OpenBasis   int       `json:"open_basis"`
+	OK          int       `json:"ok"`         // basis positions with no drift
+	Drifts      []Drift   `json:"drifts"`
+}
+
+// HasIssues reports whether anything more severe than Info was found.
+func (r Report) HasIssues() bool {
+	for _, d := range r.Drifts {
+		if d.Severity != SeverityInfo {
+			return true
+		}
+	}
+	return false
+}
+
+// Engine performs reconciliation. Both venues are optional; missing
+// venues yield "Could not verify <leg>" Info entries rather than errors.
+type Engine struct {
+	Perp  exchange.Venue
+	Swaps map[types.ChainID]swap.SwapVenue
+	// QtyToleranceBps is the relative tolerance below which a quantity
+	// drift is considered a Warning (not Critical). Default 25 bps.
+	// Anything matching exactly within this band is silently OK.
+	QtyToleranceBps int
+}
+
+// New constructs an Engine with the standard tolerance.
+func New(perp exchange.Venue, swaps map[types.ChainID]swap.SwapVenue) *Engine {
+	return &Engine{Perp: perp, Swaps: swaps, QtyToleranceBps: 25}
+}
+
+// Reconcile walks the open basis positions of one agent and verifies
+// each leg against its venue. Returns the drift list (which may be
+// empty). Errors only on hard RPC failures; a missing venue is degraded
+// silently into "could not verify" entries.
+func (e *Engine) Reconcile(ctx context.Context, agentID string, open []types.BasisPosition) (Report, error) {
+	r := Report{
+		GeneratedAt: time.Now().UTC(),
+		AgentsCount: 1,
+		OpenBasis:   len(open),
+	}
+
+	// Pull HL positions once so we don't query per-leg.
+	perpBySymbol := map[string]types.Position{}
+	perpAvailable := false
+	if e != nil && e.Perp != nil {
+		positions, err := e.Perp.Positions(ctx)
+		if err == nil {
+			perpAvailable = true
+			for _, p := range positions {
+				perpBySymbol[p.Symbol] = p
+			}
+		}
+	}
+
+	for _, p := range open {
+		drifts := e.reconcileOne(ctx, agentID, p, perpBySymbol, perpAvailable)
+		// "OK" means no warnings or criticals — Info entries (e.g.
+		// "no venue configured; could not verify") are status updates
+		// rather than problems.
+		if !hasIssue(drifts) {
+			r.OK++
+		}
+		r.Drifts = append(r.Drifts, drifts...)
+	}
+	return r, nil
+}
+
+func hasIssue(drifts []Drift) bool {
+	for _, d := range drifts {
+		if d.Severity != SeverityInfo {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *Engine) reconcileOne(ctx context.Context, agentID string, p types.BasisPosition, perpBySymbol map[string]types.Position, perpAvailable bool) []Drift {
+	var drifts []Drift
+	spotLeg, perpLeg, ok := splitLegs(p.Legs)
+	if !ok {
+		return []Drift{{
+			AgentID: agentID, BasisKey: p.Underlying, Underlying: p.Underlying,
+			Leg: "both", Field: "exists", Severity: SeverityCritical,
+			Note: "basis position has malformed legs JSON",
+		}}
+	}
+
+	// ─── PERP leg ─────────────────────────────────────────────────────
+	if !perpAvailable {
+		drifts = append(drifts, Drift{
+			AgentID: agentID, BasisKey: p.Underlying, Underlying: p.Underlying,
+			Leg: "perp", Field: "exists", Severity: SeverityInfo,
+			Note: "no Perp venue configured; could not verify",
+		})
+	} else {
+		hp, exists := perpBySymbol[perpLeg.Symbol]
+		switch {
+		case !exists:
+			drifts = append(drifts, Drift{
+				AgentID: agentID, BasisKey: p.Underlying, Underlying: p.Underlying,
+				Leg: "perp", Field: "exists", Severity: SeverityCritical,
+				Expected: perpLeg.Qty.Neg(), Actual: decimal.Zero,
+				Note: "DB says short " + perpLeg.Qty.String() + " " + perpLeg.Symbol +
+					" — venue reports no position",
+			})
+		default:
+			// We hold a SHORT, so HL reports negative szi.
+			expected := perpLeg.Qty.Neg()
+			actual := hp.Qty
+			diff := actual.Sub(expected).Abs()
+			rel := relativeBps(diff, expected.Abs())
+			switch {
+			case isOppositeSide(expected, actual):
+				drifts = append(drifts, Drift{
+					AgentID: agentID, BasisKey: p.Underlying, Underlying: p.Underlying,
+					Leg: "perp", Field: "side", Severity: SeverityCritical,
+					Expected: expected, Actual: actual, Diff: diff,
+					Note: "venue reports opposite side — strategy may have flipped position",
+				})
+			case e.QtyToleranceBps > 0 && rel > e.QtyToleranceBps:
+				drifts = append(drifts, Drift{
+					AgentID: agentID, BasisKey: p.Underlying, Underlying: p.Underlying,
+					Leg: "perp", Field: "qty",
+					Severity: severityForRel(rel),
+					Expected: expected, Actual: actual, Diff: diff,
+					Note: fmt.Sprintf("perp size mismatch: %dbps vs %dbps tolerance", rel, e.QtyToleranceBps),
+				})
+			}
+		}
+	}
+
+	// ─── SPOT leg ─────────────────────────────────────────────────────
+	swapVenue := e.swapVenueFor(spotLeg.Asset.Chain)
+	if swapVenue == nil {
+		drifts = append(drifts, Drift{
+			AgentID: agentID, BasisKey: p.Underlying, Underlying: p.Underlying,
+			Leg: "spot", Field: "exists", Severity: SeverityInfo,
+			Note: "no SwapVenue configured for chain " + string(spotLeg.Asset.Chain) +
+				"; could not verify",
+		})
+		return drifts
+	}
+	bal, err := swapVenue.Balance(ctx, spotLeg.Asset)
+	if err != nil {
+		drifts = append(drifts, Drift{
+			AgentID: agentID, BasisKey: p.Underlying, Underlying: p.Underlying,
+			Leg: "spot", Field: "exists", Severity: SeverityWarning,
+			Note: "balance query failed: " + err.Error(),
+		})
+		return drifts
+	}
+	// Expected spot quantity (in tokens) ≈ perp size (delta-neutral 1:1).
+	// This is the same approximation pnl.go uses; we'll thread real
+	// BaseQty through BasisLeg in a follow-up.
+	expected := perpLeg.Qty
+	switch {
+	case bal.IsZero() && expected.IsPositive():
+		drifts = append(drifts, Drift{
+			AgentID: agentID, BasisKey: p.Underlying, Underlying: p.Underlying,
+			Leg: "spot", Field: "exists", Severity: SeverityCritical,
+			Expected: expected, Actual: bal,
+			Note: "DB says we hold " + expected.String() + " " + spotLeg.Asset.Symbol +
+				" on " + string(spotLeg.Asset.Chain) + " — wallet reports zero",
+		})
+	default:
+		diff := bal.Sub(expected).Abs()
+		rel := relativeBps(diff, expected)
+		// Wallet > expected is fine (the agent might share a wallet
+		// with manual deposits). We only warn when wallet < expected.
+		if bal.LessThan(expected) && e.QtyToleranceBps > 0 && rel > e.QtyToleranceBps {
+			drifts = append(drifts, Drift{
+				AgentID: agentID, BasisKey: p.Underlying, Underlying: p.Underlying,
+				Leg: "spot", Field: "qty",
+				Severity: severityForRel(rel),
+				Expected: expected, Actual: bal, Diff: diff,
+				Note: fmt.Sprintf("wallet %s < expected %s on %s (%dbps under)",
+					bal, expected, spotLeg.Asset.Chain, rel),
+			})
+		}
+	}
+	return drifts
+}
+
+func (e *Engine) swapVenueFor(c types.ChainID) swap.SwapVenue {
+	if e == nil || e.Swaps == nil {
+		return nil
+	}
+	return e.Swaps[c]
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+// ErrNoBasis is returned when the caller asked to reconcile a specific
+// basis that doesn't exist in the open set.
+var ErrNoBasis = errors.New("reconcile: no such basis")
+
+func splitLegs(legs []types.BasisLeg) (spot, perp types.BasisLeg, ok bool) {
+	gotSpot, gotPerp := false, false
+	for _, l := range legs {
+		switch l.Kind {
+		case types.BasisLegSpot:
+			spot = l
+			gotSpot = true
+		case types.BasisLegPerp:
+			perp = l
+			gotPerp = true
+		}
+	}
+	return spot, perp, gotSpot && gotPerp
+}
+
+// relativeBps returns the absolute difference as a basis-point fraction
+// of expected. Returns 0 when expected is zero (avoids div-by-zero;
+// callers should special-case missing-position via the exists check).
+func relativeBps(diff, expected decimal.Decimal) int {
+	if expected.IsZero() {
+		return 0
+	}
+	bps := diff.Mul(decimal.NewFromInt(10_000)).Div(expected.Abs())
+	rounded := bps.Round(0)
+	return int(rounded.IntPart())
+}
+
+// severityForRel maps a relative-bps drift to a severity. Anything
+// above 100bps (1%) is Critical; the rest is Warning.
+func severityForRel(rel int) Severity {
+	if rel > 100 {
+		return SeverityCritical
+	}
+	return SeverityWarning
+}
+
+// isOppositeSide reports whether expected and actual have opposite signs
+// (and neither is zero). A flipped position is way worse than a sized
+// drift — the agent has effectively no hedge.
+func isOppositeSide(expected, actual decimal.Decimal) bool {
+	if expected.IsZero() || actual.IsZero() {
+		return false
+	}
+	return expected.Sign() != actual.Sign()
+}
+
+// ChainName returns a human-readable name for log lines.
+func ChainName(c types.ChainID) string { return strings.ToUpper(string(c)) }

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -1,0 +1,273 @@
+package reconcile
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/swap"
+	"github.com/teslashibe/permafrost/internal/types"
+)
+
+func d(s string) decimal.Decimal {
+	v, err := decimal.NewFromString(s)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// stubs mirror the pnl package's stubs.
+
+type stubPerp struct {
+	positions []types.Position
+	err       error
+}
+
+func (s *stubPerp) Name() string { return "stub" }
+func (s *stubPerp) FundingRates(_ context.Context, _ []string) ([]types.FundingRate, error) {
+	return nil, nil
+}
+func (s *stubPerp) Subscribe(_ context.Context, _ []string) (<-chan types.MarketEvent, error) {
+	return nil, nil
+}
+func (s *stubPerp) Positions(_ context.Context) ([]types.Position, error) {
+	return s.positions, s.err
+}
+func (s *stubPerp) Balances(_ context.Context) ([]types.Balance, error) { return nil, nil }
+func (s *stubPerp) Place(_ context.Context, _ types.OrderIntent) (types.OrderAck, error) {
+	return types.OrderAck{}, nil
+}
+func (s *stubPerp) Cancel(_ context.Context, _ types.OrderID) error { return nil }
+
+type stubSwap struct {
+	chain   types.ChainID
+	balance decimal.Decimal
+	err     error
+}
+
+func (s *stubSwap) Name() string         { return "stubswap" }
+func (s *stubSwap) Chain() types.ChainID { return s.chain }
+func (s *stubSwap) Quote(_ context.Context, req types.QuoteRequest) (types.Quote, error) {
+	return types.Quote{InToken: req.InToken, OutToken: req.OutToken, OutAmount: req.Amount}, nil
+}
+func (s *stubSwap) Swap(_ context.Context, _ types.Quote, _ int) (types.TxHash, error) {
+	return "stub", nil
+}
+func (s *stubSwap) WaitConfirm(_ context.Context, tx types.TxHash) (types.SwapResult, error) {
+	return types.SwapResult{TxHash: tx, Status: types.SwapStatusConfirmed}, nil
+}
+func (s *stubSwap) Balance(_ context.Context, _ types.Asset) (decimal.Decimal, error) {
+	return s.balance, s.err
+}
+
+func makeBasis(underlying, perpSym string, chain types.ChainID, perpSize decimal.Decimal) types.BasisPosition {
+	return types.BasisPosition{
+		ID:         "bp:" + underlying,
+		AgentID:    "a",
+		Underlying: underlying,
+		State:      types.BasisStateOpen,
+		OpenedAt:   time.Now().Add(-time.Hour),
+		Legs: []types.BasisLeg{
+			{Kind: types.BasisLegSpot, Asset: types.Asset{Symbol: underlying, Chain: chain, Mint: "m", Decimals: 6}, Qty: d("100")},
+			{Kind: types.BasisLegPerp, Symbol: perpSym, Qty: perpSize, AvgPrice: d("1")},
+		},
+	}
+}
+
+// TestReconcile_PerfectMatch: book and venue agree → no drifts.
+func TestReconcile_PerfectMatch(t *testing.T) {
+	bp := makeBasis("WIF", "WIF", types.ChainSolana, d("100"))
+	perp := &stubPerp{positions: []types.Position{
+		{Symbol: "WIF", Qty: d("-100"), EntryPrice: d("1")},
+	}}
+	swp := &stubSwap{chain: types.ChainSolana, balance: d("100")}
+	e := New(perp, map[types.ChainID]swap.SwapVenue{types.ChainSolana: swp})
+
+	rep, err := e.Reconcile(context.Background(), "a", []types.BasisPosition{bp})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rep.Drifts) != 0 {
+		t.Errorf("expected no drifts, got %+v", rep.Drifts)
+	}
+	if rep.OK != 1 {
+		t.Errorf("OK count: %d want 1", rep.OK)
+	}
+}
+
+// TestReconcile_PerpMissing: book says we're short 100, venue says we
+// have nothing. CRITICAL — we believe we're hedged but we're not.
+func TestReconcile_PerpMissing(t *testing.T) {
+	bp := makeBasis("WIF", "WIF", types.ChainSolana, d("100"))
+	perp := &stubPerp{positions: []types.Position{}} // empty
+	swp := &stubSwap{chain: types.ChainSolana, balance: d("100")}
+	e := New(perp, map[types.ChainID]swap.SwapVenue{types.ChainSolana: swp})
+
+	rep, _ := e.Reconcile(context.Background(), "a", []types.BasisPosition{bp})
+	var found bool
+	for _, drift := range rep.Drifts {
+		if drift.Leg == "perp" && drift.Severity == SeverityCritical {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected critical perp-missing drift, got %+v", rep.Drifts)
+	}
+}
+
+// TestReconcile_PerpFlippedSide: HL reports a LONG when we expected a
+// short — strategy or operator bug. Always Critical.
+func TestReconcile_PerpFlippedSide(t *testing.T) {
+	bp := makeBasis("WIF", "WIF", types.ChainSolana, d("100"))
+	perp := &stubPerp{positions: []types.Position{
+		{Symbol: "WIF", Qty: d("100"), EntryPrice: d("1")}, // POSITIVE = long
+	}}
+	swp := &stubSwap{chain: types.ChainSolana, balance: d("100")}
+	e := New(perp, map[types.ChainID]swap.SwapVenue{types.ChainSolana: swp})
+
+	rep, _ := e.Reconcile(context.Background(), "a", []types.BasisPosition{bp})
+	var ok bool
+	for _, dr := range rep.Drifts {
+		if dr.Leg == "perp" && dr.Field == "side" && dr.Severity == SeverityCritical {
+			ok = true
+		}
+	}
+	if !ok {
+		t.Errorf("expected critical side-flip drift, got %+v", rep.Drifts)
+	}
+}
+
+// TestReconcile_SpotShortfall_BelowTolerance: wallet has 99.99 of 100
+// — within the 25bps tolerance → NO drift.
+func TestReconcile_SpotShortfall_BelowTolerance(t *testing.T) {
+	bp := makeBasis("WIF", "WIF", types.ChainSolana, d("100"))
+	perp := &stubPerp{positions: []types.Position{
+		{Symbol: "WIF", Qty: d("-100"), EntryPrice: d("1")},
+	}}
+	swp := &stubSwap{chain: types.ChainSolana, balance: d("99.99")}
+	e := New(perp, map[types.ChainID]swap.SwapVenue{types.ChainSolana: swp})
+
+	rep, _ := e.Reconcile(context.Background(), "a", []types.BasisPosition{bp})
+	for _, dr := range rep.Drifts {
+		if dr.Leg == "spot" && dr.Severity != SeverityInfo {
+			t.Errorf("unexpected spot drift within tolerance: %+v", dr)
+		}
+	}
+}
+
+// TestReconcile_SpotShortfall_AboveTolerance: wallet has 95 of 100 (500bps
+// = 5%) — above 100bps Critical threshold.
+func TestReconcile_SpotShortfall_AboveTolerance(t *testing.T) {
+	bp := makeBasis("WIF", "WIF", types.ChainSolana, d("100"))
+	perp := &stubPerp{positions: []types.Position{
+		{Symbol: "WIF", Qty: d("-100"), EntryPrice: d("1")},
+	}}
+	swp := &stubSwap{chain: types.ChainSolana, balance: d("95")}
+	e := New(perp, map[types.ChainID]swap.SwapVenue{types.ChainSolana: swp})
+
+	rep, _ := e.Reconcile(context.Background(), "a", []types.BasisPosition{bp})
+	var ok bool
+	for _, dr := range rep.Drifts {
+		if dr.Leg == "spot" && dr.Severity == SeverityCritical {
+			ok = true
+		}
+	}
+	if !ok {
+		t.Errorf("expected critical spot drift, got %+v", rep.Drifts)
+	}
+}
+
+// TestReconcile_SpotSurplus_NotReported: wallet has more than expected
+// (manual deposit, gas top-up). Not flagged — only shortages matter.
+func TestReconcile_SpotSurplus_NotReported(t *testing.T) {
+	bp := makeBasis("WIF", "WIF", types.ChainSolana, d("100"))
+	perp := &stubPerp{positions: []types.Position{
+		{Symbol: "WIF", Qty: d("-100"), EntryPrice: d("1")},
+	}}
+	swp := &stubSwap{chain: types.ChainSolana, balance: d("500")}
+	e := New(perp, map[types.ChainID]swap.SwapVenue{types.ChainSolana: swp})
+
+	rep, _ := e.Reconcile(context.Background(), "a", []types.BasisPosition{bp})
+	for _, dr := range rep.Drifts {
+		if dr.Leg == "spot" && dr.Severity != SeverityInfo {
+			t.Errorf("unexpected drift on surplus: %+v", dr)
+		}
+	}
+}
+
+// TestReconcile_NoVenues_DegradesToInfo: nothing to verify against,
+// every leg gets an Info entry.
+func TestReconcile_NoVenues_DegradesToInfo(t *testing.T) {
+	bp := makeBasis("WIF", "WIF", types.ChainSolana, d("100"))
+	e := New(nil, nil)
+
+	rep, _ := e.Reconcile(context.Background(), "a", []types.BasisPosition{bp})
+	if len(rep.Drifts) != 2 {
+		t.Errorf("expected 2 Info drifts (perp + spot), got %d", len(rep.Drifts))
+	}
+	for _, dr := range rep.Drifts {
+		if dr.Severity != SeverityInfo {
+			t.Errorf("expected Info severity, got %q", dr.Severity)
+		}
+	}
+	if rep.HasIssues() {
+		t.Error("Info-only report should not have issues")
+	}
+}
+
+// TestReconcile_SpotBalanceError_Warning: a venue error on the balance
+// query is a Warning (not Critical) — could be transient RPC glitch.
+func TestReconcile_SpotBalanceError_Warning(t *testing.T) {
+	bp := makeBasis("WIF", "WIF", types.ChainSolana, d("100"))
+	perp := &stubPerp{positions: []types.Position{
+		{Symbol: "WIF", Qty: d("-100"), EntryPrice: d("1")},
+	}}
+	swp := &stubSwap{chain: types.ChainSolana, err: errors.New("rpc")}
+	e := New(perp, map[types.ChainID]swap.SwapVenue{types.ChainSolana: swp})
+
+	rep, _ := e.Reconcile(context.Background(), "a", []types.BasisPosition{bp})
+	var found bool
+	for _, dr := range rep.Drifts {
+		if dr.Leg == "spot" && dr.Severity == SeverityWarning {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected Warning on RPC error, got %+v", rep.Drifts)
+	}
+}
+
+func TestRelativeBps(t *testing.T) {
+	tests := []struct {
+		diff, expected string
+		want           int
+	}{
+		{"0", "100", 0},
+		{"1", "100", 100},   // 1% = 100bps
+		{"0.5", "100", 50},  // 50bps
+		{"5", "100", 500},   // 5%
+		{"100", "0", 0},     // div-by-zero guard
+	}
+	for _, tc := range tests {
+		got := relativeBps(d(tc.diff), d(tc.expected))
+		if got != tc.want {
+			t.Errorf("relativeBps(%s, %s) = %d want %d", tc.diff, tc.expected, got, tc.want)
+		}
+	}
+}
+
+func TestSeverityForRel(t *testing.T) {
+	if severityForRel(50) != SeverityWarning {
+		t.Error("50bps must be Warning")
+	}
+	if severityForRel(100) != SeverityWarning {
+		t.Error("100bps must still be Warning (boundary)")
+	}
+	if severityForRel(101) != SeverityCritical {
+		t.Error(">100bps must be Critical")
+	}
+}

--- a/internal/store/migrations/0007_agent_nav_snapshots.sql
+++ b/internal/store/migrations/0007_agent_nav_snapshots.sql
@@ -1,0 +1,42 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Per-agent NAV snapshots (separate from the vault-level nav_snapshots from
+-- migration 0003). One row per (agent, tick), recording every dollar:
+--
+--   nav_usdc             = total value if everything closed right now
+--   spot_value_usdc      = sum of open spot legs valued at current marks
+--   perp_unrealized_usdc = sum of open perp legs' unrealized P&L
+--   funding_accrued_usdc = funding payments received since each position open
+--                          (currently 0; populated when HL userFunding wiring lands)
+--   realized_pnl_usdc    = cumulative realized P&L since agent inception
+--                          (from strategy_positions where state='closed')
+--   cumulative_gas_usdc  = cumulative gas + fees across every swap/order
+--   open_positions       = count of basis positions currently in 'open' state
+--   positions            = per-basis breakdown (BasisValuation array as JSONB)
+--                          for ad-hoc inspection without joins
+CREATE TABLE IF NOT EXISTS agent_nav_snapshots (
+    time                  timestamptz   NOT NULL,
+    agent_id              text          NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    nav_usdc              numeric(38,9) NOT NULL,
+    spot_value_usdc       numeric(38,9) NOT NULL,
+    perp_unrealized_usdc  numeric(38,9) NOT NULL,
+    funding_accrued_usdc  numeric(38,9) NOT NULL,
+    realized_pnl_usdc     numeric(38,9) NOT NULL,
+    cumulative_gas_usdc   numeric(38,9) NOT NULL,
+    open_positions        int           NOT NULL,
+    positions             jsonb,
+    PRIMARY KEY (agent_id, time)
+);
+
+SELECT create_hypertable('agent_nav_snapshots', 'time', if_not_exists => TRUE);
+
+CREATE INDEX IF NOT EXISTS agent_nav_snapshots_agent_time_desc_idx
+    ON agent_nav_snapshots (agent_id, time DESC);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS agent_nav_snapshots;
+-- +goose StatementEnd


### PR DESCRIPTION
## Why

The single most-asked operator question — *\"is this strategy actually making money?\"* — had no clean answer. We had a system that could trade. We didn't have a system that could tell us whether the trades were profitable. **Visibility is the unlock for scaling size with confidence**, and a prerequisite for anything monetizable (HL Vault, performance fees) that depends on NAV history.

This PR closes that gap: every tick produces a NAV snapshot, and \`permafrost pnl\` + \`permafrost reconcile\` answer the questions from the CLI.

## Stack

| Component | Module |
|---|---|
| Valuation engine | \`internal/pnl\` — \`Engine.ValueAgent\` returns per-position + aggregate NAV |
| Reconciliation | \`internal/reconcile\` — \`Engine.Reconcile\` walks open positions, diffs vs venues |
| Persistence | migration 0007 → \`agent_nav_snapshots\` hypertable |
| Runtime hookup | \`Runtime.persistNAVSnapshot\` runs after every tick (best-effort, logs at WARN, never blocks trading) |

### Mark sources (locked in via design Q&A)

- **Spot leg**: live SwapVenue quote (Jupiter on Solana, 1inch on EVM) — \`token → USDC\` for the held quantity.
- **Perp leg**: HL's \`UnrealizedPnl\` directly — already accounts for funding-paid-during-position.
- **Falls back gracefully**: zero spot venue → cost basis. No HL Address → zero unrealized. Status enum (\`ok\` / \`spot_at_cost\` / \`perp_no_unrealized\` / \`both_at_cost\`) tells you which.

### Reconciliation grading

| Severity | When |
|---|---|
| info | Leg can't be verified (no venue wired) |
| warning | Drift within 100bps of expected |
| critical | Leg missing entirely OR side flipped OR drift > 100bps |

Default tolerance is 25bps. Spot SURPLUS (wallet > expected) is intentionally NOT flagged — operators may share a wallet or top up manually.

## CLI surface

\`\`\`bash
permafrost pnl summary [--live] [--json]            # one row per agent
permafrost pnl positions <agent> [--live] [--json]  # per-basis breakdown
permafrost pnl history <agent> --since 7d           # NAV time series

permafrost reconcile [agent] [--json] [--fail-on-drift]
\`\`\`

\`--fail-on-drift\` exits non-zero so this can be cron'd: *\"alert me if drift\"*.

## Tests

**Unit (16 new):**
- \`pnl_test.go\` (6): degrades without venues; HL unrealized flows through; spot mark-up + perp mark-down nets to zero (proves delta-neutrality math); RPC error doesn't crash; deterministic ordering for stable JSONB.
- \`reconcile_test.go\` (10): perfect match, perp missing (CRITICAL), side flipped (CRITICAL), spot shortfall above/below tolerance, surplus ignored, no-venue Info-only, RPC error → Warning, relativeBps math, severity boundaries.

**Verified live:**

\`\`\`
$ permafrost pnl summary
AGENT     STRATEGY           MODE   STATUS   OPEN  REALIZED  UNREALIZED  NAV      GAS      SOURCE    AGE
pnl-test  funding_arb_basic  paper  stopped  3     \$0.0000   \$0.0000     \$0.0000  \$0.0000  snapshot  0s

$ permafrost pnl positions pnl-test
BASIS   CHAIN   SPOT QTY  COST USDC  SPOT VAL  PERP UPNL  FUNDING  GAS      NET P&L  STATUS
GOAT    solana  50        \$50.0000   \$50.0000  \$0.0000    \$0.0000  \$0.0000  \$0.0000  both_at_cost
POPCAT  solana  50        \$50.0000   \$50.0000  \$0.0000    \$0.0000  \$0.0000  \$0.0000  both_at_cost
WIF     solana  50        \$50.0000   \$50.0000  \$0.0000    \$0.0000  \$0.0000  \$0.0000  both_at_cost

$ permafrost pnl history pnl-test --since 5m
TIME                       NAV      REALIZED  UNREALIZED  OPEN  GAS
2026-04-17T19:17:30-07:00  \$0.0000  \$0.0000   \$0.0000     3     \$0.0000
2026-04-17T19:17:40-07:00  \$0.0000  \$0.0000   \$0.0000     0     \$0.0000

$ permafrost reconcile pnl-test  # with HL key wired, no live positions
SEV       AGENT     BASIS   LEG   FIELD   EXPECTED  ACTUAL  NOTE
critical  pnl-test  GOAT    perp  exists  -50       0       DB says short 50 GOAT — venue reports no position
critical  pnl-test  POPCAT  perp  exists  -50       0       DB says short 50 POPCAT — venue reports no position
critical  pnl-test  WIF     perp  exists  -200      0       DB says short 200 WIF — venue reports no position
info      pnl-test  GOAT    spot  exists  0         0       no SwapVenue configured for chain solana
[...]

$ permafrost reconcile pnl-test --fail-on-drift; echo \$?
1   # cron-friendly: non-zero on drift
\`\`\`

The synthetic drift test was particularly satisfying — manually setting \`legs.qty = 200\` in the DB for WIF was caught immediately as expected=-200 vs actual=0.

## What's deferred

1. **Funding accrual via HL userFunding endpoint.** Currently we use the position's \`realized_funding\` (zero for open positions). Hooking HL's userFunding stream gives us live accrual. Small follow-up.
2. **BasisLeg.BaseQty.** Spot quantity is currently approximated as the perp size (delta-neutral 1:1). Recording actual swap output explicitly is a small schema bump for future strategies that hedge < 1.0 ratio.
3. **Web dashboard.** All data is now there; rendering is a UX project.

## Verify locally

\`\`\`
go test ./... -count=1
docker compose -f deploy/compose/docker-compose.yml up -d --build
permafrost agent create --strategy funding_arb_basic --universe WIF,POPCAT ...
permafrost agent tick <id> --funding 'WIF=100,POPCAT=80'
permafrost pnl summary
permafrost reconcile <id>
\`\`\`

Refs: SCOPE.md §10.5 (new section).