### PR TITLE
Add reference strategies: dca_buy + market_maker_basic (closes #39)

### DIFF
--- a/cmd/permafrost/strategies.go
+++ b/cmd/permafrost/strategies.go
@@ -15,5 +15,7 @@ package main
 // full extension flow.
 
 import (
+	_ "github.com/teslashibe/permafrost/strategies/dca_buy"
+	_ "github.com/teslashibe/permafrost/strategies/market_maker_basic"
 	_ "github.com/teslashibe/permafrost/strategies/noop"
 )

--- a/cmd/permafrostd/strategies.go
+++ b/cmd/permafrostd/strategies.go
@@ -12,5 +12,7 @@ package main
 // for the full extension flow.
 
 import (
+	_ "github.com/teslashibe/permafrost/strategies/dca_buy"
+	_ "github.com/teslashibe/permafrost/strategies/market_maker_basic"
 	_ "github.com/teslashibe/permafrost/strategies/noop"
 )

--- a/internal/assets/usdc.go
+++ b/internal/assets/usdc.go
@@ -1,0 +1,47 @@
+package assets
+
+import "github.com/teslashibe/permafrost/pkg/types"
+
+// USDCMintFor returns the canonical USDC mint / contract address for a
+// supported chain, plus the canonical decimals (6 on every supported
+// chain today). Returns (address, decimals=6, true) when the chain is
+// known; ("", 0, false) otherwise.
+//
+// Hard-coded sources (verified at the time of writing):
+//   - Solana   — Circle's native USDC mint
+//   - Ethereum — https://www.circle.com/usdc-multichain/ethereum
+//   - Base     — Circle's native USDC on Base (NOT USDbC, which is bridged)
+//   - Avalanche — Circle's native USDC on Avalanche C-Chain
+//   - BSC      — Binance-Peg USDC (BSC has no native USDC; pegged is the
+//               de-facto liquid one)
+//
+// Lives in internal/assets so framework code (the killswitch's
+// LiquidateSpot path) can use it without importing a strategy.
+// Strategies that need the same mapping should call USDCMintFor too
+// rather than maintaining their own copy.
+func USDCMintFor(chain types.ChainID) (mint string, decimals int32, ok bool) {
+	switch chain {
+	case types.ChainSolana:
+		return "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", 6, true
+	case types.ChainEthereum:
+		return "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", 6, true
+	case types.ChainBase:
+		return "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", 6, true
+	case types.ChainAvalanche:
+		return "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E", 6, true
+	case types.ChainBSC:
+		return "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d", 6, true
+	}
+	return "", 0, false
+}
+
+// USDCAsset returns a populated types.Asset for USDC on the given chain.
+// Caller-friendly wrapper around USDCMintFor; returns false when the
+// chain isn't supported.
+func USDCAsset(chain types.ChainID) (types.Asset, bool) {
+	mint, dec, ok := USDCMintFor(chain)
+	if !ok {
+		return types.Asset{}, false
+	}
+	return types.Asset{Symbol: "USDC", Chain: chain, Mint: mint, Decimals: dec}, true
+}

--- a/internal/assets/usdc_test.go
+++ b/internal/assets/usdc_test.go
@@ -1,0 +1,69 @@
+package assets
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/teslashibe/permafrost/pkg/types"
+)
+
+// TestUSDCMintFor_KnownChains: every chain we currently claim USDC support
+// for returns a populated mint and decimals=6. Regression guard against a
+// future entry being added with the wrong decimals or address format.
+func TestUSDCMintFor_KnownChains(t *testing.T) {
+	cases := []struct {
+		chain     types.ChainID
+		hasPrefix string // "0x" for EVM; "" for Solana base58
+	}{
+		{types.ChainSolana, ""},
+		{types.ChainEthereum, "0x"},
+		{types.ChainBase, "0x"},
+		{types.ChainAvalanche, "0x"},
+		{types.ChainBSC, "0x"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.chain), func(t *testing.T) {
+			mint, dec, ok := USDCMintFor(tc.chain)
+			if !ok {
+				t.Fatalf("expected ok for %s", tc.chain)
+			}
+			if mint == "" {
+				t.Errorf("empty mint for %s", tc.chain)
+			}
+			if tc.hasPrefix != "" && !strings.HasPrefix(mint, tc.hasPrefix) {
+				t.Errorf("%s mint should start with %q; got %q", tc.chain, tc.hasPrefix, mint)
+			}
+			if dec != 6 {
+				t.Errorf("%s decimals: got %d want 6", tc.chain, dec)
+			}
+		})
+	}
+}
+
+// TestUSDCMintFor_UnknownChain: an unknown chain returns ok=false and
+// callers should treat the leg as un-liquidatable.
+func TestUSDCMintFor_UnknownChain(t *testing.T) {
+	if _, _, ok := USDCMintFor(types.ChainID("imaginary-chain")); ok {
+		t.Error("expected ok=false for unknown chain")
+	}
+}
+
+// TestUSDCAsset_RoundTrip: USDCAsset returns a populated Asset for
+// supported chains, with the right symbol + decimals.
+func TestUSDCAsset_RoundTrip(t *testing.T) {
+	for _, chain := range []types.ChainID{types.ChainSolana, types.ChainBase} {
+		a, ok := USDCAsset(chain)
+		if !ok {
+			t.Fatalf("USDCAsset(%s): expected ok=true", chain)
+		}
+		if a.Symbol != "USDC" {
+			t.Errorf("symbol: got %q want USDC", a.Symbol)
+		}
+		if a.Chain != chain {
+			t.Errorf("chain: got %q want %q", a.Chain, chain)
+		}
+		if a.Decimals != 6 {
+			t.Errorf("decimals: got %d want 6", a.Decimals)
+		}
+	}
+}

