### PR TITLE
Add `permafrost doctor` preflight check (closes #34)

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -69,6 +69,11 @@ type CheckResult struct {
 	Err    error // populated on StatusFail; surfaced under --verbose
 }
 
+// httpClient is the doctor's HTTP client. Hard 5s ceiling so a hung TLS
+// handshake (which a bare context.WithTimeout doesn't always preempt)
+// cannot make the doctor wedge.
+var httpClient = &http.Client{Timeout: 5 * time.Second}
+
 // runDoctor executes every check. Order is deliberate (cheapest first so the
 // operator sees fast feedback even on a slow connection).
 func runDoctor(ctx context.Context, c *cobra.Command, _ bool) []CheckResult {
@@ -276,7 +281,10 @@ func checkSolanaRPC(ctx context.Context, g *Globals) CheckResult {
 		r.Detail = "not configured"
 		return r
 	}
-	body := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"getHealth"}`)
+	// Use getSlot rather than getHealth: getHealth is restricted on most
+	// commercial providers (Helius, Triton); getSlot is part of the
+	// universally-exposed RPC surface and returns a uint64 we can show.
+	body := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"getSlot"}`)
 	rpcCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(rpcCtx, http.MethodPost, g.Config.Solana.RPCURL, body)
@@ -287,7 +295,7 @@ func checkSolanaRPC(ctx context.Context, g *Globals) CheckResult {
 		return r
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		r.Status = StatusFail
 		r.Detail = redactURL(g.Config.Solana.RPCURL) + " (network error)"
@@ -296,20 +304,43 @@ func checkSolanaRPC(ctx context.Context, g *Globals) CheckResult {
 	}
 	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode == http.StatusTooManyRequests {
+		r.Status = StatusWarn
+		r.Detail = redactURL(g.Config.Solana.RPCURL) + " (rate-limited; try a paid provider like Helius/Triton)"
+		return r
+	}
 	if resp.StatusCode != http.StatusOK {
 		r.Status = StatusFail
 		r.Detail = fmt.Sprintf("%s (HTTP %d)", redactURL(g.Config.Solana.RPCURL), resp.StatusCode)
-		r.Err = fmt.Errorf("http %d: %s", resp.StatusCode, string(respBody))
+		r.Err = fmt.Errorf("http %d: %s", resp.StatusCode, truncate(string(respBody), 200))
 		return r
 	}
-	// getHealth returns "ok" in the result field on a healthy node.
-	if !strings.Contains(string(respBody), `"ok"`) {
+	// getSlot returns a number in result; presence indicates a working RPC.
+	var rpcResp struct {
+		Result *uint64 `json:"result"`
+		Error  *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(respBody, &rpcResp); err != nil {
+		r.Status = StatusFail
+		r.Detail = redactURL(g.Config.Solana.RPCURL) + " (unparseable response)"
+		r.Err = err
+		return r
+	}
+	if rpcResp.Error != nil {
+		r.Status = StatusFail
+		r.Detail = redactURL(g.Config.Solana.RPCURL) + " (rpc error: " + rpcResp.Error.Message + ")"
+		r.Err = errors.New(rpcResp.Error.Message)
+		return r
+	}
+	if rpcResp.Result == nil {
 		r.Status = StatusWarn
-		r.Detail = redactURL(g.Config.Solana.RPCURL) + " (unhealthy: " + truncate(string(respBody), 80) + ")"
+		r.Detail = redactURL(g.Config.Solana.RPCURL) + " (no result; method may be restricted)"
 		return r
 	}
 	r.Status = StatusOK
-	r.Detail = redactURL(g.Config.Solana.RPCURL)
+	r.Detail = fmt.Sprintf("%s (slot %d)", redactURL(g.Config.Solana.RPCURL), *rpcResp.Result)
 	return r
 }
 
@@ -351,7 +382,7 @@ func checkEVMRPCs(ctx context.Context, g *Globals) []CheckResult {
 			continue
 		}
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := httpClient.Do(req)
 		cancel()
 		if err != nil {
 			r.Status = StatusFail

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1,0 +1,513 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/teslashibe/permafrost/internal/store"
+	"github.com/teslashibe/permafrost/pkg/strategy"
+)
+
+// doctor is the framework's preflight checker. It runs every check in
+// sequence (does not short-circuit), prints colour-coded results, and
+// exits 1 if any check failed (warnings don't fail the command).
+//
+// The metaphor (per epic #30): Skipper the husky doing a pre-game
+// inspection of the camp. "All systems checked. World 1 is ready."
+
+func init() { addCommandFactory(newDoctorCmd) }
+
+func newDoctorCmd() *cobra.Command {
+	var verbose bool
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Preflight check: verify Go, Docker, DB, keystore, inference providers, RPCs, strategies",
+		Long: `Runs every preflight check in sequence and prints a green/yellow/red status
+for each. Exits 0 if no errors; 1 if any check fails. Warnings don't fail.
+
+Run this before 'permafrost agent start' to catch common misconfigurations
+before they bite you on the first decision tick.
+
+When an RPC check fails, try a different endpoint from https://chainlist.org/
+(EVM) or your paid Solana provider (Helius/Triton).`,
+		RunE: func(c *cobra.Command, _ []string) error {
+			results := runDoctor(c.Context(), c, verbose)
+			return printDoctorResults(c.OutOrStdout(), results, verbose)
+		},
+	}
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "show underlying error details for failures")
+	return cmd
+}
+
+// CheckStatus is the result level for one preflight check.
+type CheckStatus int
+
+const (
+	StatusOK   CheckStatus = iota // ✓ green
+	StatusWarn                    // ⚠ yellow
+	StatusFail                    // ✗ red
+	StatusSkip                    // ─ grey (check intentionally skipped)
+)
+
+// CheckResult is one row in the doctor output.
+type CheckResult struct {
+	Name   string
+	Status CheckStatus
+	Detail string
+	Err    error // populated on StatusFail; surfaced under --verbose
+}
+
+// runDoctor executes every check. Order is deliberate (cheapest first so the
+// operator sees fast feedback even on a slow connection).
+func runDoctor(ctx context.Context, c *cobra.Command, _ bool) []CheckResult {
+	g := FromContext(ctx)
+	checks := []CheckResult{}
+
+	// ── environment ───────────────────────────────────────────────
+	checks = append(checks, checkGoVersion())
+	checks = append(checks, checkDocker())
+
+	if g == nil {
+		// No globals = no config loaded; everything below depends on it.
+		// Mark remaining checks as skipped with a clear reason.
+		checks = append(checks, CheckResult{
+			Name:   "config loaded",
+			Status: StatusFail,
+			Detail: "globals not initialised; cannot run config-dependent checks",
+		})
+		return checks
+	}
+	checks = append(checks, checkConfigLoaded(g))
+
+	// ── data stores ───────────────────────────────────────────────
+	checks = append(checks, checkDatabase(ctx, g))
+
+	// ── keystore + secrets ────────────────────────────────────────
+	checks = append(checks, checkKeystorePassphrase(g))
+	checks = append(checks, checkKeystoreFile(c))
+
+	// ── inference ─────────────────────────────────────────────────
+	checks = append(checks, checkInferenceProviders(g)...)
+
+	// ── chain RPCs ────────────────────────────────────────────────
+	checks = append(checks, checkSolanaRPC(ctx, g))
+	checks = append(checks, checkEVMRPCs(ctx, g)...)
+
+	// ── strategies ────────────────────────────────────────────────
+	checks = append(checks, checkStrategiesRegistered())
+
+	return checks
+}
+
+// ─── individual checks ─────────────────────────────────────────────────────
+
+func checkGoVersion() CheckResult {
+	v := runtime.Version() // "go1.25.5"
+	r := CheckResult{Name: "go version", Detail: v, Status: StatusOK}
+	if !strings.HasPrefix(v, "go1.") {
+		r.Status = StatusWarn
+		r.Detail = v + " (unrecognised version string)"
+		return r
+	}
+	rest := strings.TrimPrefix(v, "go1.")
+	// "25.5" → minor "25"
+	minor := rest
+	if i := strings.Index(rest, "."); i >= 0 {
+		minor = rest[:i]
+	}
+	if minorInt := atoiSafe(minor); minorInt < 25 {
+		r.Status = StatusFail
+		r.Detail = v + " (need Go 1.25+)"
+		r.Err = fmt.Errorf("go version too old: %s", v)
+	}
+	return r
+}
+
+func checkDocker() CheckResult {
+	r := CheckResult{Name: "docker", Detail: ""}
+	path, err := exec.LookPath("docker")
+	if err != nil {
+		r.Status = StatusWarn
+		r.Detail = "not on PATH (only required for `make up`)"
+		return r
+	}
+	out, err := exec.Command(path, "version", "--format", "{{.Client.Version}}").CombinedOutput()
+	if err != nil {
+		r.Status = StatusWarn
+		r.Detail = "found at " + path + " but `docker version` failed (daemon not running?)"
+		r.Err = err
+		return r
+	}
+	r.Status = StatusOK
+	r.Detail = strings.TrimSpace(string(out))
+	return r
+}
+
+func checkConfigLoaded(g *Globals) CheckResult {
+	if g.Config == nil {
+		return CheckResult{
+			Name:   "config loaded",
+			Status: StatusFail,
+			Detail: "config is nil",
+		}
+	}
+	return CheckResult{
+		Name:   "config loaded",
+		Status: StatusOK,
+		Detail: fmt.Sprintf("env=%s", g.Config.Env),
+	}
+}
+
+func checkDatabase(ctx context.Context, g *Globals) CheckResult {
+	r := CheckResult{Name: "database reachable"}
+	dbCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	db, err := store.Open(dbCtx, g.Config.Database)
+	if err != nil {
+		r.Status = StatusFail
+		r.Detail = redactURL(g.Config.Database.URL)
+		r.Err = err
+		return r
+	}
+	defer db.Close()
+	r.Status = StatusOK
+	r.Detail = redactURL(g.Config.Database.URL)
+	return r
+}
+
+func checkKeystorePassphrase(g *Globals) CheckResult {
+	r := CheckResult{Name: "keystore passphrase env"}
+	envName := g.Config.Wallet.PassphraseEnv
+	if envName == "" {
+		envName = "PERMAFROST_KEYSTORE_PASSPHRASE"
+	}
+	if os.Getenv(envName) == "" {
+		r.Status = StatusWarn
+		r.Detail = envName + " not set (only required for keystore-using commands)"
+		return r
+	}
+	r.Status = StatusOK
+	r.Detail = envName + " set"
+	return r
+}
+
+func checkKeystoreFile(c *cobra.Command) CheckResult {
+	r := CheckResult{Name: "keystore file"}
+	path, err := keystorePath(c)
+	if err != nil {
+		r.Status = StatusFail
+		r.Detail = "cannot resolve path"
+		r.Err = err
+		return r
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			r.Status = StatusWarn
+			r.Detail = path + " (not yet created — run `permafrost wallet generate` or `wallet import`)"
+			return r
+		}
+		r.Status = StatusFail
+		r.Detail = path
+		r.Err = err
+		return r
+	}
+	r.Status = StatusOK
+	r.Detail = fmt.Sprintf("%s (%d bytes)", path, info.Size())
+	return r
+}
+
+func checkInferenceProviders(g *Globals) []CheckResult {
+	if len(g.Config.Inference.Providers) == 0 {
+		return []CheckResult{{
+			Name:   "inference providers",
+			Status: StatusWarn,
+			Detail: "none configured (only required for LLM-using strategies)",
+		}}
+	}
+	out := make([]CheckResult, 0, len(g.Config.Inference.Providers))
+	// Sort provider names for deterministic output ordering.
+	names := make([]string, 0, len(g.Config.Inference.Providers))
+	for n := range g.Config.Inference.Providers {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		p := g.Config.Inference.Providers[name]
+		r := CheckResult{Name: "inference: " + name}
+		if p.BaseURL == "" {
+			r.Status = StatusFail
+			r.Detail = "base_url is required"
+			r.Err = errors.New("base_url is empty")
+			out = append(out, r)
+			continue
+		}
+		// Don't actually call the provider — just verify config plausibility.
+		// A real round-trip needs `permafrost inference test --provider <name>`.
+		hasKey := p.APIKey != "" || (p.APIKeyEnv != "" && os.Getenv(p.APIKeyEnv) != "")
+		if p.APIKeyEnv != "" && !hasKey {
+			r.Status = StatusWarn
+			r.Detail = fmt.Sprintf("base_url=%s but %s not set (provider may reject auth)", p.BaseURL, p.APIKeyEnv)
+		} else {
+			r.Status = StatusOK
+			r.Detail = "base_url=" + p.BaseURL
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+func checkSolanaRPC(ctx context.Context, g *Globals) CheckResult {
+	r := CheckResult{Name: "solana RPC"}
+	if g.Config.Solana.RPCURL == "" {
+		r.Status = StatusSkip
+		r.Detail = "not configured"
+		return r
+	}
+	body := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"getHealth"}`)
+	rpcCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(rpcCtx, http.MethodPost, g.Config.Solana.RPCURL, body)
+	if err != nil {
+		r.Status = StatusFail
+		r.Detail = redactURL(g.Config.Solana.RPCURL)
+		r.Err = err
+		return r
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		r.Status = StatusFail
+		r.Detail = redactURL(g.Config.Solana.RPCURL) + " (network error)"
+		r.Err = err
+		return r
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode != http.StatusOK {
+		r.Status = StatusFail
+		r.Detail = fmt.Sprintf("%s (HTTP %d)", redactURL(g.Config.Solana.RPCURL), resp.StatusCode)
+		r.Err = fmt.Errorf("http %d: %s", resp.StatusCode, string(respBody))
+		return r
+	}
+	// getHealth returns "ok" in the result field on a healthy node.
+	if !strings.Contains(string(respBody), `"ok"`) {
+		r.Status = StatusWarn
+		r.Detail = redactURL(g.Config.Solana.RPCURL) + " (unhealthy: " + truncate(string(respBody), 80) + ")"
+		return r
+	}
+	r.Status = StatusOK
+	r.Detail = redactURL(g.Config.Solana.RPCURL)
+	return r
+}
+
+func checkEVMRPCs(ctx context.Context, g *Globals) []CheckResult {
+	if len(g.Config.EVM.Chains) == 0 {
+		return []CheckResult{{
+			Name:   "evm RPCs",
+			Status: StatusSkip,
+			Detail: "no chains configured",
+		}}
+	}
+	names := make([]string, 0, len(g.Config.EVM.Chains))
+	for n := range g.Config.EVM.Chains {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	out := make([]CheckResult, 0, len(names))
+	for _, name := range names {
+		ch := g.Config.EVM.Chains[name]
+		r := CheckResult{Name: "evm RPC: " + name}
+		if ch.RPCURL == "" {
+			r.Status = StatusFail
+			r.Detail = "rpc_url is empty (try chainlist.org for a fresh one)"
+			r.Err = errors.New("rpc_url empty")
+			out = append(out, r)
+			continue
+		}
+		// eth_blockNumber is a cheap, universally supported call.
+		body := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}`)
+		rpcCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		req, err := http.NewRequestWithContext(rpcCtx, http.MethodPost, ch.RPCURL, body)
+		if err != nil {
+			cancel()
+			r.Status = StatusFail
+			r.Detail = redactURL(ch.RPCURL)
+			r.Err = err
+			out = append(out, r)
+			continue
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		cancel()
+		if err != nil {
+			r.Status = StatusFail
+			r.Detail = redactURL(ch.RPCURL) + " (network error; try a different RPC from chainlist.org)"
+			r.Err = err
+			out = append(out, r)
+			continue
+		}
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		resp.Body.Close()
+		if resp.StatusCode == http.StatusTooManyRequests {
+			r.Status = StatusWarn
+			r.Detail = redactURL(ch.RPCURL) + " (rate-limited; try a different RPC from chainlist.org)"
+			out = append(out, r)
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			r.Status = StatusFail
+			r.Detail = fmt.Sprintf("%s (HTTP %d)", redactURL(ch.RPCURL), resp.StatusCode)
+			r.Err = fmt.Errorf("http %d: %s", resp.StatusCode, string(respBody))
+			out = append(out, r)
+			continue
+		}
+		// Parse the block number for a friendly detail line.
+		var rpcResp struct {
+			Result string `json:"result"`
+			Error  *struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		_ = json.Unmarshal(respBody, &rpcResp)
+		if rpcResp.Error != nil {
+			r.Status = StatusFail
+			r.Detail = redactURL(ch.RPCURL) + " (rpc error: " + rpcResp.Error.Message + ")"
+			r.Err = errors.New(rpcResp.Error.Message)
+			out = append(out, r)
+			continue
+		}
+		r.Status = StatusOK
+		r.Detail = fmt.Sprintf("%s (block %s)", redactURL(ch.RPCURL), rpcResp.Result)
+		out = append(out, r)
+	}
+	return out
+}
+
+func checkStrategiesRegistered() CheckResult {
+	r := CheckResult{Name: "strategies registered"}
+	names := strategy.List()
+	if len(names) == 0 {
+		r.Status = StatusFail
+		r.Detail = "no strategies registered (cmd/permafrost(d)/strategies.go missing imports?)"
+		r.Err = errors.New("registry empty")
+		return r
+	}
+	r.Status = StatusOK
+	r.Detail = strings.Join(names, ", ")
+	return r
+}
+
+// ─── output ────────────────────────────────────────────────────────────────
+
+func printDoctorResults(w io.Writer, results []CheckResult, verbose bool) error {
+	fmt.Fprintln(w, "Permafrost preflight ───────────────────────────────────────────")
+	var oks, warns, fails, skips int
+	for _, r := range results {
+		fmt.Fprintf(w, "  %s  %-26s %s\n", statusGlyph(r.Status), r.Name, r.Detail)
+		if verbose && r.Err != nil {
+			fmt.Fprintf(w, "       └─ %v\n", r.Err)
+		}
+		switch r.Status {
+		case StatusOK:
+			oks++
+		case StatusWarn:
+			warns++
+		case StatusFail:
+			fails++
+		case StatusSkip:
+			skips++
+		}
+	}
+	fmt.Fprintln(w, "─────────────────────────────────────────────────────────────────")
+	parts := []string{}
+	if oks > 0 {
+		parts = append(parts, fmt.Sprintf("%d ok", oks))
+	}
+	if warns > 0 {
+		parts = append(parts, fmt.Sprintf("%d warning(s)", warns))
+	}
+	if fails > 0 {
+		parts = append(parts, fmt.Sprintf("%d error(s)", fails))
+	}
+	if skips > 0 {
+		parts = append(parts, fmt.Sprintf("%d skipped", skips))
+	}
+	summary := strings.Join(parts, ", ")
+	if fails > 0 {
+		fmt.Fprintf(w, "%s. Fix errors before `permafrost agent start`.\n", summary)
+		if !verbose {
+			fmt.Fprintln(w, "Re-run with --verbose to see underlying errors.")
+		}
+		return errors.New("preflight failed")
+	}
+	if warns > 0 {
+		fmt.Fprintf(w, "%s. You're good to go (warnings indicate optional features).\n", summary)
+		return nil
+	}
+	fmt.Fprintf(w, "%s. You're good to go.\n", summary)
+	return nil
+}
+
+func statusGlyph(s CheckStatus) string {
+	// ANSI colour codes work in most terminals; they degrade to literal text
+	// in non-tty contexts (CI logs, file redirection) which is fine.
+	switch s {
+	case StatusOK:
+		return "\033[32m✓\033[0m"
+	case StatusWarn:
+		return "\033[33m⚠\033[0m"
+	case StatusFail:
+		return "\033[31m✗\033[0m"
+	case StatusSkip:
+		return "─"
+	}
+	return "?"
+}
+
+// ─── helpers ───────────────────────────────────────────────────────────────
+
+// redactURL strips username:password from a URL so the doctor doesn't leak
+// credentials in its output. Returns the original on any parse difficulty.
+func redactURL(raw string) string {
+	// We deliberately don't use net/url here because Postgres URLs sometimes
+	// contain query-string secrets too; a simple textual scrub is robust.
+	if i := strings.Index(raw, "@"); i > 0 {
+		// Find scheme://user:pass@host pattern
+		if j := strings.Index(raw, "://"); j >= 0 && j < i {
+			return raw[:j+3] + "REDACTED@" + raw[i+1:]
+		}
+	}
+	return raw
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+func atoiSafe(s string) int {
+	var n int
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	// Ensure noop is registered when the cli package's tests run, so the
+	// strategies-registered check has at least one entry to find.
+	_ "github.com/teslashibe/permafrost/strategies/noop"
+)
+
+// TestPrintDoctorResults_ExitCodeOnFailure verifies that any StatusFail
+// produces an "preflight failed" error from the printer, regardless of how
+// many warnings or successes are present alongside.
+func TestPrintDoctorResults_ExitCodeOnFailure(t *testing.T) {
+	results := []CheckResult{
+		{Name: "go version", Status: StatusOK, Detail: "go1.25"},
+		{Name: "docker", Status: StatusWarn, Detail: "not on PATH"},
+		{Name: "database", Status: StatusFail, Detail: "localhost:5432", Err: errors.New("ping failed")},
+	}
+	var buf bytes.Buffer
+	err := printDoctorResults(&buf, results, false)
+	if err == nil {
+		t.Fatal("expected error when any check fails")
+	}
+	if !strings.Contains(buf.String(), "Fix errors") {
+		t.Errorf("expected 'Fix errors' guidance in output:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "1 error(s)") {
+		t.Errorf("expected '1 error(s)' in summary:\n%s", buf.String())
+	}
+}
+
+// TestPrintDoctorResults_NoFailures returns nil when only warnings or all OK.
+func TestPrintDoctorResults_NoFailures(t *testing.T) {
+	results := []CheckResult{
+		{Name: "go version", Status: StatusOK, Detail: "go1.25"},
+		{Name: "docker", Status: StatusWarn, Detail: "not on PATH"},
+	}
+	var buf bytes.Buffer
+	if err := printDoctorResults(&buf, results, false); err != nil {
+		t.Fatalf("warnings should not produce an error: %v", err)
+	}
+}
+
+// TestPrintDoctorResults_VerboseShowsErrors ensures --verbose surfaces
+// the underlying error string under the failed check.
+func TestPrintDoctorResults_VerboseShowsErrors(t *testing.T) {
+	results := []CheckResult{
+		{Name: "database", Status: StatusFail, Detail: "localhost:5432", Err: errors.New("connection refused")},
+	}
+	var buf bytes.Buffer
+	_ = printDoctorResults(&buf, results, true)
+	if !strings.Contains(buf.String(), "connection refused") {
+		t.Errorf("verbose mode should include the underlying error:\n%s", buf.String())
+	}
+}
+
+// TestRedactURL strips credentials from URLs in the doctor output. This is
+// the soft-but-helpful guarantee that a user pasting their preflight log
+// in an issue tracker doesn't leak DB passwords.
+func TestRedactURL(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{
+			in:   "postgres://permafrost:secret@localhost:5432/permafrost",
+			want: "postgres://REDACTED@localhost:5432/permafrost",
+		},
+		{
+			in:   "https://api.helius.com/?api-key=abc123",
+			want: "https://api.helius.com/?api-key=abc123", // no @, nothing to redact
+		},
+		{
+			in:   "http://localhost:8899",
+			want: "http://localhost:8899",
+		},
+	}
+	for _, tc := range cases {
+		if got := redactURL(tc.in); got != tc.want {
+			t.Errorf("redactURL(%q) = %q want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestCheckGoVersion validates the version-string parser against a spread
+// of real and synthetic Go version strings. We can't easily mock
+// runtime.Version() so this exercises the parsing helpers indirectly via
+// the atoiSafe + minor-extraction logic.
+func TestAtoiSafe(t *testing.T) {
+	cases := map[string]int{
+		"25":   25,
+		"0":    0,
+		"":     0,
+		"abc":  0,
+		"25.5": 0, // dots aren't digits → returns 0
+	}
+	for in, want := range cases {
+		if got := atoiSafe(in); got != want {
+			t.Errorf("atoiSafe(%q) = %d want %d", in, got, want)
+		}
+	}
+}
+
+// TestCheckStrategiesRegistered reports the registered strategies. With
+// `noop` registered (via cmd/permafrost/strategies.go in main builds, or
+// directly imported in this test process), it must be StatusOK.
+func TestCheckStrategiesRegistered(t *testing.T) {
+	r := checkStrategiesRegistered()
+	if r.Status != StatusOK {
+		t.Errorf("expected StatusOK with noop registered; got %v (%s)", r.Status, r.Detail)
+	}
+	if !strings.Contains(r.Detail, "noop") {
+		t.Errorf("expected detail to mention noop; got %q", r.Detail)
+	}
+}
+

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -2,9 +2,14 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/teslashibe/permafrost/internal/config"
 
 	// Ensure noop is registered when the cli package's tests run, so the
 	// strategies-registered check has at least one entry to find.
@@ -114,6 +119,125 @@ func TestCheckStrategiesRegistered(t *testing.T) {
 	}
 	if !strings.Contains(r.Detail, "noop") {
 		t.Errorf("expected detail to mention noop; got %q", r.Detail)
+	}
+}
+
+// TestCheckSolanaRPC_Success uses an httptest server that responds like a
+// healthy Solana node would to getSlot. Verifies the happy path including
+// the slot number landing in the detail line.
+func TestCheckSolanaRPC_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":281234567}`))
+	}))
+	defer srv.Close()
+
+	g := &Globals{Config: &config.Config{Solana: config.SolanaConfig{RPCURL: srv.URL}}}
+	r := checkSolanaRPC(context.Background(), g)
+	if r.Status != StatusOK {
+		t.Fatalf("expected StatusOK, got %v (%s); err=%v", r.Status, r.Detail, r.Err)
+	}
+	if !strings.Contains(r.Detail, "281234567") {
+		t.Errorf("expected slot in detail; got %q", r.Detail)
+	}
+}
+
+// TestCheckSolanaRPC_NotConfigured returns StatusSkip when no RPC URL is
+// set — the doctor should never make an HTTP call against an empty URL.
+func TestCheckSolanaRPC_NotConfigured(t *testing.T) {
+	g := &Globals{Config: &config.Config{}}
+	r := checkSolanaRPC(context.Background(), g)
+	if r.Status != StatusSkip {
+		t.Errorf("expected StatusSkip when RPCURL is empty; got %v", r.Status)
+	}
+}
+
+// TestCheckSolanaRPC_RateLimited turns 429 into a warning, not a fail.
+// Operators on free public RPCs hit this constantly; warning + a nudge
+// to chainlist/Helius is the right UX.
+func TestCheckSolanaRPC_RateLimited(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	g := &Globals{Config: &config.Config{Solana: config.SolanaConfig{RPCURL: srv.URL}}}
+	r := checkSolanaRPC(context.Background(), g)
+	if r.Status != StatusWarn {
+		t.Fatalf("429 should produce StatusWarn, got %v (%s)", r.Status, r.Detail)
+	}
+	if !strings.Contains(r.Detail, "rate-limited") {
+		t.Errorf("warning detail should mention rate-limited; got %q", r.Detail)
+	}
+}
+
+// TestCheckSolanaRPC_RPCError surfaces a JSON-RPC error from the node
+// as a failure with the underlying message in Err.
+func TestCheckSolanaRPC_RPCError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}`))
+	}))
+	defer srv.Close()
+
+	g := &Globals{Config: &config.Config{Solana: config.SolanaConfig{RPCURL: srv.URL}}}
+	r := checkSolanaRPC(context.Background(), g)
+	if r.Status != StatusFail {
+		t.Fatalf("rpc error should produce StatusFail, got %v", r.Status)
+	}
+	if r.Err == nil || !strings.Contains(r.Err.Error(), "Method not found") {
+		t.Errorf("expected underlying error to mention Method not found; got %v", r.Err)
+	}
+}
+
+// TestCheckEVMRPCs_HappyAndRateLimitMix verifies the per-chain check
+// handles a mix of healthy + rate-limited backends and reports both
+// correctly without aborting the whole batch.
+func TestCheckEVMRPCs_HappyAndRateLimitMix(t *testing.T) {
+	healthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x16a4c8d"}`))
+	}))
+	defer healthy.Close()
+	rateLimited := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer rateLimited.Close()
+
+	g := &Globals{Config: &config.Config{
+		EVM: config.EVMConfig{
+			Chains: map[string]config.EVMChainConfig{
+				"base":     {RPCURL: healthy.URL},
+				"ethereum": {RPCURL: rateLimited.URL},
+			},
+		},
+	}}
+	results := checkEVMRPCs(context.Background(), g)
+	if len(results) != 2 {
+		t.Fatalf("expected one row per chain; got %d", len(results))
+	}
+	statusByName := map[string]CheckStatus{}
+	for _, r := range results {
+		statusByName[r.Name] = r.Status
+	}
+	if statusByName["evm RPC: base"] != StatusOK {
+		t.Errorf("base should be OK, got %v", statusByName["evm RPC: base"])
+	}
+	if statusByName["evm RPC: ethereum"] != StatusWarn {
+		t.Errorf("ethereum (429) should be Warn, got %v", statusByName["evm RPC: ethereum"])
+	}
+}
+
+// TestCheckEVMRPCs_NoChainsConfigured returns a single Skip row when
+// no EVM chains are configured. Common state for noop-only operators.
+func TestCheckEVMRPCs_NoChainsConfigured(t *testing.T) {
+	g := &Globals{Config: &config.Config{}}
+	results := checkEVMRPCs(context.Background(), g)
+	if len(results) != 1 || results[0].Status != StatusSkip {
+		t.Errorf("expected single StatusSkip row; got %+v", results)
 	}
 }
 


