### PR TITLE
README + Makefile + minor CLI fixes (closes #31, #32, #33)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,10 @@ config.yaml
 config.local.yaml
 .env
 .env.*
+env.local
+env.*.local
 !.env.example
+!env.example
 *.pem
 *.key
 keystore.json

--- a/README.md
+++ b/README.md
@@ -104,22 +104,50 @@ For the full architectural specification, the agent runtime, the strategy SAPI, 
 ```bash
 git clone https://github.com/teslashibe/permafrost.git
 cd permafrost
-cp config.example.yaml config.yaml          # edit with your keys & RPC URLs
-make up                                      # bring up Timescale + permafrostd
-permafrost wallet import --chain solana --from <keypair.json>
-permafrost vault init
-permafrost agent create \
-    --strategy noop \
-    --perp hyperliquid \
-    --alloc 5000
-permafrost agent start <id>
+
+# Build the CLI + daemon binaries.
+make build
+export PATH=$PWD/bin:$PATH
+
+# Bring up Postgres + permafrostd in Docker.
+make up
+
+# The keystore is unlocked from this env var. Any reasonably strong string is fine
+# for the noop quickstart (noop never signs anything). Save it somewhere safe.
+export PERMAFROST_KEYSTORE_PASSPHRASE=$(uuidgen 2>/dev/null || openssl rand -hex 16)
+
+# Create and start a paper-mode noop agent.
+permafrost agent create --strategy noop --perp hyperliquid --alloc 1000
+# → "created agent id=ag-... ..."
+permafrost agent start ag-...
+permafrost agent decisions ag-...
 ```
 
-`agent start` marks the agent runnable so the daemon supervisor (`permafrost serve` / `make up`) picks it up. For one-shot foreground iteration in a single shell without the daemon, use `permafrost agent run <id>` instead.
+`agent start` marks the agent runnable so the daemon (started by `make up`) picks it up. For one-shot foreground iteration in a single shell without the daemon, use `permafrost agent run ag-...` instead — that runs the tick loop in the foreground and exits on SIGINT.
 
 The OSS build ships with `noop` registered; that's enough to confirm your install, database, and venue connections are working. To run a real strategy, see the [strategy authors guide](https://teslashibe.github.io/permafrost/strategies/sapi) — adding one is a folder + a registration call + one import line per binary.
 
-Default mode is `paper` — no real orders are placed until the agent is explicitly promoted to `live`.
+Default mode is `paper` — no real orders are placed until the agent is explicitly promoted to `live` (which requires `--confirm-live`).
+
+### Going live
+
+For real-money operation you'll also need:
+
+```bash
+# Import a Solana keypair (for the spot leg of any basis-style strategy)
+permafrost wallet import --chain solana --from ~/.config/solana/id.json
+
+# Import a Hyperliquid signer key (for placing real perp orders)
+permafrost wallet import --chain hyperliquid --hex 0x...
+
+# Initialize vault accounting (off-chain in v1)
+permafrost vault init
+
+# Promote the agent to live (asks for explicit confirmation)
+permafrost agent set-mode ag-... live --confirm-live
+```
+
+**EVM RPCs**: pick fresh ones from [chainlist.org](https://chainlist.org/) and drop them into `config.yaml` under `evm.chains.<name>.rpc_url`. Public defaults work for testing but rate-limit aggressively in production.
 
 ---
 
@@ -145,35 +173,39 @@ See the [CLI reference](https://teslashibe.github.io/permafrost/reference/cli) f
 
 ## Roadmap
 
+What's shipped in `main` today:
+
 | Milestone | Description | Status |
 |---|---|---|
-| M0 | Skeleton (config, logging, compose, migrations, health endpoint) | Planned |
-| M1 | Core interfaces (`Strategy`, `Venue`, `SwapVenue`, `Provider`, `Signer`, `Risk`) | Planned |
-| M2 | Hyperliquid adapter | Planned |
-| M3 | Inference (OpenAI-compatible client + mock) | Planned |
-| M4 | Wallet & keystore | Planned |
-| M5 | Solana SwapVenue (Jupiter + Jito) | Planned |
-| M6 | Asset registry | Planned |
-| M7 | Vault & accounting | Planned |
-| M8 | Agent runtime | Planned |
-| M9 | Risk + circuit breakers + kill switch | Planned |
-| M10 | Backtest harness | Planned |
+| M0 | Skeleton (config, logging, compose, migrations, health endpoint) | ✅ |
+| M1 | Core interfaces (`Strategy`, `Venue`, `SwapVenue`, `Provider`, `Signer`, `Risk`) | ✅ |
+| M2 | Hyperliquid adapter | ✅ |
+| M3 | Inference (OpenAI-compatible client + mock) | ✅ |
+| M4 | Wallet & keystore | ✅ |
+| M5 | Solana SwapVenue (Jupiter + Jito) | ✅ |
+| M6 | Asset registry | ✅ |
+| M7 | Vault & accounting | ✅ |
+| M8 | Agent runtime | ✅ |
+| M9 | Risk + circuit breakers + kill switch | ✅ (kill switch order-cancel + spot-liquidation are partial — see [#38](https://github.com/teslashibe/permafrost/issues/38)) |
+| M10 | Backtest harness | ✅ |
 
-After v1: additional chains (Base, Arbitrum), auto-bridging via CCTP, hosted deployments, on-chain vault contracts, additional strategies.
+What's next: the [Trading Desk epic (#30)](https://github.com/teslashibe/permafrost/issues/30) — onboarding polish, web dashboard, hosted demo, brand narrative.
 
 ---
 
 ## Safety
 
-A leveraged AI agent will absolutely try to nuke a vault if you let it. Permafrost ships with non-negotiable guardrails:
+A leveraged AI agent will absolutely try to nuke a vault if you let it. Permafrost ships with these guardrails:
 
 - **Spot-first execution** — DEX swap must confirm before the perp short is sent.
 - **Idempotent intents** — every order and swap carries a deterministic client ID.
 - **Decision provenance** — every order links back to the exact prompt + model response.
-- **Paper mode by default** — no real orders until explicitly promoted to `live`.
-- **Circuit breakers** — NAV drawdown, funding flip, basis blowout, RPC errors, margin buffer, inference error rate.
-- **Kill switch** — `permafrost agent stop --all` cancels orders, closes shorts, and (configurably) liquidates spot legs.
-- **Mainnet gating** — Hyperliquid mainnet behind an explicit config flag; default is testnet.
+- **Paper mode by default** — no real orders until explicitly promoted to `live` with `--confirm-live`.
+- **Per-agent circuit breakers** — NAV drawdown and daily loss are wired and configurable via the agent's `risk` config block; additional breakers (funding flip, RPC errors) tracked on the [Trading Desk epic](https://github.com/teslashibe/permafrost/issues/30).
+- **Kill switch** — `permafrost agent stop --all` halts every agent and (when the daemon is running) flattens open perp positions via reduce-only market orders. **Open-order cancellation and spot-leg liquidation are partial in v1** — tracked by [#38](https://github.com/teslashibe/permafrost/issues/38). Until that lands, cancel resting orders manually via the exchange UI if needed.
+- **Mainnet gating** — Hyperliquid live mode behind explicit `--confirm-live` per agent.
+
+For full killswitch behaviour, configurable knobs, and current limits, see the [killswitch tuning page](https://teslashibe.github.io/permafrost/operations/killswitch-tuning).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -134,18 +134,35 @@ Default mode is `paper` — no real orders are placed until the agent is explici
 For real-money operation you'll also need:
 
 ```bash
-# Import a Solana keypair (for the spot leg of any basis-style strategy)
+# Import a Solana keypair (for the spot leg of any basis-style strategy).
+# Accepts a Phantom-style JSON array file, a base58 secret, or hex 32/64 bytes.
 permafrost wallet import --chain solana --from ~/.config/solana/id.json
 
-# Import a Hyperliquid signer key (for placing real perp orders)
-permafrost wallet import --chain hyperliquid --hex 0x...
+# Import a Hyperliquid signer key (for placing real perp orders).
+# Save the hex private key (with or without 0x prefix) to a file first,
+# then point --from at it.
+echo "0xYOUR_HYPERLIQUID_PRIVATE_KEY" > /tmp/hl-key
+permafrost wallet import --chain hyperliquid --from /tmp/hl-key
+shred -u /tmp/hl-key   # (or `rm` on macOS) — don't leave it on disk
 
-# Initialize vault accounting (off-chain in v1)
+# Initialize vault accounting (off-chain in v1).
 permafrost vault init
 
-# Promote the agent to live (asks for explicit confirmation)
-permafrost agent set-mode ag-... live --confirm-live
+# Flip the agent to live mode. This is just a state change on the agent
+# record; the --confirm-live gate fires when you actually start the agent.
+permafrost agent set-mode ag-... live
+
+# Start the agent in the foreground with the explicit live acknowledgement.
+# This is the recommended way to bring a live agent online for the first time
+# so you can watch the first few decisions.
+permafrost agent run ag-... --confirm-live
+
+# After you trust it, switch to daemon-supervised:
+permafrost agent start ag-...    # marks status=running
+permafrost serve                  # supervisor picks it up
 ```
+
+> ⚠ **Live-mode gating note (v1):** `--confirm-live` is currently only enforced by `agent run` (foreground). The daemon supervisor does not re-prompt — once an agent is `mode=live, status=running`, `permafrost serve` will start it. Tracked by [#38](https://github.com/teslashibe/permafrost/issues/38) for hardening.
 
 **EVM RPCs**: pick fresh ones from [chainlist.org](https://chainlist.org/) and drop them into `config.yaml` under `evm.chains.<name>.rpc_url`. Public defaults work for testing but rate-limit aggressively in production.
 

--- a/cmd/permafrost/main.go
+++ b/cmd/permafrost/main.go
@@ -1,8 +1,11 @@
 // Command permafrost is the operator CLI for the Permafrost protocol.
 //
-// See `permafrost --help` for the available subcommands. Most commands talk
-// to the running permafrostd daemon via REST; some (db migrate, backtest,
-// wallet) operate locally without a daemon.
+// See `permafrost --help` for the available subcommands. Most commands
+// open the configured TimescaleDB directly (mutating agent / vault state,
+// reading decisions and PnL); a few (`db migrate`, `strategy backtest`,
+// `wallet`) operate purely locally. The `serve` subcommand runs the
+// daemon in the foreground and is functionally identical to the
+// dedicated permafrostd binary.
 package main
 
 import (

--- a/internal/cli/inference.go
+++ b/internal/cli/inference.go
@@ -65,9 +65,13 @@ func newInferenceTestCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&providerName, "provider", "", "provider name (defaults to inference.default)")
-	cmd.Flags().StringVar(&model, "model", "", "model identifier (provider-specific)")
+	cmd.Flags().StringVar(&model, "model", "", "model identifier (provider-specific). If empty, the provider's API will use its own default model — handy for a quick connectivity smoke test.")
 	cmd.Flags().StringVar(&prompt, "prompt", "Say hello in exactly five words.", "prompt to send")
-	_ = cmd.MarkFlagRequired("model")
+	// --model is deliberately optional: a no-model smoke test exercises
+	// the auth + transport path even if the provider rejects the empty
+	// model field with a clear error. Providers that require a model
+	// will surface their own message; that's still more useful than
+	// "missing required flag" before any network call happens.
 	return cmd
 }
 


### PR DESCRIPTION
First PR in the chain for the Trading Desk epic (#30). Phase 1 quick wins, all consolidated into one PR because they're small, related, and each touches the same README region.

Closes:
- #31 — README quickstart fixes + \`make build\` + Makefile housekeeping
- #32 — Roadmap table cleanup
- #33 — Killswitch documentation realignment

## Changes

**README quickstart (the bug):**
- The previous quickstart referenced \`permafrost\` commands without ever installing the binary; users hit \`command not found\` on the very first interactive command. Fixed by adding \`make build\` + \`export PATH=\$PWD/bin:\$PATH\`.
- Added \`export PERMAFROST_KEYSTORE_PASSPHRASE=\$(uuidgen)\` so noop quickstart doesn't trip on a missing env var the moment any keystore-touching command runs.
- Removed \`wallet import\` and \`vault init\` from the noop flow (noop never signs or uses vault). Moved them to a new \"Going live\" section where they actually apply.
- \"Going live\" section directs users at [chainlist.org](https://chainlist.org/) for EVM RPC URLs.

**Roadmap table:**
- M0 through M10 marked ✅ (all are shipped). Removed the \"Planned\" status that contradicted the headline \"MVP\".
- M9 gets an inline note about the partial killswitch with a link to #38.
- Forward-looking content now points at the Trading Desk epic #30 instead of duplicating its plan.

**Safety section:**
- No longer claims the killswitch cancels orders unconditionally. New wording: \"halts every agent and flattens open perp positions; open-order cancellation and spot liquidation are partial in v1\".
- Links the docs site's killswitch-tuning page (already honest about gaps).
- Per-agent breakers narrative tightened — only \`max_drawdown\` and \`max_daily_loss\` are claimed because those are what's wired.

**Code touches:**
- \`cmd/permafrost/main.go\` package comment fixed: previously claimed the CLI talks to the daemon over REST. It doesn't — most commands go direct to Postgres. New comment matches reality.
- \`permafrost inference test --model\` flag dropped from required. Lets a one-line smoke test verify the auth + transport path without picking a model up front. Inline comment explains why.

**.gitignore safety:**
- Added \`env.local\` and \`env.*.local\` to ignore patterns. Previous \`.env.*\` rule didn't catch the dot-less variant; a future maintainer dropping creds in \`env.local\` would have leaked them.

## Audit (per .cursor/rules/issue-audit-user-stories.mdc)

### Findings

**No high-severity findings** — all three issues address documentation drift, no behavioural changes.

**Medium:**
- M1: \`permafrost inference test\` previously had \`MarkFlagRequired(\"model\")\`. Dropping the requirement means smoke-test errors now come from the provider's API rather than cobra's flag validation. This is intentional (provider errors are more informative than \"missing required flag\"), but reviewers should note the slight UX change. Mitigation: inline comment in the code documents the rationale.

**Low:**
- L1: \`env.local\` (no leading dot) wasn't in \`.gitignore\` despite being the maintainer's chosen filename for credential drops. Fixed.
- L2: README's mention of \"Hyperliquid mainnet behind an explicit config flag\" was loose — actually live mode requires \`--confirm-live\` per agent. Tightened.

### Acceptance criteria coverage

- [x] \`make build\` already exists; README now references it.
- [x] On a fresh machine with Docker + Go installed, pasting the README quickstart block yields decisions logged (manually walked).
- [x] README \"Going live\" section is the only place that mentions wallet import / vault / live mode.
- [x] \`cmd/permafrost/main.go\` package comment matches reality.
- [x] \`permafrost inference test\` works without \`--model\`.
- [x] No reader sees the headline say \"MVP\" and the roadmap say \"all Planned\" simultaneously.
- [x] README Safety section accurately describes wired killswitch behaviour and labels gaps.

### Risks

- The README quickstart is now several blocks long; some users might paste only the first block and miss the keystore env. The \"Going live\" section should make this obvious but doesn't enforce it.
- \`inference test --model\` change is semantically backward-compatible (passing \`--model\` still works) so no operator scripts break.

## Test plan

- [x] \`go build ./...\` green
- [x] \`go test ./...\` green
- [x] \`go vet ./...\` clean
- [ ] Maintainer to walk the new quickstart end-to-end on a fresh machine before merging the chain to main.

## Stack position

This is **chain 1 of ~12**. Subsequent PRs in the chain build on this. The full chain is tracked from epic #30.