### PR TITLE
Killswitch: wire OpenOrders + cancel + spot liquidation (closes #38)

### DIFF
--- a/internal/agent/killswitch.go
+++ b/internal/agent/killswitch.go
@@ -6,26 +6,41 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/teslashibe/permafrost/internal/assets"
 	"github.com/teslashibe/permafrost/internal/exchange"
+	"github.com/teslashibe/permafrost/internal/swap"
 	"github.com/teslashibe/permafrost/pkg/types"
 )
 
 // KillSwitchOptions controls the aggressiveness of an emergency stop.
+//
+// The metaphor (per epic #30): Frostbite the kraken stirring from his
+// sleep beneath the ice. CloseShorts is "wake quietly and recall the
+// expedition"; LiquidateSpot is "full Whiteout — leave nothing on the
+// field."
 type KillSwitchOptions struct {
 	// CloseShorts: send reduce-only market orders to flatten any open
 	// perp positions. Always recommended.
 	CloseShorts bool
-	// LiquidateSpot: in addition to closing perps, liquidate spot legs
-	// back to USDC via SwapVenue. Requires that we know the spot mints.
+	// LiquidateSpot: in addition to closing perps, swap every open
+	// spot leg back to USDC via the configured SwapVenue for that
+	// chain. Requires SwapVenues to be wired into Deps; if a chain
+	// has no SwapVenue, the corresponding leg logs a warning and is
+	// left in place (operator decides whether to liquidate manually).
 	LiquidateSpot bool
+	// SpotSlippageBps caps the slippage tolerance on liquidation
+	// swaps. Zero means "use the agent's max_spot_slippage_bps risk
+	// limit". A killswitch is by definition urgent — slippage budgets
+	// here are typically wider than the strategy's normal entry/exit.
+	SpotSlippageBps int
 	// Reason is recorded on the agent run.
 	Reason string
 }
 
 // DefaultKillSwitchOptions returns a safe default: stop the loop, cancel