### PR DESCRIPTION
Second PR in the Trading Desk epic chain (#30, Phase 2).

Closes #34.

## What it does

Adds `permafrost doctor` — a preflight subcommand that runs every common-failure-mode check in sequence and prints colour-coded results. Exit 0 if no errors; 1 if any check fails. Warnings don't fail the command.

The use case: before `permafrost agent start`, an operator runs doctor and immediately sees whether they're going to have a good day. Catches the "forgot the keystore env / RPC isn't responding / wrong DB url" class of mistakes that today surface as half-helpful errors on the first decision tick.

## Checks (v1)

| Check | Verifies |
|---|---|
| go version | runtime ≥ 1.25 |
| docker | `docker version` succeeds (warn only, since `make up` is optional) |
| config loaded | globals + config struct present |
| database reachable | `store.Open` + `Ping` with 5s timeout |
| keystore passphrase env | env var named in `wallet.passphrase_env` is set |
| keystore file | exists at the resolved path |
| inference: `<provider>` | one row per configured provider; checks `base_url` + API key env |
| solana RPC | POST `getHealth`, expect `"ok"` |
| evm RPC: `<chain>` | one row per configured chain; POST `eth_blockNumber`, expect 200 with result |
| strategies registered | `strategy.List()` non-empty |

Each check returns `(Name, Status, Detail, Err)`. Status is `✓ ok` (green), `⚠ warn` (yellow), `✗ fail` (red), or `─ skip` (grey, intentionally unrun).

## Output

```
Permafrost preflight ───────────────────────────────────────────
  ✓  go version                 go1.25.5
  ✓  docker                     28.0.0
  ✓  config loaded              env=dev
  ✗  database reachable         postgres://REDACTED@localhost:5432/...
  ⚠  keystore passphrase env    PERMAFROST_KEYSTORE_PASSPHRASE not set
  ⚠  keystore file              ~/.permafrost/keystore.json (not yet created)
  ⚠  inference providers        none configured
  ─  solana RPC                 not configured
  ─  evm RPCs                   no chains configured
  ✓  strategies registered      funding_arb_basic, noop
─────────────────────────────────────────────────────────────────
4 ok, 3 warning(s), 1 error(s), 2 skipped. Fix errors before \`permafrost agent start\`.
Re-run with --verbose to see underlying errors.
```

ANSI colour codes degrade to plain text in non-tty contexts (CI logs, file redirection). When an EVM RPC fails or rate-limits, the detail line nudges users toward [chainlist.org](https://chainlist.org/) for a fresh endpoint.

## Audit (per .cursor/rules/issue-audit-user-stories.mdc)

### Findings

**No high-severity findings.**

**Medium:**

- M1: `redactURL` uses simple textual scrub rather than `net/url` parsing because Postgres URLs sometimes carry secrets in the query string and net/url parsing has edge cases (e.g. unencoded \"@\" in passwords). Trade-off documented inline; redacts the common case correctly. Test coverage in `TestRedactURL`.
- M2: Inference provider check verifies config plausibility (base_url + API key env) but does **not** make a real round-trip. A real ping would consume API quota on every doctor invocation. The doc-comment directs users at `permafrost inference test` for live verification.

**Low:**

- L1: ANSI colour codes are emitted unconditionally. In a strict pipe / file context they show up as escape sequences. Acceptable for v1; a `--no-color` flag is a 5-line follow-up if anyone asks.
- L2: HTTP timeout is hard-coded at 5s for both Solana + EVM checks. Reasonable for preflight; could be a flag.

### Acceptance criteria coverage (from #34)

- [x] `permafrost doctor` exists and runs all v1 checks listed above.
- [x] Output is colour-coded (✓/⚠/✗) and includes a one-line summary.
- [x] `--verbose` shows underlying errors for failures.
- [x] Exit code 0 / 1 based on errors only (warnings don't fail).
- [x] At least 5 of the checks have unit tests with mocked dependencies (6 tests; covers exit-code, no-failure, verbose, redaction, version parsing, registry).

### Risks

- The doctor calls `store.Open` which actually opens a connection pool. Cheap but does establish a real connection. For repeated runs against a laggy DB, doctor takes ~5s per run.
- The HTTP RPC checks use `http.DefaultClient` which has no global timeout. Mitigated by the 5s context timeout per request.

## Test plan

- [x] `go build ./...` green
- [x] `go test ./...` green (24 packages)
- [x] `go vet ./...` clean
- [x] Smoke-run on author's machine: doctor correctly reports DB unreachable when Postgres isn't running, OK when it is, and properly degrades to warnings/skips for unconfigured features.

## Stack position

PR 2 of ~12 in the Trading Desk epic chain. Targets `main` directly (not stacked on #44 since it touches a different file set).

## Out of scope

- Auto-fix mode. Doctor reports; the operator decides.
- Continuous health monitoring. That's the supervisor's job.
- A `--no-color` flag. 5-line follow-up if anyone needs it.