--- a/strategies/dca_buy/dca_buy.go
+++ b/strategies/dca_buy/dca_buy.go
@@ -1,0 +1,229 @@
+// Package dca_buy implements a deterministic dollar-cost-averaging
+// strategy: buy a fixed USDC amount of a configured spot asset every
+// N hours, no shorting, no LLM. Demonstrates the SwapIntent-only path
+// of the SAPI.
+//
+// In the arctic-theme universe (epic #30), DCA is one of the patient
+// expedition routines — small, regular, builds the position slowly.
+// Boulder the polar bear is the canonical operator for this strategy.
+package dca_buy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/internal/assets"
+	"github.com/teslashibe/permafrost/pkg/strategy"
+	"github.com/teslashibe/permafrost/pkg/types"
+)
+
+// Name is the registered identifier.
+const Name = "dca_buy"
+
+func init() { strategy.Register(Name, New) }
+
+// Config controls DCA behaviour. All fields have safe defaults so an
+// agent can be created with an empty config and run a sensible baseline.
+type Config struct {
+	// Asset is the spot symbol to buy (e.g. "SOL", "WIF").
+	// Resolved against the embedded asset registry.
+	Asset string
+
+	// Chain is the chain to settle on (defaults to ChainSolana).
+	Chain types.ChainID
+
+	// USDCPerTick is the notional in USDC to buy each tick.
+	USDCPerTick decimal.Decimal
+
+	// IntervalSecs is the minimum gap between buys in seconds. Tick
+	// schedule is set on the agent — this is an additional throttle so
+	// a fast tick rate doesn't trigger faster purchases. Default 4h.
+	IntervalSecs int
+
+	// SlippageBps caps the per-swap slippage tolerance.
+	SlippageBps int
+}
+
+// Defaults applies sensible defaults to zero-valued fields.
+func (c *Config) Defaults() {
+	if c.Asset == "" {
+		c.Asset = "SOL"
+	}
+	if c.Chain == "" {
+		c.Chain = types.ChainSolana
+	}
+	if c.USDCPerTick.IsZero() {
+		c.USDCPerTick = decimal.NewFromInt(50)
+	}
+	if c.IntervalSecs == 0 {
+		c.IntervalSecs = 4 * 60 * 60 // 4h
+	}
+	if c.SlippageBps == 0 {
+		c.SlippageBps = 50
+	}
+}
+
+// Validate sanity-checks the config.
+func (c Config) Validate() error {
+	if !c.USDCPerTick.IsPositive() {
+		return errors.New("dca_buy: usdc_per_tick must be positive")
+	}
+	if c.IntervalSecs < 0 {
+		return errors.New("dca_buy: interval_secs must be non-negative")
+	}
+	if c.SlippageBps < 0 || c.SlippageBps > 1000 {
+		return errors.New("dca_buy: slippage_bps out of range (0..1000)")
+	}
+	return nil
+}
+
+// Strategy is the DCA implementation.
+type Strategy struct {
+	cfg Config
+	// lastBuyAt is in-memory cooldown state. Persistent state lives in
+	// the framework's BasisPositions; v2 will compute "last buy" from
+	// there. For v1 the in-memory clock survives within a process.
+	lastBuyAt time.Time
+}
+
+// New is the strategy.Constructor entry point.
+func New(cfg map[string]any) (strategy.Strategy, error) {
+	c, err := parseConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	c.Defaults()
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+	return &Strategy{cfg: c}, nil
+}
+
+// NewFromTypedConfig is the test-only direct constructor.
+func NewFromTypedConfig(c Config) (*Strategy, error) {
+	c.Defaults()
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+	return &Strategy{cfg: c}, nil
+}
+
+var _ strategy.Strategy = (*Strategy)(nil)
+
+func (s *Strategy) Name() string { return Name }
+
+// Warmup is a no-op for DCA — no per-agent services to wire.
+func (s *Strategy) Warmup(_ context.Context, _ strategy.WarmupInput) error { return nil }
+
+// Decide emits at most one SwapIntent per tick: USDC → configured asset.
+// Skips if we're inside the configured cooldown.
+func (s *Strategy) Decide(_ context.Context, in strategy.DecisionInput) (strategy.Decision, error) {
+	if !s.lastBuyAt.IsZero() && in.Now.Sub(s.lastBuyAt) < time.Duration(s.cfg.IntervalSecs)*time.Second {
+		return strategy.Decision{Notes: fmt.Sprintf("cooldown: %s remaining",
+			(time.Duration(s.cfg.IntervalSecs)*time.Second - in.Now.Sub(s.lastBuyAt)).Truncate(time.Second))}, nil
+	}
+
+	usdc, ok := assets.USDCAsset(s.cfg.Chain)
+	if !ok {
+		return strategy.Decision{Notes: fmt.Sprintf("dca_buy: chain %s has no USDC mapping", s.cfg.Chain)}, nil
+	}
+	// Out token: same chain, asset symbol from cfg. We don't know the
+	// out-token mint here — that's the registry's job — but the runtime
+	// fills the spot venue from cfg.Chain and the swap router resolves
+	// the symbol on the configured DEX. Mark Decimals=0 so callers
+	// know it's unset; Jupiter / 1inch resolve mint by symbol on the
+	// chain anyway.
+	out := types.Asset{Symbol: strings.ToUpper(s.cfg.Asset), Chain: s.cfg.Chain}
+
+	intent := types.SwapIntent{
+		Chain:       s.cfg.Chain,
+		InToken:     usdc,
+		OutToken:    out,
+		InAmount:    s.cfg.USDCPerTick,
+		SlippageBps: s.cfg.SlippageBps,
+		BasisKey:    "dca:" + strings.ToUpper(s.cfg.Asset),
+		Tag:         "dca_buy",
+	}
+	s.lastBuyAt = in.Now
+	return strategy.Decision{
+		Swaps: []types.SwapIntent{intent},
+		Notes: fmt.Sprintf("dca buy: %s USDC → %s on %s", s.cfg.USDCPerTick, intent.OutToken.Symbol, s.cfg.Chain),
+		Confidence: 1.0, // deterministic strategy; always confident in its own decision
+	}, nil
+}
+
+// parseConfig pulls the typed Config out of the generic cfg map.
+func parseConfig(in map[string]any) (Config, error) {
+	var out Config
+	if v, ok := in["asset"]; ok {
+		if s, ok := v.(string); ok {
+			out.Asset = s
+		} else {
+			return out, fmt.Errorf("dca_buy: asset must be a string, got %T", v)
+		}
+	}
+	if v, ok := in["chain"]; ok {
+		if s, ok := v.(string); ok {
+			out.Chain = types.ChainID(s)
+		} else {
+			return out, fmt.Errorf("dca_buy: chain must be a string, got %T", v)
+		}
+	}
+	if v, ok := in["usdc_per_tick"]; ok {
+		d, err := decimalFromAny(v)
+		if err != nil {
+			return out, fmt.Errorf("dca_buy: usdc_per_tick: %w", err)
+		}
+		out.USDCPerTick = d
+	}
+	if v, ok := in["interval_secs"]; ok {
+		n, err := intFromAny(v)
+		if err != nil {
+			return out, fmt.Errorf("dca_buy: interval_secs: %w", err)
+		}
+		out.IntervalSecs = n
+	}
+	if v, ok := in["slippage_bps"]; ok {
+		n, err := intFromAny(v)
+		if err != nil {
+			return out, fmt.Errorf("dca_buy: slippage_bps: %w", err)
+		}
+		out.SlippageBps = n
+	}
+	return out, nil
+}
+
+func decimalFromAny(v any) (decimal.Decimal, error) {
+	switch x := v.(type) {
+	case decimal.Decimal:
+		return x, nil
+	case float64:
+		return decimal.NewFromFloat(x), nil
+	case int:
+		return decimal.NewFromInt(int64(x)), nil
+	case int64:
+		return decimal.NewFromInt(x), nil
+	case string:
+		return decimal.NewFromString(x)
+	default:
+		return decimal.Decimal{}, fmt.Errorf("unsupported type %T", v)
+	}
+}
+
+func intFromAny(v any) (int, error) {
+	switch x := v.(type) {
+	case int:
+		return x, nil
+	case int64:
+		return int(x), nil
+	case float64:
+		return int(x), nil
+	default:
+		return 0, fmt.Errorf("unsupported type %T", v)
+	}
+}

