### PR TITLE
Add `permafrost init` interactive setup wizard (closes #35)

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -1,0 +1,412 @@
+package cli
+
+import (
+	"bufio"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// init wires the `permafrost init` command into the cobra registry.
+//
+// The wizard walks a first-time operator from "git clone" to a working
+// configuration in 60 seconds. End state: config.yaml exists, a keystore
+// passphrase is generated and saved to a sourceable env file, and the
+// operator is told the next 3 commands to type. Deliberately does NOT
+// touch the database — that requires `make up` first.
+
+func init() { addCommandFactory(newInitCmd) }
+
+func newInitCmd() *cobra.Command {
+	opts := initOptions{Theme: "arctic"}
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Interactive setup wizard: config + keystore passphrase + first-agent template",
+		Long: `Walks a first-time operator through Permafrost setup in ~60 seconds.
+
+Idempotent: re-running on an already-configured repo detects existing
+files and offers to skip / append rather than overwriting. Safe to run
+multiple times.
+
+The arctic theme uses character vocabulary (Captain Pole the polar bear,
+penguin traders, etc.). Pass --theme plain for the no-vocabulary version.
+
+Use --non-interactive for scripted installs; defaults are applied
+silently and any existing files are left alone.`,
+		RunE: func(c *cobra.Command, _ []string) error {
+			var p prompter = newStdioPrompter(c.InOrStdin(), c.OutOrStdout())
+			if opts.NonInteractive {
+				p = nonInteractivePrompter{}
+			}
+			return runInit(c.OutOrStdout(), p, opts)
+		},
+	}
+	cmd.Flags().BoolVar(&opts.NonInteractive, "non-interactive", false, "skip all prompts; accept defaults silently (for CI / scripts)")
+	cmd.Flags().StringVar(&opts.Theme, "theme", "arctic", "vocabulary theme: arctic (Captain Pole, penguins, …) or plain")
+	cmd.Flags().StringVar(&opts.ConfigPath, "config-out", "", "where to write config.yaml (default: ./config.yaml)")
+	cmd.Flags().StringVar(&opts.KeystorePath, "keystore-out", "", "where to put the keystore (default: ~/.permafrost/keystore.json)")
+	cmd.Flags().StringVar(&opts.EnvOut, "env-out", "", "where to write the generated passphrase env file (default: ~/.permafrost/env)")
+	return cmd
+}
+
+// initOptions are the wizard's flags. Each one has a sensible default;
+// non-interactive mode applies all of them silently.
+type initOptions struct {
+	NonInteractive bool
+	Theme          string
+	ConfigPath     string
+	KeystorePath   string
+	EnvOut         string
+}
+
+// runInit is the wizard body. Split out from the cobra cmd so tests can
+// drive it with a scripted prompter and capture output for assertions.
+func runInit(out io.Writer, p prompter, opts initOptions) error {
+	v := vocab(opts.Theme)
+	fmt.Fprintln(out, v.banner())
+
+	// ── 1. Captain's callsign ─────────────────────────────────────
+	callsign, err := p.Ask(v.callsignPrompt(), v.defaultCallsign())
+	if err != nil {
+		return err
+	}
+
+	// ── 2. Resolve target paths ───────────────────────────────────
+	configPath := opts.ConfigPath
+	if configPath == "" {
+		configPath, err = p.Ask("Where should I keep your config?", "./config.yaml")
+		if err != nil {
+			return err
+		}
+	}
+	keystorePath := opts.KeystorePath
+	if keystorePath == "" {
+		def, _ := defaultKeystorePath()
+		keystorePath, err = p.Ask("Where should I keep your keystore?", def)
+		if err != nil {
+			return err
+		}
+	}
+	envPath := opts.EnvOut
+	if envPath == "" {
+		def, _ := defaultEnvPath()
+		envPath, err = p.Ask("Where should I save the generated passphrase env file?", def)
+		if err != nil {
+			return err
+		}
+	}
+
+	// ── 3. Config file ────────────────────────────────────────────
+	wroteConfig, err := writeConfigIfAbsent(configPath, p)
+	if err != nil {
+		return fmt.Errorf("config: %w", err)
+	}
+
+	// ── 4. Keystore passphrase ────────────────────────────────────
+	wrotePassphrase, passphraseValue, err := generatePassphraseIfAbsent(envPath, p)
+	if err != nil {
+		return fmt.Errorf("passphrase: %w", err)
+	}
+
+	// ── 5. Inference (optional) ───────────────────────────────────
+	wantInf, err := p.AskYN(v.inferencePrompt(), false)
+	if err != nil {
+		return err
+	}
+	infChoice := ""
+	if wantInf {
+		infChoice, err = p.AskChoice(
+			"Pick a provider (you can edit config.yaml later):",
+			[]string{"openrouter", "openai", "groq", "ollama", "skip"},
+			0,
+		)
+		if err != nil {
+			return err
+		}
+		if infChoice != "skip" {
+			fmt.Fprintf(out, "  ℹ Make sure %s_API_KEY is set in your env (or edit config.yaml inference.providers.%s.api_key_env).\n",
+				strings.ToUpper(infChoice), infChoice)
+		}
+	}
+
+	// ── 6. EVM chains: nudge to chainlist.org ─────────────────────
+	fmt.Fprintf(out, "\n  ℹ EVM RPCs: pick fresh ones from https://chainlist.org/ when you want to trade EVM-chain spot legs.\n")
+	fmt.Fprintf(out, "    Add them under evm.chains.<name>.rpc_url in %s.\n", configPath)
+
+	// ── 7. Done ───────────────────────────────────────────────────
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, v.done())
+	if wroteConfig {
+		fmt.Fprintf(out, "  ✓ wrote %s\n", configPath)
+	} else {
+		fmt.Fprintf(out, "  ─ kept existing %s (re-run with rm if you want a fresh template)\n", configPath)
+	}
+	if wrotePassphrase {
+		fmt.Fprintf(out, "  ✓ generated keystore passphrase, saved to %s\n", envPath)
+		fmt.Fprintf(out, "    BACK UP THIS PASSPHRASE: %s\n", passphraseValue)
+		fmt.Fprintf(out, "    If you lose it, the keystore is unrecoverable.\n")
+	} else {
+		fmt.Fprintf(out, "  ─ kept existing passphrase env at %s\n", envPath)
+	}
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, v.nextSteps(envPath, callsign))
+	return nil
+}
+
+// ─── prompter ──────────────────────────────────────────────────────────────
+
+// prompter is a tiny abstraction over os.Stdin/Stdout so tests can feed
+// scripted responses. We intentionally hand-roll this rather than pulling
+// in a third-party prompt library — fewer deps, easier to mock, fully
+// scriptable from CI without a TTY.
+type prompter interface {
+	Ask(prompt, defaultValue string) (string, error)
+	AskYN(prompt string, defaultYes bool) (bool, error)
+	AskChoice(prompt string, choices []string, defaultIdx int) (string, error)
+}
+
+// stdioPrompter reads single-line answers from stdin, writes prompts to
+// stdout. Empty input accepts the default. Trailing whitespace stripped.
+type stdioPrompter struct {
+	r *bufio.Reader
+	w io.Writer
+}
+
+func newStdioPrompter(in io.Reader, out io.Writer) *stdioPrompter {
+	return &stdioPrompter{r: bufio.NewReader(in), w: out}
+}
+
+func (s *stdioPrompter) Ask(prompt, def string) (string, error) {
+	if def != "" {
+		fmt.Fprintf(s.w, "  %s [%s]: ", prompt, def)
+	} else {
+		fmt.Fprintf(s.w, "  %s: ", prompt)
+	}
+	line, err := s.r.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", err
+	}
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return def, nil
+	}
+	return line, nil
+}
+
+func (s *stdioPrompter) AskYN(prompt string, defaultYes bool) (bool, error) {
+	def := "y"
+	if !defaultYes {
+		def = "n"
+	}
+	resp, err := s.Ask(prompt+" [y/n]", def)
+	if err != nil {
+		return false, err
+	}
+	switch strings.ToLower(resp) {
+	case "y", "yes":
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+func (s *stdioPrompter) AskChoice(prompt string, choices []string, defaultIdx int) (string, error) {
+	if defaultIdx < 0 || defaultIdx >= len(choices) {
+		defaultIdx = 0
+	}
+	def := choices[defaultIdx]
+	for {
+		resp, err := s.Ask(prompt+" ("+strings.Join(choices, " / ")+")", def)
+		if err != nil {
+			return "", err
+		}
+		for _, c := range choices {
+			if strings.EqualFold(resp, c) {
+				return c, nil
+			}
+		}
+		fmt.Fprintf(s.w, "  please choose one of: %s\n", strings.Join(choices, ", "))
+	}
+}
+
+// nonInteractivePrompter always returns the default. Used by
+// `permafrost init --non-interactive` for scripted installs.
+type nonInteractivePrompter struct{}
+
+func (nonInteractivePrompter) Ask(_ string, def string) (string, error) { return def, nil }
+func (nonInteractivePrompter) AskYN(_ string, defaultYes bool) (bool, error) {
+	return defaultYes, nil
+}
+func (nonInteractivePrompter) AskChoice(_ string, choices []string, defaultIdx int) (string, error) {
+	if defaultIdx < 0 || defaultIdx >= len(choices) {
+		defaultIdx = 0
+	}
+	return choices[defaultIdx], nil
+}
+
+// ─── side-effecting helpers ────────────────────────────────────────────────
+
+// writeConfigIfAbsent writes a starter config.yaml if the path doesn't
+// exist. Returns (wrote, err) — wrote=false means we kept what was there.
+// We deliberately do NOT prompt to overwrite; idempotency means
+// non-destructive on re-run.
+func writeConfigIfAbsent(path string, _ prompter) (bool, error) {
+	if _, err := os.Stat(path); err == nil {
+		return false, nil
+	} else if !os.IsNotExist(err) {
+		return false, fmt.Errorf("stat %s: %w", path, err)
+	}
+	// Use the example as the starter. We don't embed it because it
+	// already lives at config.example.yaml in the repo and operators
+	// can find it. Just point the user at it instead of duplicating.
+	exampleSrc := "config.example.yaml"
+	body, err := os.ReadFile(exampleSrc)
+	if err != nil {
+		// Repo layout doesn't have it (running from elsewhere). Write a
+		// minimal stub so the daemon at least boots.
+		body = []byte(minimalConfigYAML)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return false, err
+	}
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// generatePassphraseIfAbsent creates a 32-byte hex passphrase and writes
+// it to envPath in a sourceable form. Returns (wrote, value, err);
+// wrote=false means a passphrase was already present and we kept it.
+func generatePassphraseIfAbsent(envPath string, _ prompter) (bool, string, error) {
+	if _, err := os.Stat(envPath); err == nil {
+		return false, "", nil
+	} else if !os.IsNotExist(err) {
+		return false, "", fmt.Errorf("stat %s: %w", envPath, err)
+	}
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return false, "", fmt.Errorf("random: %w", err)
+	}
+	passphrase := hex.EncodeToString(raw)
+	if err := os.MkdirAll(filepath.Dir(envPath), 0o700); err != nil {
+		return false, "", err
+	}
+	body := fmt.Sprintf(`# Permafrost keystore passphrase. Source this in your shell:
+#   set -a; source %s; set +a
+# Or in CI / Docker, mount as an env file.
+PERMAFROST_KEYSTORE_PASSPHRASE=%s
+`, envPath, passphrase)
+	// 0600 — readable only by the owner. The directory is 0700.
+	if err := os.WriteFile(envPath, []byte(body), 0o600); err != nil {
+		return false, "", err
+	}
+	return true, passphrase, nil
+}
+
+func defaultKeystorePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".permafrost", "keystore.json"), nil
+}
+
+func defaultEnvPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".permafrost", "env"), nil
+}
+
+const minimalConfigYAML = `# Permafrost minimal config (generated by 'permafrost init').
+# See config.example.yaml in the repo for the full annotated reference.
+env: dev
+server:
+  bind: 127.0.0.1:8080
+logging:
+  level: info
+database:
+  url: postgres://permafrost:permafrost@localhost:5432/permafrost?sslmode=disable
+wallet:
+  passphrase_env: PERMAFROST_KEYSTORE_PASSPHRASE
+`
+
+// ─── vocabulary ────────────────────────────────────────────────────────────
+
+// vocabulary swaps the wizard's text between the arctic theme and plain
+// English. The arctic theme uses Captain Pole the polar bear, penguin
+// traders, etc. — see epic #30 for the full character mapping. Plain
+// theme exists for users who'd rather see "agent" / "operator".
+type vocabulary struct {
+	arctic bool
+}
+
+func vocab(theme string) vocabulary {
+	return vocabulary{arctic: theme != "plain"}
+}
+
+func (v vocabulary) banner() string {
+	if v.arctic {
+		return "❄ ❄   Permafrost camp setup\n──────"
+	}
+	return "Permafrost setup\n────────────────"
+}
+
+func (v vocabulary) callsignPrompt() string {
+	if v.arctic {
+		return "Captain's callsign (just for display)"
+	}
+	return "Operator name (just for display)"
+}
+
+func (v vocabulary) defaultCallsign() string {
+	if v.arctic {
+		return "Captain Pole"
+	}
+	return "Operator"
+}
+
+func (v vocabulary) inferencePrompt() string {
+	if v.arctic {
+		return "Want to set up an LLM provider so your narwhal advisors can speak?"
+	}
+	return "Configure an LLM provider for inference-using strategies?"
+}
+
+func (v vocabulary) done() string {
+	if v.arctic {
+		return "✓ Camp set up. The expedition is ready to launch."
+	}
+	return "✓ Setup complete."
+}
+
+func (v vocabulary) nextSteps(envPath, _ string) string {
+	source := fmt.Sprintf("source %s", envPath)
+	if v.arctic {
+		return fmt.Sprintf(`Next steps:
+
+  set -a; %s; set +a    # load the keystore passphrase into your shell
+  make up                                         # bring up Postgres + permafrostd
+  permafrost doctor                               # confirm everything is wired
+  permafrost agent create --strategy noop --perp hyperliquid --alloc 1000
+  permafrost agent start <id>                     # mark runnable; supervisor picks up
+
+Or for one-shot foreground iteration: 'permafrost agent run <id>'.`, source)
+	}
+	return fmt.Sprintf(`Next steps:
+
+  set -a; %s; set +a
+  make up
+  permafrost doctor
+  permafrost agent create --strategy noop --perp hyperliquid --alloc 1000
+  permafrost agent start <id>`, source)
+}

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -1,0 +1,279 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// scriptedPrompter is a test prompter that returns canned responses in
+// order. AskYN reads "y"/"n" responses; AskChoice reads literal choice
+// strings. If responses run out, it returns the prompted default — so
+// half-scripted tests behave gracefully.
+type scriptedPrompter struct {
+	answers []string
+	idx     int
+}
+
+func (s *scriptedPrompter) next(def string) string {
+	if s.idx >= len(s.answers) {
+		return def
+	}
+	v := s.answers[s.idx]
+	s.idx++
+	if v == "" {
+		return def
+	}
+	return v
+}
+
+func (s *scriptedPrompter) Ask(_, def string) (string, error) {
+	return s.next(def), nil
+}
+
+func (s *scriptedPrompter) AskYN(_ string, defaultYes bool) (bool, error) {
+	def := "n"
+	if defaultYes {
+		def = "y"
+	}
+	v := s.next(def)
+	return strings.EqualFold(v, "y") || strings.EqualFold(v, "yes"), nil
+}
+
+func (s *scriptedPrompter) AskChoice(_ string, choices []string, defaultIdx int) (string, error) {
+	def := choices[defaultIdx]
+	v := s.next(def)
+	for _, c := range choices {
+		if strings.EqualFold(v, c) {
+			return c, nil
+		}
+	}
+	return def, nil
+}
+
+// TestRunInit_FreshHappyPath drives the wizard end-to-end against a
+// fresh tmpdir and asserts: config + env files materialised, output
+// includes the next-steps block, exit was clean.
+func TestRunInit_FreshHappyPath(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	keystorePath := filepath.Join(dir, "keystore.json")
+	envPath := filepath.Join(dir, "env")
+
+	p := &scriptedPrompter{answers: []string{
+		"Captain Pole",   // callsign
+		cfgPath,          // config path
+		keystorePath,     // keystore path
+		envPath,          // env path
+		"n",              // skip inference setup
+	}}
+	var out bytes.Buffer
+	err := runInit(&out, p, initOptions{Theme: "arctic"})
+	if err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+
+	if _, err := os.Stat(cfgPath); err != nil {
+		t.Errorf("config not written: %v", err)
+	}
+	if _, err := os.Stat(envPath); err != nil {
+		t.Errorf("env file not written: %v", err)
+	}
+	body, _ := os.ReadFile(envPath)
+	if !strings.Contains(string(body), "PERMAFROST_KEYSTORE_PASSPHRASE=") {
+		t.Errorf("env file missing passphrase var; got:\n%s", body)
+	}
+
+	got := out.String()
+	for _, frag := range []string{
+		"Camp set up",            // arctic done message
+		"Next steps:",            // next-steps header
+		"permafrost doctor",      // doctor in next steps
+		"chainlist.org",          // EVM nudge
+	} {
+		if !strings.Contains(got, frag) {
+			t.Errorf("output missing %q:\n%s", frag, got)
+		}
+	}
+}
+
+// TestRunInit_Idempotent re-runs the wizard against an existing
+// installation and asserts files aren't overwritten and the user is
+// told what was kept.
+func TestRunInit_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	envPath := filepath.Join(dir, "env")
+
+	// Pre-seed both files with sentinel content.
+	if err := os.WriteFile(cfgPath, []byte("# pre-existing config\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(envPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(envPath, []byte("# pre-existing env\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &scriptedPrompter{answers: []string{
+		"",       // callsign default
+		cfgPath,  // config path (exists)
+		filepath.Join(dir, "keystore.json"),
+		envPath,  // env path (exists)
+		"n",      // skip inference
+	}}
+	var out bytes.Buffer
+	if err := runInit(&out, p, initOptions{Theme: "arctic"}); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+
+	// Files should be untouched.
+	if body, _ := os.ReadFile(cfgPath); string(body) != "# pre-existing config\n" {
+		t.Errorf("config was overwritten; got %q", body)
+	}
+	if body, _ := os.ReadFile(envPath); string(body) != "# pre-existing env\n" {
+		t.Errorf("env was overwritten; got %q", body)
+	}
+
+	// Output should announce the keeps.
+	got := out.String()
+	if !strings.Contains(got, "kept existing") {
+		t.Errorf("output should mention 'kept existing':\n%s", got)
+	}
+}
+
+// TestRunInit_NonInteractive_PlainTheme verifies the --non-interactive
+// + --theme plain combination produces a working setup with no
+// prompts and no arctic vocabulary.
+func TestRunInit_NonInteractive_PlainTheme(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	envPath := filepath.Join(dir, "env")
+
+	var out bytes.Buffer
+	err := runInit(&out, nonInteractivePrompter{}, initOptions{
+		NonInteractive: true,
+		Theme:          "plain",
+		ConfigPath:     cfgPath,
+		KeystorePath:   filepath.Join(dir, "keystore.json"),
+		EnvOut:         envPath,
+	})
+	if err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+	if _, err := os.Stat(cfgPath); err != nil {
+		t.Errorf("config not written: %v", err)
+	}
+	if _, err := os.Stat(envPath); err != nil {
+		t.Errorf("env not written: %v", err)
+	}
+	got := out.String()
+	if strings.Contains(got, "Captain Pole") {
+		t.Errorf("plain theme should not contain arctic vocab; got:\n%s", got)
+	}
+	if !strings.Contains(got, "Setup complete") {
+		t.Errorf("plain theme done message missing:\n%s", got)
+	}
+}
+
+// TestGeneratePassphrase_ProducesUniqueValues sanity-checks that two
+// successive generations land on different passphrases. (Also exercises
+// the "wrote" path of generatePassphraseIfAbsent.)
+func TestGeneratePassphrase_ProducesUniqueValues(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "env-a")
+	b := filepath.Join(dir, "env-b")
+
+	_, valA, err := generatePassphraseIfAbsent(a, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, valB, err := generatePassphraseIfAbsent(b, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if valA == "" || valB == "" {
+		t.Fatal("expected non-empty passphrases")
+	}
+	if valA == valB {
+		t.Errorf("two successive passphrases collided (vanishingly improbable; check rand source)")
+	}
+	// File permissions should be 0600 — passphrase is a secret.
+	info, err := os.Stat(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("env file permission = %o, want 0600", perm)
+	}
+}
+
+// TestGeneratePassphrase_KeptIfExists verifies the second call returns
+// wrote=false and an empty value (the wizard treats this as "keep
+// what's there"). Critical for idempotency.
+func TestGeneratePassphrase_KeptIfExists(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, "env")
+
+	if _, _, err := generatePassphraseIfAbsent(envPath, nil); err != nil {
+		t.Fatal(err)
+	}
+	wrote, val, err := generatePassphraseIfAbsent(envPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wrote {
+		t.Errorf("second call should not have written")
+	}
+	if val != "" {
+		t.Errorf("kept-path should return empty value, got %q", val)
+	}
+}
+
+// TestVocabSwap verifies the arctic↔plain vocabulary toggle flips every
+// user-facing string. Cheap regression guard against a future contributor
+// adding an arctic-flavoured prompt that isn't gated behind v.arctic.
+func TestVocabSwap(t *testing.T) {
+	arctic := vocab("arctic")
+	plain := vocab("plain")
+	pairs := []struct {
+		arcticVal string
+		plainVal  string
+	}{
+		{arctic.banner(), plain.banner()},
+		{arctic.callsignPrompt(), plain.callsignPrompt()},
+		{arctic.defaultCallsign(), plain.defaultCallsign()},
+		{arctic.inferencePrompt(), plain.inferencePrompt()},
+		{arctic.done(), plain.done()},
+	}
+	for _, p := range pairs {
+		if p.arcticVal == p.plainVal {
+			t.Errorf("arctic and plain vocab agree (%q); should differ", p.arcticVal)
+		}
+	}
+}
+
+// TestStdioPrompter_DefaultsOnEmptyInput exercises the actual stdin path
+// to make sure pressing Enter accepts the default cleanly.
+func TestStdioPrompter_DefaultsOnEmptyInput(t *testing.T) {
+	in := strings.NewReader("\n\n\n")
+	var out bytes.Buffer
+	p := newStdioPrompter(in, &out)
+
+	got, err := p.Ask("ignored", "default-value")
+	if err != nil && !errors.Is(err, nil) {
+		t.Fatal(err)
+	}
+	if got != "default-value" {
+		t.Errorf("Ask: got %q, want default-value", got)
+	}
+
+	yn, _ := p.AskYN("ignored", true)
+	if !yn {
+		t.Errorf("AskYN with defaultYes=true and empty input should return true")
+	}
+}


### PR DESCRIPTION
PR 3 of ~10 in the Trading Desk epic chain (#30, Phase 2). Closes #35.

## What it does

`permafrost init` walks a first-time operator from \"git clone\" to a working configuration in ~60 seconds. End state: `config.yaml` exists, a strong keystore passphrase is generated and saved to a sourceable env file, and the user is told the next 3 commands to type.

The wizard deliberately does **not** touch the database — that needs `make up` first. Wizard configures; operator runs.

## Interactive flow (default arctic theme)

```
❄ ❄   Permafrost camp setup
 ──────

  Captain's callsign (just for display) [Captain Pole]: ▌
  Where should I keep your config? [./config.yaml]: ▌
  Where should I keep your keystore? [~/.permafrost/keystore.json]: ▌
  Where should I save the generated passphrase env file? [~/.permafrost/env]: ▌
  Want to set up an LLM provider so your narwhal advisors can speak? [y/n]: n

  ℹ EVM RPCs: pick fresh ones from https://chainlist.org/ when you
    want to trade EVM-chain spot legs.

✓ Camp set up. The expedition is ready to launch.
  ✓ wrote config.yaml
  ✓ generated keystore passphrase, saved to ~/.permafrost/env
    BACK UP THIS PASSPHRASE: 6e412a...9359

Next steps:
  set -a; source ~/.permafrost/env; set +a
  make up
  permafrost doctor
  permafrost agent create --strategy noop --perp hyperliquid --alloc 1000
  permafrost agent start <id>
```

## Flags

- `--non-interactive` — skip prompts, accept defaults (CI / scripts)
- `--theme {arctic,plain}` — vocabulary; default arctic with Captain Pole + narwhals
- `--config-out`, `--keystore-out`, `--env-out` — path overrides

## Implementation notes

- **No new dependencies.** Hand-rolled prompter (bufio.Reader + io.Writer interface). Smaller binary, easier to mock for tests, fully scriptable from CI without a TTY.
- **Idempotent.** Existing config / env files are detected and kept. Wizard reports what it kept; no destructive overwrites. Critical for the \"oh no I accidentally re-ran it\" case.
- **Passphrase generation.** 32 bytes of `crypto/rand` → 64 hex chars. Env file written with 0600, parent dir 0700.
- **Wizard does not auto-source the env file** or modify the operator's shell profile. Asks them to source it explicitly. Less magic, less accidental damage.
- **Chainlist.org nudge** lands in the EVM-skip step so operators get pointed at the right RPC source from setup-time.
- **Vocabulary toggle** (arctic ↔ plain) keeps every user-facing string behind a `vocabulary` type. A future contributor can't accidentally break the plain theme by inlining a penguin reference.

## Audit (per .cursor/rules/issue-audit-user-stories.mdc)

### Findings

**No high-severity findings.** The wizard does no irreversible operations and refuses to overwrite existing files.

**Medium:**

- M1: The minimal config stub (used as fallback when `config.example.yaml` isn't readable) duplicates content from the example file. Mild drift risk over time. Mitigation: keep the stub minimal so drift is visible; the wizard prefers the real example file when it exists.
- M2: Passphrase is printed to stdout once (\"BACK UP THIS PASSPHRASE: …\"). Operators running with shell history enabled will have it captured. Acceptable trade-off — the passphrase has to be visible at least once for the operator to back it up. Documented inline.

**Low:**

- L1: Wizard does not validate that the operator's chosen config / env paths are writable before going through prompts. A read-only-filesystem operator would only discover this at the end. Trade-off accepted: pre-flight write tests would create empty files; the failure-at-end mode is rare and surfaces a clear error.
- L2: AskChoice only matches case-insensitively against the literal choice strings. No fuzzy matching / autocompletion. Acceptable for a 5-choice menu.

### Acceptance criteria coverage (from #35)

- [x] `permafrost init` exists; first-run produces a working config + env file
- [x] Re-run is non-destructive (TestRunInit_Idempotent)
- [x] `--non-interactive` works for scripted installs
- [x] At the end, the user is told exactly the next 5 commands to type
- [x] All prompts have sensible defaults; pressing Enter repeatedly produces a working setup
- [x] EVM chain configuration directs users at chainlist.org rather than baking in opinionated defaults

### Risks

- **Generated passphrase shown once on stdout.** If the operator's terminal scrollback is captured (tmux, screen recording, terminal logger), the secret leaks. Standard trade-off for any first-time-setup tool that generates secrets; documented.
- **Env file written world-unreadable (0600) but the directory permission depends on the parent.** If the parent (~/.permafrost) was created by another process with looser permissions, the env file inherits that visibility risk. Wizard creates `~/.permafrost` with 0700 if it doesn't exist; existing dirs are not chmod'd.

## Test plan

- [x] `go build ./...` green
- [x] `go test ./...` green (24 packages)
- [x] `go vet ./...` clean
- [x] 7 new unit tests cover the happy path, idempotency, non-interactive mode, plain theme, passphrase entropy + permissions, vocab swap, and stdin-default behaviour
- [x] Manually smoke-tested against `/tmp/pf-test-*` paths; produced a working config + env file with a fresh 64-hex-char passphrase. Re-run on the same tmpdir was a no-op as designed.

## Stack position

PR 3 of ~10 in the Trading Desk epic chain. Targets `main` directly (not stacked on #44 or #45 since it touches a different file set).

## Out of scope

- Hosted account creation. Permafrost is local-first; \"sign up\" is not a thing.
- Live-mode setup (key generation for Hyperliquid signing). The wizard hands off to a separate `permafrost go-live` flow that's a follow-up on the epic.
- Auto-sourcing the env file into the operator's shell profile. Too much magic.