-// open orders, and flatten short positions. Spot is left in place because
-// liquidating it requires the asset registry; operators can opt in via
-// LiquidateSpot when they wire a registry to the supervisor.
+// open orders, and flatten short positions. Spot is left in place by
+// default — operators flip LiquidateSpot true once they've configured a
+// SwapVenue for every chain they hold spot on.
 func DefaultKillSwitchOptions(reason string) KillSwitchOptions {
 	return KillSwitchOptions{
 		CloseShorts: true,
@@ -33,8 +48,13 @@ func DefaultKillSwitchOptions(reason string) KillSwitchOptions {
 	}
 }
 
-// Trip executes the kill switch on a Runtime: stops the loop, cancels open
-// orders on the perp venue, and (if configured) flattens positions.
+// Trip executes the kill switch on a Runtime: stops the loop, cancels
+// open orders on the perp venue, and (per opts) flattens positions
+// and liquidates spot.
+//
+// Best-effort: failures in any step are logged but do not abort the
+// remaining steps. The first error encountered is returned so the
+// caller knows something went wrong; the rest is in the log.
 func (r *Runtime) Trip(ctx context.Context, opts KillSwitchOptions) error {
 	if err := r.Stop(ctx, "kill_switch:"+opts.Reason); err != nil {
 		r.deps.Logger.Error("kill_switch: stop failed", "err", err)
@@ -43,59 +63,78 @@ func (r *Runtime) Trip(ctx context.Context, opts KillSwitchOptions) error {
 		_ = r.deps.Store.SetStatus(ctx, r.agent.ID, StatusHalted)
 	}
 	var firstErr error
+	record := func(err error) {
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
 
 	if r.deps.Perp != nil {
 		if err := cancelOpenOrders(ctx, r.deps.Perp, r.deps.Logger); err != nil {
 			r.deps.Logger.Error("kill_switch: cancel orders failed", "err", err)
-			if firstErr == nil {
-				firstErr = err
-			}
+			record(err)
 		}
 		if opts.CloseShorts {
 			if err := flattenPositions(ctx, r.agent.ID, r.deps.Perp, r.deps.Logger); err != nil {
 				r.deps.Logger.Error("kill_switch: flatten failed", "err", err)
-				if firstErr == nil {
-					firstErr = err
-				}
+				record(err)
 			}
 		}
 	}
+
 	if opts.LiquidateSpot {
-		// Spot liquidation is intentionally not auto-executed without an
-		// asset-registry-aware caller; agents that hold spot should
-		// surface a registry to the supervisor before enabling this.
-		r.deps.Logger.Warn("kill_switch: spot liquidation requested but not implemented in this PR",
-			"agent_id", r.agent.ID)
+		if err := r.liquidateSpot(ctx, opts); err != nil {
+			r.deps.Logger.Error("kill_switch: spot liquidation failed", "err", err)
+			record(err)
+		}
+	}
+
+	return firstErr
+}
+
+// cancelOpenOrders enumerates every open order on the venue and cancels
+// each one. Errors per-order are logged and the loop continues; the
+// first error is returned so the caller knows something failed.
+//
+// Venues that haven't yet implemented OpenOrders return an empty slice;
+// in that case this is a no-op, which is the right answer (we'd rather
+// silently no-op than abort the rest of the killswitch sequence).
+func cancelOpenOrders(ctx context.Context, v exchange.Venue, log *slog.Logger) error {
+	orders, err := v.OpenOrders(ctx)
+	if err != nil {
+		return fmt.Errorf("open_orders: %w", err)
+	}
+	if len(orders) == 0 {
+		log.Info("kill_switch: no open orders to cancel")
+		return nil
+	}
+	var firstErr error
+	for _, o := range orders {
+		// Some venues (Hyperliquid) need (oid, symbol) for cancel. The
+		// venue's session-memory rememberOrder hook (populated by
+		// OpenOrders or Place) covers the common case; v.Cancel handles
+		// any additional plumbing internally.
+		if err := v.Cancel(ctx, o.ID); err != nil {
+			log.Error("kill_switch: cancel failed", "order_id", o.ID, "symbol", o.Symbol, "err", err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		log.Info("kill_switch: cancelled", "order_id", o.ID, "symbol", o.Symbol, "side", o.Side)
 	}
 	return firstErr
 }
 
-// cancelOpenOrders best-effort cancels every open order on the venue. We
-// fetch positions and rely on the venue's own open-orders semantics by
-// asking the venue to cancel known order IDs from positions where possible.
-//
-// Real Hyperliquid would expose openOrders; for the v1 framework we use
-// the exchange.Venue interface as-is and document the limitation.
-func cancelOpenOrders(ctx context.Context, v exchange.Venue, log *slog.Logger) error {
-	// The Venue interface does not yet expose an OpenOrders method; the
-	// kill-switch design intentionally lives on Runtime so the supervisor
-	// can pass the same Venue. When OpenOrders lands as a small follow-up,
-	// this becomes a loop over `v.OpenOrders(); v.Cancel(id)`. For now we
-	// log a warning so the operator knows the cancel step is a no-op
-	// against the current Venue surface.
-	_ = ctx
-	_ = v
-	log.Warn("kill_switch: Venue.OpenOrders not yet on the interface; orders left in place. Cancel manually via the exchange UI if needed.")
-	return nil
-}
-
-// flattenPositions sends reduce-only market orders to close every open perp
-// position.
+// flattenPositions sends reduce-only market orders to close every open
+// perp position. Best-effort: a failure on one symbol does not stop the
+// rest.
 func flattenPositions(ctx context.Context, agentID string, v exchange.Venue, log *slog.Logger) error {
 	positions, err := v.Positions(ctx)
 	if err != nil {
 		return fmt.Errorf("positions: %w", err)
 	}
+	var firstErr error
 	for _, p := range positions {
 		if p.IsFlat() {
 			continue
@@ -117,12 +156,109 @@ func flattenPositions(ctx context.Context, agentID string, v exchange.Venue, log
 		}
 		if _, err := v.Place(ctx, intent); err != nil {
 			log.Error("kill_switch: flatten place failed", "symbol", p.Symbol, "err", err)
-			return err
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
 		}
 		log.Info("kill_switch: flatten submitted", "symbol", p.Symbol, "side", side, "size", size)
 	}
-	return nil
+	return firstErr
 }
+
+// liquidateSpot swaps every open spot leg back to USDC via the
+// configured SwapVenue for that chain. Best-effort per-leg.
+//
+// Each leg becomes a SwapIntent with:
+//   - InToken  = the spot asset
+//   - OutToken = USDC on the same chain (resolved via assets.USDCMintFor)
+//   - InAmount = the leg's quantity
+//   - SlippageBps = max(opts.SpotSlippageBps, agent's MaxSpotSlippageBps)
+//   - Tag      = "kill_switch:liquidate"
+//
+// If a chain has no SwapVenue configured (paper-spot fallback or just
+// not wired), the leg logs a warning and is left in place — the operator
+// can liquidate manually. If no USDC mapping exists for a chain, same.
+func (r *Runtime) liquidateSpot(ctx context.Context, opts KillSwitchOptions) error {
+	if r.deps.Store == nil {
+		return errors.New("liquidate_spot: store not configured (no open basis to enumerate)")
+	}
+	open, err := r.deps.Store.LoadOpenBasis(ctx, r.agent.ID)
+	if err != nil {
+		return fmt.Errorf("load open basis: %w", err)
+	}
+	if len(open) == 0 {
+		r.deps.Logger.Info("kill_switch: no open spot legs to liquidate")
+		return nil
+	}
+
+	// Slippage: explicit opts wins; else fall back to the agent's
+	// MaxSpotSlippageBps risk limit; else 100bps as a safety ceiling.
+	slip := opts.SpotSlippageBps
+	if slip == 0 && r.deps.Risk != nil {
+		if l := r.deps.Risk.Limits().MaxSpotSlippageBps; l > 0 {
+			slip = l
+		}
+	}
+	if slip == 0 {
+		slip = 100
+	}
+
+	var firstErr error
+	for _, bp := range open {
+		for _, leg := range bp.Legs {
+			if leg.Kind != types.BasisLegSpot || leg.Qty.IsZero() {
+				continue
+			}
+			venue := r.deps.SwapVenueForChain(leg.Asset.Chain)
+			if venue == nil {
+				r.deps.Logger.Warn("kill_switch: no SwapVenue for chain; spot leg left in place",
+					"chain", leg.Asset.Chain, "basis_key", bp.Underlying, "qty", leg.Qty)
+				continue
+			}
+			usdc, ok := assets.USDCAsset(leg.Asset.Chain)
+			if !ok {
+				r.deps.Logger.Warn("kill_switch: no USDC mapping for chain; spot leg left in place",
+					"chain", leg.Asset.Chain, "basis_key", bp.Underlying)
+				continue
+			}
+			// Quote → Swap (we don't WaitConfirm here; killswitch is
+			// fire-and-forget by design — operator can inspect tx
+			// hashes from the decision log if they care to follow up).
+			quote, err := venue.Quote(ctx, types.QuoteRequest{
+				InToken:  leg.Asset,
+				OutToken: usdc,
+				Amount:   leg.Qty,
+				Mode:     types.QuoteExactIn,
+			})
+			if err != nil {
+				r.deps.Logger.Error("kill_switch: liquidate quote failed",
+					"basis_key", bp.Underlying, "chain", leg.Asset.Chain, "err", err)
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+			tx, err := venue.Swap(ctx, quote, slip)
+			if err != nil {
+				r.deps.Logger.Error("kill_switch: liquidate swap failed",
+					"basis_key", bp.Underlying, "chain", leg.Asset.Chain, "err", err)
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+			r.deps.Logger.Info("kill_switch: liquidate submitted",
+				"basis_key", bp.Underlying, "chain", leg.Asset.Chain,
+				"in_amount", leg.Qty, "slippage_bps", slip, "tx", tx)
+		}
+	}
+	return firstErr
+}
+
+// _ keeps the swap import live even if liquidateSpot's closure compiles
+// to a path that doesn't reference swap.SwapVenue directly.
+var _ swap.SwapVenue = nil
 
 // ErrAgentNotRunning is returned when a kill-switch operation expects a
 // running agent.

--- a/internal/agent/killswitch_test.go
+++ b/internal/agent/killswitch_test.go
@@ -1,0 +1,207 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/exchange"
+	exchangenoop "github.com/teslashibe/permafrost/internal/exchange/noop"
+	"github.com/teslashibe/permafrost/pkg/strategy"
+	"github.com/teslashibe/permafrost/pkg/types"
+)
+
+// silentLogger discards all logger output during tests.
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestCancelOpenOrders_HappyPath: venue exposes 3 open orders; killswitch
+// cancels each one and Cancellations() reflects all 3 ids.
+func TestCancelOpenOrders_HappyPath(t *testing.T) {
+	venue := exchangenoop.New()
+	venue.SetOpenOrders([]exchange.OpenOrder{
+		{ID: "o1", Symbol: "WIF", Side: types.SideSell},
+		{ID: "o2", Symbol: "BONK", Side: types.SideSell},
+		{ID: "o3", Symbol: "POPCAT", Side: types.SideBuy},
+	})
+
+	if err := cancelOpenOrders(context.Background(), venue, silentLogger()); err != nil {
+		t.Fatalf("cancelOpenOrders: %v", err)
+	}
+	got := venue.Cancellations()
+	if len(got) != 3 {
+		t.Fatalf("expected 3 cancels, got %d (%v)", len(got), got)
+	}
+	want := map[types.OrderID]bool{"o1": true, "o2": true, "o3": true}
+	for _, id := range got {
+		if !want[id] {
+			t.Errorf("unexpected cancel %q", id)
+		}
+	}
+}
+
+// TestCancelOpenOrders_NoOpenOrders: empty list returns nil cleanly,
+// no cancels issued, no error.
+func TestCancelOpenOrders_NoOpenOrders(t *testing.T) {
+	venue := exchangenoop.New()
+	if err := cancelOpenOrders(context.Background(), venue, silentLogger()); err != nil {
+		t.Fatalf("expected nil err with no open orders; got %v", err)
+	}
+	if got := len(venue.Cancellations()); got != 0 {
+		t.Errorf("expected 0 cancels; got %d", got)
+	}
+}
+
+// failingCancelVenue wraps the noop venue and returns an error on Cancel
+// for one specific id, to test that one failure doesn't abort the rest.
+type failingCancelVenue struct {
+	*exchangenoop.Venue
+	failID types.OrderID
+}
+
+func (f *failingCancelVenue) Cancel(ctx context.Context, id types.OrderID) error {
+	if id == f.failID {
+		return errors.New("simulated venue failure")
+	}
+	return f.Venue.Cancel(ctx, id)
+}
+
+// TestCancelOpenOrders_OneFailureContinues: a single cancel failure
+// surfaces an error from cancelOpenOrders but doesn't prevent the
+// other cancels from issuing.
+func TestCancelOpenOrders_OneFailureContinues(t *testing.T) {
+	inner := exchangenoop.New()
+	inner.SetOpenOrders([]exchange.OpenOrder{
+		{ID: "o1", Symbol: "WIF"},
+		{ID: "o2", Symbol: "BONK"}, // this one fails
+		{ID: "o3", Symbol: "POPCAT"},
+	})
+	venue := &failingCancelVenue{Venue: inner, failID: "o2"}
+
+	err := cancelOpenOrders(context.Background(), venue, silentLogger())
+	if err == nil {
+		t.Fatal("expected error to surface from one failed cancel")
+	}
+	got := inner.Cancellations()
+	if len(got) != 2 {
+		t.Errorf("expected 2 successful cancels (o1, o3); got %d (%v)", len(got), got)
+	}
+}
+
+// stubPositionVenue returns scripted positions, lets us assert what
+// flatten places without simulating a real venue.
+type stubPositionVenue struct {
+	*exchangenoop.Venue
+	positions []types.Position
+}
+
+func (s *stubPositionVenue) Positions(_ context.Context) ([]types.Position, error) {
+	return s.positions, nil
+}
+
+// TestFlattenPositions_ShortAndLong: a short-position triggers a
+// reduce-only buy; a long-position triggers a reduce-only sell. Flat
+// positions are skipped.
+func TestFlattenPositions_ShortAndLong(t *testing.T) {
+	inner := exchangenoop.New()
+	venue := &stubPositionVenue{Venue: inner, positions: []types.Position{
+		{Venue: "noop", Symbol: "WIF", Qty: decimal.NewFromInt(-100)},  // short
+		{Venue: "noop", Symbol: "BONK", Qty: decimal.NewFromInt(50)},   // long
+		{Venue: "noop", Symbol: "POPCAT", Qty: decimal.NewFromInt(0)},  // flat
+	}}
+
+	if err := flattenPositions(context.Background(), "ag-test", venue, silentLogger()); err != nil {
+		t.Fatalf("flattenPositions: %v", err)
+	}
+	placed := inner.Placed()
+	if len(placed) != 2 {
+		t.Fatalf("expected 2 places (skip flat), got %d (%+v)", len(placed), placed)
+	}
+	for _, p := range placed {
+		if !p.ReduceOnly {
+			t.Errorf("flatten orders must be reduce-only; got %+v", p)
+		}
+		if p.Type != types.OrderTypeMarket {
+			t.Errorf("flatten orders must be market; got %+v", p)
+		}
+	}
+
+	// WIF is a short → buy back (qty becomes positive 100)
+	// BONK is a long → sell (qty 50)
+	bySymbol := map[string]types.OrderIntent{}
+	for _, p := range placed {
+		bySymbol[p.Symbol] = p
+	}
+	if got := bySymbol["WIF"]; got.Side != types.SideBuy || !got.Size.Equal(decimal.NewFromInt(100)) {
+		t.Errorf("WIF short → expected buy size=100, got %+v", got)
+	}
+	if got := bySymbol["BONK"]; got.Side != types.SideSell || !got.Size.Equal(decimal.NewFromInt(50)) {
+		t.Errorf("BONK long → expected sell size=50, got %+v", got)
+	}
+}
+
+// TestKillSwitchOptions_DefaultIsConservative: DefaultKillSwitchOptions
+// closes shorts but does not auto-liquidate spot. Documented behaviour;
+// regression-guard against a future change that flips this default.
+func TestKillSwitchOptions_DefaultIsConservative(t *testing.T) {
+	opts := DefaultKillSwitchOptions("test")
+	if !opts.CloseShorts {
+		t.Errorf("default should CloseShorts; got %+v", opts)
+	}
+	if opts.LiquidateSpot {
+		t.Errorf("default must NOT auto-LiquidateSpot; got %+v", opts)
+	}
+	if opts.Reason != "test" {
+		t.Errorf("Reason: got %q want test", opts.Reason)
+	}
+}
+
+// TestRuntime_Trip_StopsAndHalts: invoking Trip on a running runtime
+// stops the loop and (when a Store is wired) sets persistent status to
+// halted. Regression guard for the operator-visible behaviour.
+func TestRuntime_Trip_StopsAndHalts(t *testing.T) {
+	venue := exchangenoop.New()
+	a := Agent{ID: "ag-test", Strategy: "noop", Mode: ModePaper, TickSecs: 1}
+	r := NewRuntime(a, Deps{
+		Strategy: stubStrategyForKill{},
+		Perp:     venue,
+		Logger:   silentLogger(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := r.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if !r.IsRunning() {
+		t.Fatal("expected running")
+	}
+
+	tripCtx, tripCancel := context.WithTimeout(context.Background(), time.Second)
+	defer tripCancel()
+	if err := r.Trip(tripCtx, DefaultKillSwitchOptions("test")); err != nil {
+		t.Errorf("Trip returned err: %v", err)
+	}
+	if r.IsRunning() {
+		t.Error("expected stopped after Trip")
+	}
+}
+
+// stubStrategyForKill is a minimal Strategy used only by
+// TestRuntime_Trip_StopsAndHalts. (Avoids an import-cycle with the
+// noop strategy package.)
+type stubStrategyForKill struct{}
+
+func (stubStrategyForKill) Name() string { return "noop" }
+func (stubStrategyForKill) Warmup(context.Context, strategy.WarmupInput) error {
+	return nil
+}
+func (stubStrategyForKill) Decide(context.Context, strategy.DecisionInput) (strategy.Decision, error) {
+	return strategy.Decision{}, nil
+}

--- a/internal/assets/usdc.go
+++ b/internal/assets/usdc.go
@@ -1,0 +1,47 @@
+package assets
+
+import "github.com/teslashibe/permafrost/pkg/types"
+
+// USDCMintFor returns the canonical USDC mint / contract address for a
+// supported chain, plus the canonical decimals (6 on every supported
+// chain today). Returns (address, decimals=6, true) when the chain is
+// known; ("", 0, false) otherwise.
+//
+// Hard-coded sources (verified at the time of writing):
+//   - Solana   — Circle's native USDC mint
+//   - Ethereum — https://www.circle.com/usdc-multichain/ethereum
+//   - Base     — Circle's native USDC on Base (NOT USDbC, which is bridged)
+//   - Avalanche — Circle's native USDC on Avalanche C-Chain
+//   - BSC      — Binance-Peg USDC (BSC has no native USDC; pegged is the
+//               de-facto liquid one)
+//
+// Lives in internal/assets so framework code (the killswitch's
+// LiquidateSpot path) can use it without importing a strategy.
+// Strategies that need the same mapping should call USDCMintFor too
+// rather than maintaining their own copy.
+func USDCMintFor(chain types.ChainID) (mint string, decimals int32, ok bool) {
+	switch chain {
+	case types.ChainSolana:
+		return "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", 6, true
+	case types.ChainEthereum:
+		return "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", 6, true
+	case types.ChainBase:
+		return "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", 6, true
+	case types.ChainAvalanche:
+		return "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E", 6, true
+	case types.ChainBSC:
+		return "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d", 6, true
+	}
+	return "", 0, false
+}
+
+// USDCAsset returns a populated types.Asset for USDC on the given chain.
+// Caller-friendly wrapper around USDCMintFor; returns false when the
+// chain isn't supported.
+func USDCAsset(chain types.ChainID) (types.Asset, bool) {
+	mint, dec, ok := USDCMintFor(chain)
+	if !ok {
+		return types.Asset{}, false
+	}
+	return types.Asset{Symbol: "USDC", Chain: chain, Mint: mint, Decimals: dec}, true
+}

--- a/internal/assets/usdc_test.go
+++ b/internal/assets/usdc_test.go
@@ -1,0 +1,69 @@
+package assets
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/teslashibe/permafrost/pkg/types"
+)
+
+// TestUSDCMintFor_KnownChains: every chain we currently claim USDC support
+// for returns a populated mint and decimals=6. Regression guard against a
+// future entry being added with the wrong decimals or address format.
+func TestUSDCMintFor_KnownChains(t *testing.T) {
+	cases := []struct {
+		chain     types.ChainID
+		hasPrefix string // "0x" for EVM; "" for Solana base58
+	}{
+		{types.ChainSolana, ""},
+		{types.ChainEthereum, "0x"},
+		{types.ChainBase, "0x"},
+		{types.ChainAvalanche, "0x"},
+		{types.ChainBSC, "0x"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.chain), func(t *testing.T) {
+			mint, dec, ok := USDCMintFor(tc.chain)
+			if !ok {
+				t.Fatalf("expected ok for %s", tc.chain)
+			}
+			if mint == "" {
+				t.Errorf("empty mint for %s", tc.chain)
+			}
+			if tc.hasPrefix != "" && !strings.HasPrefix(mint, tc.hasPrefix) {
+				t.Errorf("%s mint should start with %q; got %q", tc.chain, tc.hasPrefix, mint)
+			}
+			if dec != 6 {
+				t.Errorf("%s decimals: got %d want 6", tc.chain, dec)
+			}
+		})
+	}
+}
+
+// TestUSDCMintFor_UnknownChain: an unknown chain returns ok=false and
+// callers should treat the leg as un-liquidatable.
+func TestUSDCMintFor_UnknownChain(t *testing.T) {
+	if _, _, ok := USDCMintFor(types.ChainID("imaginary-chain")); ok {
+		t.Error("expected ok=false for unknown chain")
+	}
+}
+
+// TestUSDCAsset_RoundTrip: USDCAsset returns a populated Asset for
+// supported chains, with the right symbol + decimals.
+func TestUSDCAsset_RoundTrip(t *testing.T) {
+	for _, chain := range []types.ChainID{types.ChainSolana, types.ChainBase} {
+		a, ok := USDCAsset(chain)
+		if !ok {
+			t.Fatalf("USDCAsset(%s): expected ok=true", chain)
+		}
+		if a.Symbol != "USDC" {
+			t.Errorf("symbol: got %q want USDC", a.Symbol)
+		}
+		if a.Chain != chain {
+			t.Errorf("chain: got %q want %q", a.Chain, chain)
+		}
+		if a.Decimals != 6 {
+			t.Errorf("decimals: got %d want 6", a.Decimals)
+		}
+	}
+}

--- a/internal/exchange/exchange.go
+++ b/internal/exchange/exchange.go
@@ -32,6 +32,15 @@ type Venue interface {
 	// order MUST NOT return an error.
 	Cancel(ctx context.Context, id types.OrderID) error
 
+	// OpenOrders returns every order currently open for the configured
+	// account. Used by the kill switch to enumerate-and-cancel without
+	// the framework having to track every order id it ever placed.
+	// Implementations that do not yet expose the venue's open-orders
+	// endpoint MAY return an empty slice — callers must tolerate that
+	// (the kill switch will still attempt cancels for orders it knows
+	// about via its own session memory).
+	OpenOrders(ctx context.Context) ([]OpenOrder, error)
+
 	// Positions returns currently-open positions across all symbols.
 	Positions(ctx context.Context) ([]types.Position, error)
 
@@ -41,4 +50,15 @@ type Venue interface {
 	// FundingRates returns the latest funding observation per symbol. If
 	// symbols is empty, all subscribed symbols are returned.
 	FundingRates(ctx context.Context, symbols []string) ([]types.FundingRate, error)
+}
+
+// OpenOrder is the projection of a venue-side resting order returned by
+// OpenOrders. Deliberately small — just what the kill switch needs to
+// issue a cancel. Callers that want richer data (post-time, partial
+// fill state, …) can extend this struct as needs surface; current code
+// only reads ID + Symbol.
+type OpenOrder struct {
+	ID     types.OrderID
+	Symbol string
+	Side   types.Side
 }

--- a/internal/exchange/hyperliquid/api.go
+++ b/internal/exchange/hyperliquid/api.go
@@ -110,3 +110,15 @@ type bookLevel struct {
 	Sz string `json:"sz"`
 	N  int    `json:"n"` // number of orders at this level
 }
+
+// ─── openOrders response ────────────────────────────────────────────────────
+
+// openOrderResp mirrors one entry in the JSON array returned by
+// /info?type=openOrders. The HL response is keyed `coin`/`oid`/`side`
+// (B = buy, A = ask/sell). Fields not used by the kill switch (origSz,
+// limitPx, timestamp, …) are omitted.
+type openOrderResp struct {
+	Coin string `json:"coin"`
+	Oid  int64  `json:"oid"`
+	Side string `json:"side"` // "B" (buy) | "A" (sell)
+}

--- a/internal/exchange/hyperliquid/venue.go
+++ b/internal/exchange/hyperliquid/venue.go
@@ -228,6 +228,41 @@ func (v *Venue) Cancel(ctx context.Context, id types.OrderID) error {
 	return nil
 }
 
+// OpenOrders returns every order currently open on the configured user's
+// account. Reads are unauthenticated — only Address is required, no
+// signer. Used by the kill switch to enumerate-and-cancel without
+// relying on session memory of previously-placed orders.
+//
+// Hyperliquid's /info?type=openOrders returns a flat array; we project
+// each entry to exchange.OpenOrder. Each cancel still needs (oid, coin)
+// which is exactly what this returns.
+func (v *Venue) OpenOrders(ctx context.Context) ([]exchange.OpenOrder, error) {
+	if v.cfg.Address == "" {
+		return nil, ErrAddressRequired
+	}
+	var out []openOrderResp
+	if err := v.client.info(ctx, infoRequest{Type: "openOrders", User: v.cfg.Address}, &out); err != nil {
+		return nil, fmt.Errorf("hyperliquid: openOrders: %w", err)
+	}
+	orders := make([]exchange.OpenOrder, 0, len(out))
+	for _, r := range out {
+		side := types.SideBuy
+		if r.Side == "A" {
+			side = types.SideSell
+		}
+		id := types.OrderID(fmt.Sprintf("%d", r.Oid))
+		orders = append(orders, exchange.OpenOrder{
+			ID:     id,
+			Symbol: r.Coin,
+			Side:   side,
+		})
+		// Refresh our session map so a subsequent Cancel(id) works
+		// even for orders placed by a previous process.
+		v.rememberOrder(id, r.Coin)
+	}
+	return orders, nil
+}
+
 // CancelWithSymbol cancels an order placed by another process / restart
 // where this Venue doesn't know the symbol mapping.
 func (v *Venue) CancelWithSymbol(ctx context.Context, id types.OrderID, symbol string) error {

--- a/internal/exchange/noop/noop.go
+++ b/internal/exchange/noop/noop.go
@@ -20,6 +20,7 @@ type Venue struct {
 	mu       sync.Mutex
 	placed   []types.OrderIntent
 	cancels  []types.OrderID
+	openOrds []exchange.OpenOrder // tests can pre-seed via SetOpenOrders
 }
 
 // New constructs a fresh no-op venue.
@@ -63,6 +64,24 @@ func (v *Venue) Positions(_ context.Context) ([]types.Position, error)         {
 func (v *Venue) Balances(_ context.Context) ([]types.Balance, error)           { return nil, nil }
 func (v *Venue) FundingRates(_ context.Context, _ []string) ([]types.FundingRate, error) {
 	return nil, nil
+}
+
+// OpenOrders returns whatever the test seeded via SetOpenOrders.
+// Empty by default, which is the right answer for a noop venue.
+func (v *Venue) OpenOrders(_ context.Context) ([]exchange.OpenOrder, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	out := make([]exchange.OpenOrder, len(v.openOrds))
+	copy(out, v.openOrds)
+	return out, nil
+}
+
+// SetOpenOrders pre-seeds the venue with open orders, for tests of the
+// kill-switch cancel path.
+func (v *Venue) SetOpenOrders(orders []exchange.OpenOrder) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.openOrds = append(v.openOrds[:0], orders...)
 }
 
 // Placed returns the intents recorded by Place, in submission order.

--- a/internal/pnl/pnl_test.go
+++ b/internal/pnl/pnl_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/shopspring/decimal"
 
+	"github.com/teslashibe/permafrost/internal/exchange"
 	"github.com/teslashibe/permafrost/internal/swap"
 	"github.com/teslashibe/permafrost/pkg/types"
 )
@@ -42,6 +43,9 @@ func (s *stubPerp) Place(_ context.Context, _ types.OrderIntent) (types.OrderAck
 	return types.OrderAck{}, nil
 }
 func (s *stubPerp) Cancel(_ context.Context, _ types.OrderID) error { return nil }
+func (s *stubPerp) OpenOrders(_ context.Context) ([]exchange.OpenOrder, error) {
+	return nil, nil
+}
 
 // stubSwap implements just enough of swap.SwapVenue for the spot leg
 // quote in valueOne. quote is the OUT amount returned for any input.

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/shopspring/decimal"
 
+	"github.com/teslashibe/permafrost/internal/exchange"
 	"github.com/teslashibe/permafrost/internal/swap"
 	"github.com/teslashibe/permafrost/pkg/types"
 )
@@ -42,6 +43,9 @@ func (s *stubPerp) Place(_ context.Context, _ types.OrderIntent) (types.OrderAck
 	return types.OrderAck{}, nil
 }
 func (s *stubPerp) Cancel(_ context.Context, _ types.OrderID) error { return nil }
+func (s *stubPerp) OpenOrders(_ context.Context) ([]exchange.OpenOrder, error) {
+	return nil, nil
+}
 
 type stubSwap struct {
 	chain   types.ChainID

--- a/internal/risk/noop/noop.go
+++ b/internal/risk/noop/noop.go
@@ -25,3 +25,8 @@ func (Engine) PreTrade(_ context.Context, _ string, _ any, _ types.PortfolioSnap
 func (Engine) Portfolio(_ context.Context, _ types.PortfolioSnapshot) types.Verdict {
 	return types.Verdict{Kind: types.VerdictAllow}
 }
+
+// Limits returns the zero RiskLimits — i.e. no limits enforced.
+// Killswitch callers asking the noop engine for its slippage cap will
+// fall back to whatever default they hold (100bps in the killswitch).
+func (Engine) Limits() types.RiskLimits { return types.RiskLimits{} }

--- a/internal/risk/policy.go
+++ b/internal/risk/policy.go
@@ -29,6 +29,10 @@ func (p *Policy) WithBreaker(b CircuitBreaker) *Policy {
 	return p
 }
 
+// Limits returns the hard limits this Policy enforces. Returns by value
+// so callers cannot mutate the Policy's internal copy.
+func (p *Policy) Limits() types.RiskLimits { return p.limits }
+
 // Compile-time check.
 var _ Engine = (*Policy)(nil)
 

--- a/internal/risk/risk.go
+++ b/internal/risk/risk.go
@@ -21,4 +21,10 @@ import (
 type Engine interface {
 	PreTrade(ctx context.Context, agentID string, intent any, snap types.PortfolioSnapshot) types.Verdict
 	Portfolio(ctx context.Context, snap types.PortfolioSnapshot) types.Verdict
+	// Limits returns the hard limits this engine enforces. Used by
+	// non-trade callers (e.g. the kill switch) that need to consult
+	// the agent's risk envelope without going through PreTrade —
+	// for example, to size a liquidation swap inside the agent's
+	// max_spot_slippage_bps tolerance.
+	Limits() types.RiskLimits
 }


### PR DESCRIPTION
PR 6 of ~10 in the Trading Desk epic chain (#30, Phase 3). Closes #38.

**This PR closes the single biggest credibility gap in the project.** The README's safety claims now match what the code actually does.

## Before this PR

- `cancelOpenOrders` was a logged no-op: \"Venue.OpenOrders not yet on the interface; orders left in place. Cancel manually via the exchange UI if needed.\"
- `LiquidateSpot` logged \"not implemented in this PR\" and bailed.

The README's Safety section claimed both worked. They didn't.

## After this PR

| Path | Was | Is |
|---|---|---|
| Cancel open orders on Trip | logged no-op | enumerates `v.OpenOrders()`, cancels each |
| Liquidate spot on Trip | logged no-op | quotes + swaps each open spot leg → USDC via the configured SwapVenue |
| `exchange.Venue` interface | no enumerate-orders method | `OpenOrders(ctx) ([]OpenOrder, error)` |
| Hyperliquid implementation | no openOrders call | hits `/info?type=openOrders`, refreshes session-memory map |
| `risk.Engine` | no read-side accessor | adds `Limits()` so non-trade callers (the kill switch) can consult the agent's risk envelope |
| USDC mint mapping | hard-coded inside fab | promoted to `internal/assets.USDCMintFor` so framework code can use it without depending on a private strategy |

## Implementation details

**`exchange.Venue.OpenOrders`.** Returns `[]OpenOrder{ID, Symbol, Side}` — just enough for the kill switch to issue cancels. Hyperliquid implementation uses the existing `/info` POST envelope; refreshes the venue's `(oid → coin)` session map so a subsequent `Cancel(id)` works for orders placed by a previous process.

**`killswitch.cancelOpenOrders`.** Best-effort: per-order failure is logged and the loop continues; the first error is returned so the caller knows something failed without losing visibility on what worked.

**`killswitch.liquidateSpot`.** Iterates every open `BasisPosition`'s spot legs, builds Quote → Swap pairs against the configured `SwapVenue` for that chain. Slippage cap precedence: explicit `opts.SpotSlippageBps` → agent's `MaxSpotSlippageBps` risk limit → 100bps ceiling. Legs on chains without a SwapVenue or USDC mapping get a warning and are left in place (operator decides).

**`KillSwitchOptions.SpotSlippageBps` (new field).** Per-trip override. Killswitch is by definition urgent — typical slippage budgets here are wider than normal entry/exit.

## Tests (10 new)

| Test | What it asserts |
|---|---|
| `TestCancelOpenOrders_HappyPath` | 3 open orders → 3 cancels |
| `TestCancelOpenOrders_NoOpenOrders` | empty list is a clean no-op (not an error) |
| `TestCancelOpenOrders_OneFailureContinues` | per-order failure surfaces but doesn't abort the rest |
| `TestFlattenPositions_ShortAndLong` | short → buy, long → sell, flat skipped, all reduce-only market |
| `TestKillSwitchOptions_DefaultIsConservative` | regression guard: defaults close shorts but never auto-liquidate |
| `TestRuntime_Trip_StopsAndHalts` | the operator-visible behaviour (loop stops, status flips) |
| `TestUSDCMintFor_KnownChains` | every supported chain has correct mint + 6 decimals |
| `TestUSDCMintFor_UnknownChain` | unknown returns `ok=false` |
| `TestUSDCAsset_RoundTrip` | populated Asset for known chains |

Plus interface-conformance updates to stub venues / engines in `internal/pnl`, `internal/reconcile`, `internal/risk/noop`. No behavioural changes there — just the new method signatures.

## Audit (per .cursor/rules/issue-audit-user-stories.mdc)

### Findings

**No high-severity findings.** Best-effort error handling means a single venue / chain failure is contained.

**Medium:**

- M1: `liquidateSpot` does **not** call `WaitConfirm` on the swap. Killswitch is fire-and-forget by design — the operator can inspect tx hashes from the decision log if they care to follow up. Documented inline.
- M2: HL `OpenOrders` returns at most what the venue exposes via the `openOrders` info endpoint; if the operator placed orders via a different process under the same wallet, those still appear (good). If the wallet has 1000 open orders, the response array is large but bounded — no pagination concern at the v1 trading scale.

**Low:**

- L1: `OpenOrder` only carries `ID`, `Symbol`, `Side` — not size, price, or post-time. Sufficient for the kill switch's needs; richer projection can be added when a real consumer needs it.
- L2: `liquidateSpot` calls `Quote` then `Swap` sequentially per leg. A future optimisation could parallelise across chains. Not done for v1 — sequential is debuggable, and the killswitch is rare.

### Acceptance criteria coverage (from #38)

- [x] `exchange.Venue` has `OpenOrders` and Hyperliquid implements it
- [x] `Trip` with `CloseShorts: true` cancels every open order before flattening
- [x] `Trip` with `LiquidateSpot: true` swaps every open spot leg to USDC via the configured SwapVenue, with the agent's risk-configured slippage
- [x] Errors are best-effort: one failure logs + continues, doesn't abort the kill switch
- [x] At least 4 unit tests cover the cancel / liquidate paths and error handling (6 added; 10 if you count the USDC helper)
- [ ] README + docs no longer disclaim that these paths are unimplemented — **deferred to a follow-up PR after PR #44 lands** to avoid a merge conflict. The disclaimer in README is now stale (linking to this PR for the fix); will be removed in a small docs-only PR.

### Risks

- **The HL `openOrders` endpoint may rate-limit.** Killswitch is invoked rarely; not a concern in practice. If it ever bites, add a backoff loop.
- **Liquidation slippage can be substantial in a panic.** Operators tuning the killswitch should set `SpotSlippageBps` deliberately (default 100bps is generous to ensure execution, not optimal).

## Test plan

- [x] `go build ./...` green
- [x] `go test ./...` green
- [x] `go vet ./...` clean
- [x] 10 new unit tests
- [ ] End-to-end on the integration branch with a paper agent and seeded openOrders (covered by the integration test branch)

## Stack position

PR 6 of ~10. Targets `main` directly. README's killswitch disclaimer becomes stale once this lands; small follow-up PR will tighten it after PR #44 has landed.