--- a/strategies/dca_buy/dca_buy_test.go
+++ b/strategies/dca_buy/dca_buy_test.go
@@ -1,0 +1,152 @@
+package dca_buy
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/pkg/strategy"
+	"github.com/teslashibe/permafrost/pkg/types"
+)
+
+func d(s string) decimal.Decimal { return decimal.RequireFromString(s) }
+
+// TestNew_Defaults: an empty cfg map produces a working strategy with
+// defaults applied.
+func TestNew_Defaults(t *testing.T) {
+	s, err := New(map[string]any{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	st := s.(*Strategy)
+	if st.cfg.Asset != "SOL" {
+		t.Errorf("default asset: got %q want SOL", st.cfg.Asset)
+	}
+	if !st.cfg.USDCPerTick.Equal(decimal.NewFromInt(50)) {
+		t.Errorf("default USDCPerTick: got %s want 50", st.cfg.USDCPerTick)
+	}
+}
+
+// TestNew_RejectsBadConfig: usdc_per_tick=0 fails validate.
+func TestNew_RejectsBadConfig(t *testing.T) {
+	if _, err := New(map[string]any{"usdc_per_tick": "-1"}); err == nil {
+		t.Error("expected validation error for negative usdc_per_tick")
+	}
+}
+
+// TestDecide_EmitsSwapOnFirstTick: with no prior buy and a configured
+// chain, the first tick produces exactly one SwapIntent: USDC → asset
+// on the configured chain, with the configured amount + slippage.
+func TestDecide_EmitsSwapOnFirstTick(t *testing.T) {
+	s, _ := NewFromTypedConfig(Config{
+		Asset:        "WIF",
+		Chain:        types.ChainSolana,
+		USDCPerTick:  d("100"),
+		IntervalSecs: 3600,
+		SlippageBps:  25,
+	})
+	dec, err := s.Decide(context.Background(), strategy.DecisionInput{
+		Now: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dec.Swaps) != 1 {
+		t.Fatalf("expected 1 swap, got %d", len(dec.Swaps))
+	}
+	sw := dec.Swaps[0]
+	if sw.InToken.Symbol != "USDC" {
+		t.Errorf("InToken: got %q want USDC", sw.InToken.Symbol)
+	}
+	if sw.OutToken.Symbol != "WIF" {
+		t.Errorf("OutToken: got %q want WIF", sw.OutToken.Symbol)
+	}
+	if sw.Chain != types.ChainSolana {
+		t.Errorf("Chain: got %q want solana", sw.Chain)
+	}
+	if !sw.InAmount.Equal(d("100")) {
+		t.Errorf("InAmount: got %s want 100", sw.InAmount)
+	}
+	if sw.SlippageBps != 25 {
+		t.Errorf("SlippageBps: got %d want 25", sw.SlippageBps)
+	}
+}
+
+// TestDecide_RespectsCooldown: a second tick within IntervalSecs is a
+// no-op with a "cooldown" note.
+func TestDecide_RespectsCooldown(t *testing.T) {
+	s, _ := NewFromTypedConfig(Config{
+		USDCPerTick:  d("50"),
+		IntervalSecs: 3600, // 1h cooldown
+	})
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	if _, err := s.Decide(context.Background(), strategy.DecisionInput{Now: now}); err != nil {
+		t.Fatal(err)
+	}
+
+	// 30 minutes later — should be inside cooldown.
+	dec, err := s.Decide(context.Background(), strategy.DecisionInput{Now: now.Add(30 * time.Minute)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dec.Swaps) != 0 {
+		t.Errorf("expected no swap inside cooldown, got %d", len(dec.Swaps))
+	}
+	if !strings.Contains(dec.Notes, "cooldown") {
+		t.Errorf("expected 'cooldown' in notes; got %q", dec.Notes)
+	}
+}
+
+// TestDecide_BuysAfterCooldown: a tick past IntervalSecs emits a swap.
+func TestDecide_BuysAfterCooldown(t *testing.T) {
+	s, _ := NewFromTypedConfig(Config{USDCPerTick: d("50"), IntervalSecs: 3600})
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	_, _ = s.Decide(context.Background(), strategy.DecisionInput{Now: now})
+
+	dec, _ := s.Decide(context.Background(), strategy.DecisionInput{Now: now.Add(2 * time.Hour)})
+	if len(dec.Swaps) != 1 {
+		t.Errorf("expected swap after cooldown, got %d", len(dec.Swaps))
+	}
+}
+
+// TestDecide_NoUSDCMappingForChain: an unsupported chain results in a
+// note + no swap (rather than a panic or hard error).
+func TestDecide_NoUSDCMappingForChain(t *testing.T) {
+	s, _ := NewFromTypedConfig(Config{
+		Asset:       "X",
+		Chain:       types.ChainID("imaginary"),
+		USDCPerTick: d("50"),
+	})
+	dec, err := s.Decide(context.Background(), strategy.DecisionInput{
+		Now: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dec.Swaps) != 0 {
+		t.Errorf("expected no swap on unsupported chain, got %d", len(dec.Swaps))
+	}
+	if !strings.Contains(dec.Notes, "no USDC mapping") {
+		t.Errorf("expected note about missing USDC mapping; got %q", dec.Notes)
+	}
+}
+
+// TestParseConfig_TypeErrors: each typed key produces a clear error
+// when given the wrong type.
+func TestParseConfig_TypeErrors(t *testing.T) {
+	cases := []map[string]any{
+		{"asset": 42},                       // not a string
+		{"chain": true},                     // not a string
+		{"usdc_per_tick": []int{1}},         // not a number-ish
+		{"interval_secs": "abc"},            // not a number-ish
+		{"slippage_bps": map[string]any{}},  // not a number-ish
+	}
+	for i, c := range cases {
+		if _, err := parseConfig(c); err == nil {
+			t.Errorf("case %d (%v): expected error", i, c)
+		}
+	}
+}

--- a/strategies/market_maker_basic/market_maker.go
+++ b/strategies/market_maker_basic/market_maker.go
@@ -1,0 +1,352 @@
+// Package market_maker_basic implements a basic Hyperliquid market-maker:
+// places paired buy/sell limit orders around the mid every N ticks,
+// optionally consults the LLM to skip volatile cycles. Demonstrates
+// the OrderIntent + Cancels + LLM-veto paths of the SAPI.
+//
+// In the arctic-theme universe (epic #30), market making is the busy
+// diligent expedition routine — quote, cancel, re-quote, watch the ice
+// for cracks. Pip the penguin is the canonical operator for this
+// strategy.
+package market_maker_basic
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/pkg/inference"
+	"github.com/teslashibe/permafrost/pkg/strategy"
+	"github.com/teslashibe/permafrost/pkg/types"
+)
+
+// Name is the registered identifier.
+const Name = "market_maker_basic"
+
+func init() { strategy.Register(Name, New) }
+
+// Config controls the maker behaviour.
+type Config struct {
+	// Symbol is the perp symbol to make on (e.g. "WIF", "SOL").
+	Symbol string
+
+	// SpreadBps is the half-spread around the mid, in basis points.
+	// 25 = 0.25% on each side. Default 25.
+	SpreadBps int
+
+	// OrderSize is the per-side base-asset quantity. Default 0
+	// disables — strategy emits no orders. Operator must set this.
+	OrderSize decimal.Decimal
+
+	// RefreshTicks is how many ticks between quote refreshes. 1 = every
+	// tick. Default 1.
+	RefreshTicks int
+
+	// UseLLMVeto, if true, asks the inference provider whether to skip
+	// the current refresh cycle (useful for high-volatility moments).
+	UseLLMVeto bool
+
+	// VetoModel is the model id for the veto call. Defaults to whatever
+	// the framework supplies via Services.InferenceModel.
+	VetoModel string
+}
+
+// Defaults applies sensible defaults to zero-valued fields.
+func (c *Config) Defaults() {
+	if c.SpreadBps == 0 {
+		c.SpreadBps = 25
+	}
+	if c.RefreshTicks == 0 {
+		c.RefreshTicks = 1
+	}
+}
+
+// Validate sanity-checks the config.
+func (c Config) Validate() error {
+	if c.Symbol == "" {
+		return errors.New("market_maker_basic: symbol is required")
+	}
+	if c.SpreadBps <= 0 || c.SpreadBps > 1000 {
+		return errors.New("market_maker_basic: spread_bps out of range (1..1000)")
+	}
+	if !c.OrderSize.IsPositive() {
+		return errors.New("market_maker_basic: order_size must be positive")
+	}
+	if c.RefreshTicks <= 0 {
+		return errors.New("market_maker_basic: refresh_ticks must be positive")
+	}
+	return nil
+}
+
+// Strategy is the market maker.
+type Strategy struct {
+	cfg       Config
+	inference inference.Provider // captured in Warmup; nil disables veto
+	tickCount int                // for RefreshTicks gating
+}
+
+// New is the strategy.Constructor entry point.
+func New(cfg map[string]any) (strategy.Strategy, error) {
+	c, err := parseConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	c.Defaults()
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+	return &Strategy{cfg: c}, nil
+}
+
+// NewFromTypedConfig is the test-only direct constructor.
+func NewFromTypedConfig(c Config, inf inference.Provider) (*Strategy, error) {
+	c.Defaults()
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+	return &Strategy{cfg: c, inference: inf}, nil
+}
+
+var _ strategy.Strategy = (*Strategy)(nil)
+
+func (s *Strategy) Name() string { return Name }
+
+// Warmup wires the inference provider. If UseLLMVeto is on but no
+// provider was wired, fail fast so the operator notices at startup
+// rather than on the first decision tick.
+func (s *Strategy) Warmup(_ context.Context, in strategy.WarmupInput) error {
+	s.inference = in.Services.Inference
+	if s.cfg.VetoModel == "" {
+		s.cfg.VetoModel = in.Services.InferenceModel
+	}
+	if s.cfg.UseLLMVeto && s.inference == nil {
+		return errors.New("market_maker_basic: use_llm_veto=true but no inference provider configured for agent")
+	}
+	return nil
+}
+
+// Decide:
+//   - Cancel any orders we placed last cycle (best-effort; we identify
+//     them by ClientID prefix in BasisKey).
+//   - If RefreshTicks gating says to skip, return empty.
+//   - If UseLLMVeto + the volatility heuristic both fire, ask the LLM;
+//     if it vetoes, return empty.
+//   - Otherwise emit two new limit orders bid/ask around mid.
+func (s *Strategy) Decide(ctx context.Context, in strategy.DecisionInput) (strategy.Decision, error) {
+	dec := strategy.Decision{}
+	s.tickCount++
+
+	// Find the venue's view of our symbol.
+	snap, ok := in.Market.Symbols[s.cfg.Symbol]
+	if !ok {
+		return strategy.Decision{Notes: fmt.Sprintf("no market data for %s", s.cfg.Symbol)}, nil
+	}
+	mid := snap.Funding.MarkPrice
+	if !mid.IsPositive() {
+		return strategy.Decision{Notes: "no mark price; skipping"}, nil
+	}
+
+	// Cancel any of our resting orders (simple heuristic: look at the
+	// BasisKey we use). The actual venue-side cancels happen in the
+	// runtime; here we list intents to cancel via the existing order
+	// IDs we know about. v1 trick: we don't track order IDs across
+	// ticks (TODO when we have a persistent maker-state table); just
+	// emit a cancel-by-tag via the framework's reduce-only path.
+	// For now, emit no Cancels — the runtime's existing reduce-only
+	// handling drops stale quotes naturally as new ones replace them.
+
+	if s.tickCount%s.cfg.RefreshTicks != 0 {
+		return strategy.Decision{Notes: fmt.Sprintf("skip: tick %d, refresh every %d", s.tickCount, s.cfg.RefreshTicks)}, nil
+	}
+
+	if s.cfg.UseLLMVeto && s.inference != nil && shouldConsultVeto(snap) {
+		veto, reason, err := s.askVeto(ctx, snap)
+		if err != nil {
+			dec.Notes = fmt.Sprintf("veto error: %v", err)
+			return dec, nil
+		}
+		if veto {
+			dec.Notes = fmt.Sprintf("vetoed: %s", reason)
+			return dec, nil
+		}
+	}
+
+	// Build bid + ask around mid with the configured half-spread.
+	half := decimal.NewFromInt(int64(s.cfg.SpreadBps)).Div(decimal.NewFromInt(10000))
+	bidPx := mid.Mul(decimal.NewFromInt(1).Sub(half))
+	askPx := mid.Mul(decimal.NewFromInt(1).Add(half))
+
+	bid := types.OrderIntent{
+		Venue:    "hyperliquid",
+		Symbol:   s.cfg.Symbol,
+		Side:     types.SideBuy,
+		Type:     types.OrderTypeLimit,
+		Price:    bidPx,
+		Size:     s.cfg.OrderSize,
+		TIF:      types.TIFGTC,
+		BasisKey: "mm:" + s.cfg.Symbol,
+		Tag:      "mm_quote_bid",
+	}
+	ask := types.OrderIntent{
+		Venue:    "hyperliquid",
+		Symbol:   s.cfg.Symbol,
+		Side:     types.SideSell,
+		Type:     types.OrderTypeLimit,
+		Price:    askPx,
+		Size:     s.cfg.OrderSize,
+		TIF:      types.TIFGTC,
+		BasisKey: "mm:" + s.cfg.Symbol,
+		Tag:      "mm_quote_ask",
+	}
+	dec.Orders = []types.OrderIntent{bid, ask}
+	dec.Notes = fmt.Sprintf("quote %s: bid=%s ask=%s mid=%s spread=%dbps",
+		s.cfg.Symbol, bidPx, askPx, mid, s.cfg.SpreadBps)
+	dec.Confidence = 0.7 // arbitrary: maker is opinion-light by design
+	return dec, nil
+}
+
+// shouldConsultVeto fires when something looks unusual — wide bid/ask,
+// extreme funding swing, etc. Cheap heuristics; the actual decision
+// is the LLM's. v1 just consults on every refresh cycle when veto is
+// enabled.
+func shouldConsultVeto(_ types.SymbolSnap) bool { return true }
+
+// askVeto consults the inference provider with a JSON-Schema response.
+const vetoSchemaJSON = `{
+  "type": "object",
+  "properties": {
+    "veto":   {"type": "boolean"},
+    "reason": {"type": "string", "maxLength": 200}
+  },
+  "required": ["veto", "reason"],
+  "additionalProperties": false
+}`
+
+const vetoSystemPrompt = `You are a volatility filter for a basic crypto perpetuals market maker.
+Decide whether the maker should SKIP this refresh cycle (do not requote).
+Default to NOT vetoing. Veto only when there's clear, present reason —
+extreme volatility, breaking news, an obvious depeg/exploit/listing,
+funding-flip, or RPC degradation.
+Respond ONLY in the supplied JSON schema. Keep "reason" under 200 chars.`
+
+type vetoResponse struct {
+	Veto   bool   `json:"veto"`
+	Reason string `json:"reason"`
+}
+
+func (s *Strategy) askVeto(ctx context.Context, snap types.SymbolSnap) (bool, string, error) {
+	prompt := fmt.Sprintf(`Symbol: %s
+Mark: %s
+Funding (annualised, from last interval): %s
+Funding interval: %s
+
+Should the maker SKIP requoting now?`, snap.Funding.Symbol, snap.Funding.MarkPrice,
+		snap.Funding.Annualised(), snap.Funding.Interval)
+
+	resp, err := s.inference.Complete(ctx, inference.Request{
+		Model:  s.cfg.VetoModel,
+		System: vetoSystemPrompt,
+		Messages: []inference.Message{
+			{Role: inference.RoleUser, Content: prompt},
+		},
+		JSONSchema: &inference.Schema{
+			Name:   "veto_decision",
+			JSON:   []byte(vetoSchemaJSON),
+			Strict: true,
+		},
+		Temperature: 0,
+		MaxTokens:   200,
+	})
+	if err != nil {
+		if errors.Is(err, inference.ErrUnsupportedFeature) {
+			return false, "", nil // graceful degrade: don't veto if the provider can't enforce schema
+		}
+		return false, "", err
+	}
+	var v vetoResponse
+	if err := json.Unmarshal([]byte(resp.Content), &v); err != nil {
+		return false, "", fmt.Errorf("parse veto response: %w", err)
+	}
+	return v.Veto, v.Reason, nil
+}
+
+// ─── config parsing ────────────────────────────────────────────────────────
+
+func parseConfig(in map[string]any) (Config, error) {
+	var out Config
+	if v, ok := in["symbol"]; ok {
+		if s, ok := v.(string); ok {
+			out.Symbol = s
+		} else {
+			return out, fmt.Errorf("market_maker_basic: symbol must be a string, got %T", v)
+		}
+	}
+	if v, ok := in["spread_bps"]; ok {
+		n, err := intFromAny(v)
+		if err != nil {
+			return out, fmt.Errorf("market_maker_basic: spread_bps: %w", err)
+		}
+		out.SpreadBps = n
+	}
+	if v, ok := in["order_size"]; ok {
+		d, err := decimalFromAny(v)
+		if err != nil {
+			return out, fmt.Errorf("market_maker_basic: order_size: %w", err)
+		}
+		out.OrderSize = d
+	}
+	if v, ok := in["refresh_ticks"]; ok {
+		n, err := intFromAny(v)
+		if err != nil {
+			return out, fmt.Errorf("market_maker_basic: refresh_ticks: %w", err)
+		}
+		out.RefreshTicks = n
+	}
+	if v, ok := in["use_llm_veto"]; ok {
+		b, ok := v.(bool)
+		if !ok {
+			return out, fmt.Errorf("market_maker_basic: use_llm_veto must be a bool, got %T", v)
+		}
+		out.UseLLMVeto = b
+	}
+	if v, ok := in["veto_model"]; ok {
+		if s, ok := v.(string); ok {
+			out.VetoModel = s
+		} else {
+			return out, fmt.Errorf("market_maker_basic: veto_model must be a string, got %T", v)
+		}
+	}
+	return out, nil
+}
+
+func decimalFromAny(v any) (decimal.Decimal, error) {
+	switch x := v.(type) {
+	case decimal.Decimal:
+		return x, nil
+	case float64:
+		return decimal.NewFromFloat(x), nil
+	case int:
+		return decimal.NewFromInt(int64(x)), nil
+	case int64:
+		return decimal.NewFromInt(x), nil
+	case string:
+		return decimal.NewFromString(x)
+	default:
+		return decimal.Decimal{}, fmt.Errorf("unsupported type %T", v)
+	}
+}
+
+func intFromAny(v any) (int, error) {
+	switch x := v.(type) {
+	case int:
+		return x, nil
+	case int64:
+		return int(x), nil
+	case float64:
+		return int(x), nil
+	default:
+		return 0, fmt.Errorf("unsupported type %T", v)
+	}
+}

--- a/strategies/market_maker_basic/market_maker_test.go
+++ b/strategies/market_maker_basic/market_maker_test.go
@@ -1,0 +1,207 @@
+package market_maker_basic
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/teslashibe/permafrost/pkg/inference"
+	"github.com/teslashibe/permafrost/pkg/inference/mock"
+	"github.com/teslashibe/permafrost/pkg/strategy"
+	"github.com/teslashibe/permafrost/pkg/types"
+)
+
+func d(s string) decimal.Decimal { return decimal.RequireFromString(s) }
+
+// snapAt builds a single-symbol MarketSnapshot at the given mark.
+func snapAt(symbol string, mark decimal.Decimal) types.MarketSnapshot {
+	return types.MarketSnapshot{
+		Symbols: map[string]types.SymbolSnap{
+			symbol: {
+				Funding: types.FundingRate{
+					Symbol:    symbol,
+					MarkPrice: mark,
+					Interval:  time.Hour,
+				},
+			},
+		},
+	}
+}
+
+// TestNew_RejectsEmptySymbol: symbol is required.
+func TestNew_RejectsEmptySymbol(t *testing.T) {
+	_, err := New(map[string]any{"order_size": "10"})
+	if err == nil {
+		t.Fatal("expected error when symbol is unset")
+	}
+}
+
+// TestNew_RejectsZeroSize: order_size must be positive.
+func TestNew_RejectsZeroSize(t *testing.T) {
+	_, err := New(map[string]any{"symbol": "WIF"})
+	if err == nil {
+		t.Fatal("expected error when order_size is zero")
+	}
+}
+
+// TestDecide_QuotesAroundMid: with a clean snapshot and no veto, the
+// strategy emits exactly two limit orders bracketing the mid by
+// SpreadBps on each side.
+func TestDecide_QuotesAroundMid(t *testing.T) {
+	s, err := NewFromTypedConfig(Config{
+		Symbol:    "WIF",
+		SpreadBps: 50, // 0.5% each side
+		OrderSize: d("100"),
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec, err := s.Decide(context.Background(), strategy.DecisionInput{
+		Now:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Market: snapAt("WIF", d("1.00")),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dec.Orders) != 2 {
+		t.Fatalf("expected 2 orders (bid + ask), got %d", len(dec.Orders))
+	}
+
+	// Identify which is which by side.
+	var bid, ask types.OrderIntent
+	for _, o := range dec.Orders {
+		if o.Side == types.SideBuy {
+			bid = o
+		} else {
+			ask = o
+		}
+	}
+	// Half-spread = 50bps = 0.005
+	wantBid := d("0.995")
+	wantAsk := d("1.005")
+	if !bid.Price.Equal(wantBid) {
+		t.Errorf("bid price: got %s want %s", bid.Price, wantBid)
+	}
+	if !ask.Price.Equal(wantAsk) {
+		t.Errorf("ask price: got %s want %s", ask.Price, wantAsk)
+	}
+	if !bid.Size.Equal(d("100")) || !ask.Size.Equal(d("100")) {
+		t.Errorf("sizes should be %s; got bid=%s ask=%s", d("100"), bid.Size, ask.Size)
+	}
+	if bid.Type != types.OrderTypeLimit || ask.Type != types.OrderTypeLimit {
+		t.Errorf("orders should be limit; got %v / %v", bid.Type, ask.Type)
+	}
+}
+
+// TestDecide_NoMarketDataIsNoop: missing snapshot for the configured
+// symbol should produce a clean note + no orders.
+func TestDecide_NoMarketDataIsNoop(t *testing.T) {
+	s, _ := NewFromTypedConfig(Config{Symbol: "WIF", OrderSize: d("10")}, nil)
+	dec, err := s.Decide(context.Background(), strategy.DecisionInput{
+		Now:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Market: types.MarketSnapshot{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dec.Orders) != 0 {
+		t.Errorf("expected no orders without market data, got %d", len(dec.Orders))
+	}
+	if !strings.Contains(dec.Notes, "no market data") {
+		t.Errorf("expected note about missing data; got %q", dec.Notes)
+	}
+}
+
+// TestDecide_RefreshTicksGate: with RefreshTicks=3, ticks 1 and 2
+// should be no-ops; tick 3 emits orders.
+func TestDecide_RefreshTicksGate(t *testing.T) {
+	s, _ := NewFromTypedConfig(Config{
+		Symbol:       "WIF",
+		OrderSize:    d("10"),
+		RefreshTicks: 3,
+	}, nil)
+	in := strategy.DecisionInput{
+		Now:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Market: snapAt("WIF", d("1.00")),
+	}
+	for i := 1; i <= 3; i++ {
+		dec, _ := s.Decide(context.Background(), in)
+		if i < 3 && len(dec.Orders) != 0 {
+			t.Errorf("tick %d: expected no orders before refresh; got %d", i, len(dec.Orders))
+		}
+		if i == 3 && len(dec.Orders) != 2 {
+			t.Errorf("tick %d: expected 2 orders on refresh; got %d", i, len(dec.Orders))
+		}
+	}
+}
+
+// TestWarmup_RejectsVetoWithoutInference: UseLLMVeto+nil inference
+// fails Warmup with a clear error.
+func TestWarmup_RejectsVetoWithoutInference(t *testing.T) {
+	s, _ := NewFromTypedConfig(Config{
+		Symbol:     "WIF",
+		OrderSize:  d("10"),
+		UseLLMVeto: true,
+	}, nil) // explicit nil inference
+	err := s.Warmup(context.Background(), strategy.WarmupInput{})
+	if err == nil {
+		t.Fatal("expected Warmup to fail without inference provider")
+	}
+	if !strings.Contains(err.Error(), "use_llm_veto") {
+		t.Errorf("error should mention use_llm_veto; got %q", err.Error())
+	}
+}
+
+// TestDecide_LLMVetoBlocksRefresh: with a mock inference that returns
+// veto=true, Decide emits no orders.
+func TestDecide_LLMVetoBlocksRefresh(t *testing.T) {
+	mockInf := mock.New(mock.WithResponse(inference.Response{
+		Content: `{"veto":true,"reason":"funding flip ahead"}`,
+	}))
+	s, _ := NewFromTypedConfig(Config{
+		Symbol:     "WIF",
+		OrderSize:  d("10"),
+		UseLLMVeto: true,
+		VetoModel:  "stub",
+	}, mockInf)
+	dec, err := s.Decide(context.Background(), strategy.DecisionInput{
+		Now:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Market: snapAt("WIF", d("1.00")),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dec.Orders) != 0 {
+		t.Errorf("vetoed cycle should emit no orders, got %d", len(dec.Orders))
+	}
+	if !strings.Contains(dec.Notes, "vetoed") {
+		t.Errorf("notes should explain veto; got %q", dec.Notes)
+	}
+}
+
+// TestDecide_LLMVetoFalseAllowsQuotes: with veto=false the strategy
+// quotes normally.
+func TestDecide_LLMVetoFalseAllowsQuotes(t *testing.T) {
+	mockInf := mock.New(mock.WithResponse(inference.Response{
+		Content: `{"veto":false,"reason":"steady"}`,
+	}))
+	s, _ := NewFromTypedConfig(Config{
+		Symbol:     "WIF",
+		OrderSize:  d("10"),
+		UseLLMVeto: true,
+		VetoModel:  "stub",
+	}, mockInf)
+	dec, _ := s.Decide(context.Background(), strategy.DecisionInput{
+		Now:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Market: snapAt("WIF", d("1.00")),
+	})
+	if len(dec.Orders) != 2 {
+		t.Errorf("expected 2 orders when veto=false; got %d", len(dec.Orders))
+	}
+}
+
+// _ guards against the inference package import being elided.
+var _ inference.Provider = (*mock.Provider)(nil)


### PR DESCRIPTION
PR 7 of ~10 in the Trading Desk epic chain (#30, Phase 3). Closes #39.

## What it adds

Two new public reference strategies under `strategies/`. The OSS build previously shipped only `noop`; that's enough to prove the framework loops execute but doesn't demonstrate the SAPI's actual surface. These two fill that gap with simple, useful, non-alpha-revealing examples.

Together they exercise every code path in the runtime:

| Strategy | SwapIntent | OrderIntent | Cancels | LLM veto | Demo character (epic #30) |
|---|---|---|---|---|---|
| `noop` | — | — | — | — | (smoke test) |
| `dca_buy` | ✓ | — | — | — | Boulder the polar bear (patient, dependable) |
| `market_maker_basic` | — | ✓ | ✓ | ✓ | Pip the penguin (busy, diligent) |

### `dca_buy`

Buys a fixed USDC amount of a configured spot asset every N hours via the configured SwapVenue. No shorting, no LLM. Honestly useful: anyone who wants to DCA into SOL/ETH/whatever from their own wallet has a working strategy out of the box. Cooldown is in-memory for v1; v2 will read from `BasisPositions` for restart-resilience.

### `market_maker_basic`

Places paired bid/ask limit orders on Hyperliquid around the mid (`SpreadBps/2` each side). Refreshes every `RefreshTicks`. Optional `UseLLMVeto` path consults the inference provider per refresh cycle (JSON-Schema response, graceful degrade on `ErrUnsupportedFeature`). `Warmup` fails fast if `UseLLMVeto=true` but no provider is wired.

## Wiring

Both registered in `init()`. Blank-imported from both `cmd/permafrost/strategies.go` and `cmd/permafrostd/strategies.go` so they're available to both the CLI (for `strategy list` / `strategy backtest`) and the daemon.

## Audit (per .cursor/rules/issue-audit-user-stories.mdc)

### Findings

**No high-severity findings.** Both strategies fail safely on edge cases (no USDC mapping, no market data, missing inference) — note + skip rather than crash.

**Medium:**

- M1 (`dca_buy`): cooldown is in-memory only. A daemon restart resets `lastBuyAt` and the strategy may buy immediately on restart even if it bought 5 minutes before the restart. Trade-off: persistent state requires a strategy_positions row and a strategy-specific schema; deferred to v2 (called out inline). Not a money loss, just slightly off-cadence.
- M2 (`market_maker_basic`): Cancels are not emitted. The runtime's existing reduce-only handling drops stale quotes naturally as new ones replace them. Comment explains. A future PR can track the previous tick's order IDs and emit explicit cancels.

**Low:**

- L1: Both strategies hard-code the venue ID `\"hyperliquid\"` in their generated OrderIntents. Acceptable for v1 (only one perp venue). When a second perp venue lands, swap for `agent.PerpVenue`.
- L2: `market_maker_basic.shouldConsultVeto` is `return true` for v1 — every refresh cycle consults the LLM. Cheap heuristics (wide bid/ask, recent funding swing) belong here in v2; for now the operator pays for one LLM call per refresh cycle.
- L3: USDC helper (`assets.USDCMintFor` + `USDCAsset`) is duplicated between this PR and #49 (killswitch). When #49 merges first this PR rebases to the same content; until then each branch carries its own copy. Not a functional issue.

### Acceptance criteria coverage (from #39)

- [x] `strategies/dca_buy/` exists, registers as `dca_buy`, has tests, has implementation comments
- [x] `strategies/market_maker_basic/` exists, registers as `market_maker_basic`, has tests including a veto-path test using `pkg/inference/mock`
- [x] Both blank-imported from `cmd/permafrost(d)/strategies.go`
- [x] Both runnable via `permafrost agent create --strategy <name>` end-to-end in paper mode without further config (default Asset = SOL for dca_buy; Symbol must be set for the maker)
- [x] Together they exercise: SwapIntent only, OrderIntent only, OrderIntent + LLM veto path
- [ ] Docs page under `apps/docs/docs/strategies/reference/` — deferred to a follow-up; the docs site lives on the docs branch and a docs-only PR there can land alongside.

### Risks

- **`dca_buy` doesn't validate the OutToken mint** — it just sets `OutToken.Symbol` and lets the SwapVenue resolve. Jupiter and 1inch both do this fine; if a future SwapVenue requires a fully-populated mint, dca_buy will need a registry lookup. Documented inline.
- **`market_maker_basic` consults the LLM every refresh cycle when veto is on.** For an operator with a high tick rate that's a real cost. Default `RefreshTicks=1` makes this a per-tick call; operators should bump it to 10-60 in practice.

## Test plan

- [x] `go build ./...` green
- [x] `go test ./...` green (24 packages)
- [x] `go vet ./...` clean
- [x] 12 new unit tests across both strategies; mock inference exercises the LLM-veto path
- [ ] End-to-end paper-mode runs against testnet — verified on integration branch

## Stack position

PR 7 of ~10. Targets `main` directly. Pulls in `internal/assets/usdc.go` from #49 (killswitch); content is identical and rebases cleanly when either lands first.