### PR TITLE
Trading Desk UI v1: arctic theme + 8 hand-authored SVG sprites (closes #41)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,26 @@ jobs:
       - name: test
         run: go test ./... -race -count=1
 
+  desk-ui:
+    name: trading desk — typecheck + build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/desk
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: apps/desk/package-lock.json
+      - name: install
+        run: npm ci --no-audit --no-fund
+      - name: typecheck
+        run: npm run typecheck
+      - name: build
+        run: npm run build
+
   no-tracked-private-strategies:
     # Guards the gitignored-private-strategies contract: the public
     # repo must never have strategies/private/ or any strategies_local.go

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ go.work.sum
 .DS_Store
 Thumbs.db
 
+## Vite / Trading Desk build outputs
+apps/desk/node_modules/
+apps/desk/dist/
+
 ## Local config & secrets
 config.yaml
 config.local.yaml

--- a/apps/desk/README.md
+++ b/apps/desk/README.md
@@ -1,0 +1,64 @@
+# Permafrost — Trading Desk
+
+The arctic-themed operator dashboard. React + Vite, no UI framework
+dependency. Hand-authored SVG sprites for every character (see
+`src/characters/`).
+
+## Run locally
+
+```bash
+cd apps/desk
+npm install
+npm run dev          # http://127.0.0.1:5173
+```
+
+The dev server proxies `/v1/*` to `http://127.0.0.1:8080` (the
+permafrostd default) so the UI works against `make up` without you
+having to configure CORS.
+
+If the daemon isn't reachable, the UI falls back to a small **demo
+mode** dataset so you can preview the experience without `make up`.
+
+## Build
+
+```bash
+npm run typecheck    # tsc --noEmit
+npm run build        # → dist/
+npm run preview      # serve dist/ on :5173
+```
+
+The `dist/` directory is what a future PR will `go:embed` into the
+daemon and serve under `/ui`.
+
+## Cast
+
+| Character                 | Role                                      |
+|---------------------------|-------------------------------------------|
+| 🐻 Pole the polar bear    | Camp Director — the operator's avatar.    |
+| 🐧 Penguin trader         | One per running agent.                    |
+| 🦄 Narwhal advisor        | Floats beside an agent that uses the LLM. |
+| 🦉 Aurora the snowy owl   | Risk monitor; eye blinks red on a trip.   |
+| 🐕 Skipper the husky      | Reconciliation runner.                    |
+| 🦦 Kelp the walrus        | Swap router.                              |
+| 🐙 Frostbite the kraken   | Killswitch.                               |
+| 🦣 Tusk the mammoth       | Operator's gitignored private strategies. |
+| 🪙 Coin                   | One per ~$100 of accumulated NAV.         |
+
+See [the brand narrative](../docs/docs/brand.md) for the full
+metaphor.
+
+## v1 scope
+
+- Static layout: chrome (Pole + Aurora) + Vault + Agents rail + Decision Log + Cast showcase
+- 3-second polling against `/v1/agents` and `/v1/agents/<id>/decisions`
+- Demo-mode fallback when the daemon is offline
+- All sprites and CSS animations included; build is < 60 KB gzipped
+
+## Out of scope (v2)
+
+- WebSocket / SSE multiplex for sub-second decision latency
+- Per-agent action buttons (start / stop / set-mode / kill)
+- NAV history chart (currently just the current value)
+- Trade-history view
+- Dark/light mode (we're dark-only on purpose for v1)
+- Mobile breakpoints (desktop-first; mobile in v2)

--- a/apps/desk/index.html
+++ b/apps/desk/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Permafrost Trading Desk — your expedition team is on the ice." />
+    <title>Permafrost — Trading Desk</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/desk/package-lock.json
+++ b/apps/desk/package-lock.json
@@ -1,0 +1,1729 @@
+{
+  "name": "@permafrost/desk",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@permafrost/desk",
+      "version": "0.0.1",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "@vitejs/plugin-react": "^4.3.4",
+        "typescript": "^5.7.2",
+        "vite": "^5.4.11"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
+      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/apps/desk/package.json
+++ b/apps/desk/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@permafrost/desk",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Permafrost Trading Desk — arctic-themed operator dashboard",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview --host 127.0.0.1 --port 5173",
+    "typecheck": "tsc --noEmit",
+    "lint": "echo 'lint: hand-written; no formal lint configured for v1'"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.7.2",
+    "vite": "^5.4.11"
+  }
+}

--- a/apps/desk/public/favicon.svg
+++ b/apps/desk/public/favicon.svg
@@ -1,0 +1,65 @@
+<!--
+  Pole the polar bear (Captain). The operator's avatar.
+  Hand-authored pixel art, 32×32 logical grid, scaled to 256×256.
+  Palette: ice white #ECF6FF, navy outline #1B2A4E, snout pink #F4B6C0,
+           captain hat navy #1B2A4E + gold #F0C24A.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Pole the polar bear, Captain">
+  <title>Pole the polar bear (Captain)</title>
+  <desc>The operator's avatar  a stylized polar bear with a navy captain's cap, presiding over the trading-desk pyramid.</desc>
+
+  <!-- Captain's hat brim (black) -->
+  <rect x="9"  y="5"  width="14" height="1" fill="#1B2A4E"/>
+  <!-- Hat body -->
+  <rect x="11" y="3"  width="10" height="2" fill="#1B2A4E"/>
+  <rect x="12" y="2"  width="8"  height="1" fill="#1B2A4E"/>
+  <!-- Hat gold band -->
+  <rect x="9"  y="6"  width="14" height="1" fill="#F0C24A"/>
+  <!-- Hat anchor emblem (gold dot) -->
+  <rect x="15" y="3"  width="2"  height="1" fill="#F0C24A"/>
+
+  <!-- Head outline (rounded square) -->
+  <rect x="8"  y="7"  width="16" height="1" fill="#1B2A4E"/>
+  <rect x="7"  y="8"  width="1"  height="9" fill="#1B2A4E"/>
+  <rect x="24" y="8"  width="1"  height="9" fill="#1B2A4E"/>
+  <rect x="8"  y="17" width="16" height="1" fill="#1B2A4E"/>
+
+  <!-- Head fill -->
+  <rect x="8"  y="8"  width="16" height="9" fill="#ECF6FF"/>
+
+  <!-- Ears -->
+  <rect x="9"  y="6"  width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="22" y="6"  width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="8"  y="7"  width="2"  height="1" fill="#ECF6FF"/>
+  <rect x="22" y="7"  width="2"  height="1" fill="#ECF6FF"/>
+
+  <!-- Eyes -->
+  <rect x="11" y="11" width="2"  height="2" fill="#1B2A4E"/>
+  <rect x="19" y="11" width="2"  height="2" fill="#1B2A4E"/>
+  <!-- Eye highlights -->
+  <rect x="11" y="11" width="1"  height="1" fill="#ECF6FF"/>
+  <rect x="19" y="11" width="1"  height="1" fill="#ECF6FF"/>
+
+  <!-- Snout -->
+  <rect x="13" y="13" width="6"  height="3" fill="#F8FBFF"/>
+  <rect x="13" y="14" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="18" y="14" width="1"  height="1" fill="#1B2A4E"/>
+  <!-- Nose -->
+  <rect x="15" y="14" width="2"  height="1" fill="#1B2A4E"/>
+  <!-- Mouth -->
+  <rect x="14" y="15" width="4"  height="1" fill="#F4B6C0"/>
+
+  <!-- Body fill (peeks below head) -->
+  <rect x="9"  y="18" width="14" height="6" fill="#ECF6FF"/>
+  <rect x="8"  y="18" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="23" y="18" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="9"  y="24" width="14" height="1" fill="#1B2A4E"/>
+
+  <!-- Captain's collar (gold) -->
+  <rect x="11" y="18" width="10" height="1" fill="#F0C24A"/>
+  <rect x="14" y="19" width="4"  height="1" fill="#1B2A4E"/>
+
+  <!-- Paws (peeking out from sides) -->
+  <rect x="8"  y="20" width="1"  height="3" fill="#ECF6FF"/>
+  <rect x="23" y="20" width="1"  height="3" fill="#ECF6FF"/>
+</svg>

--- a/apps/desk/src/App.tsx
+++ b/apps/desk/src/App.tsx
@@ -1,0 +1,163 @@
+import React, { useEffect, useState } from 'react';
+import { APIClient, Agent, DecisionLite, demoData } from './api/client';
+import { DashboardChrome } from './components/DashboardChrome';
+import { AgentCard } from './components/AgentCard';
+import { DecisionRow } from './components/DecisionRow';
+import { Vault } from './components/Vault';
+import { CastShowcase } from './components/CastShowcase';
+
+// App is the root view. v1 layout:
+//
+//   ┌──────────────────────────────────────────────────────────────┐
+//   │  [Pole]   ❄ Permafrost — Trading Desk          [conn] [Owl] │  chrome
+//   ├──────────────────┬──────────────────────────────────────────┤
+//   │                  │                                          │
+//   │  Vault           │  Decision Log                            │
+//   │  (coins)         │  (last 20)                               │
+//   │                  │                                          │
+//   │  Agents          │                                          │
+//   │  ─ Pip 🐧+🦄     │                                          │
+//   │  ─ Boulder 🐧    │                                          │
+//   │  ─ ...           │                                          │
+//   │                  │                                          │
+//   ├──────────────────┴──────────────────────────────────────────┤
+//   │  The Expedition (cast showcase)                             │
+//   └──────────────────────────────────────────────────────────────┘
+//
+// Polls /v1/agents and /v1/agents/<id>/decisions every 3s. v2 will
+// switch to a single WebSocket multiplex for sub-second latency
+// (#41 follow-up; the polling baseline is fine for the v1 ship).
+
+const POLL_MS = 3000;
+const client = new APIClient();
+
+export const App: React.FC = () => {
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [decisions, setDecisions] = useState<DecisionLite[]>([]);
+  const [connected, setConnected] = useState(false);
+  const [lastError, setLastError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const poll = async () => {
+      try {
+        const list = await client.listAgents();
+        if (cancelled) return;
+        setAgents(list);
+        setConnected(true);
+        setLastError(null);
+        // For v1 just pull decisions for the first agent. v2 will
+        // multiplex over WebSocket and merge per-agent streams.
+        if (list.length > 0) {
+          const decs = await client.recentDecisions(list[0].id, 20);
+          if (!cancelled) setDecisions(decs);
+        } else {
+          setDecisions([]);
+        }
+      } catch (err) {
+        if (cancelled) return;
+        // Disconnected: show the demo data so the UI still feels
+        // alive, but flag it clearly.
+        setConnected(false);
+        setAgents(demoData.agents);
+        setDecisions(demoData.recent_decisions);
+        setLastError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!cancelled) timer = setTimeout(poll, POLL_MS);
+      }
+    };
+    void poll();
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+
+  // V1 doesn't yet pipe NAV through the API — synthesise from
+  // alloc_usd as a stand-in. Real NAV stream lands when /v1/vault/nav
+  // is added (separate small PR).
+  const navUSD = agents.reduce((acc, a) => acc + parseFloat(a.alloc_usd || '0'), 0);
+
+  // Aurora alerts when any agent is halted or errored. Cheap heuristic
+  // until per-breaker telemetry is plumbed.
+  const alertActive = agents.some(a => a.status === 'halted' || a.status === 'error');
+
+  return (
+    <>
+      <DashboardChrome
+        title="Permafrost — Trading Desk"
+        subtitle={connected ? 'live data from permafrostd' : 'demo mode (daemon unreachable)'}
+        alertActive={alertActive}
+        connected={connected}
+      />
+
+      <main style={{
+        display: 'grid',
+        gridTemplateColumns: 'minmax(320px, 1fr) 2fr',
+        gap: 16,
+        padding: 24,
+        maxWidth: 1400,
+        margin: '0 auto',
+      }}>
+        <aside style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <Vault navUSD={navUSD} />
+          <section>
+            <h2 style={{ fontSize: 14, opacity: 0.8, letterSpacing: 0.5, marginBottom: 8, textTransform: 'uppercase' }}>
+              Agents
+            </h2>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {agents.length === 0
+                ? <EmptyAgents />
+                : agents.map(a => <AgentCard key={a.id} agent={a} />)}
+            </div>
+          </section>
+        </aside>
+
+        <section>
+          <h2 style={{ fontSize: 14, opacity: 0.8, letterSpacing: 0.5, marginBottom: 8, textTransform: 'uppercase' }}>
+            Decision Log
+          </h2>
+          <div style={{
+            background: 'var(--ice-mid)',
+            border: '1px solid var(--ice-edge)',
+            borderRadius: 8,
+            overflow: 'hidden',
+          }}>
+            {decisions.length === 0
+              ? <EmptyDecisions connected={connected} />
+              : decisions.map(d => <DecisionRow key={d.id} d={d} />)}
+          </div>
+        </section>
+      </main>
+
+      <CastShowcase />
+
+      {lastError && !connected && (
+        <footer style={{ padding: 12, fontSize: 10, opacity: 0.5, textAlign: 'center' }}>
+          {lastError} — start the daemon with <code>make up</code> to see live data.
+        </footer>
+      )}
+    </>
+  );
+};
+
+const EmptyAgents: React.FC = () => (
+  <div style={{
+    padding: 16, background: 'var(--ice-mid)',
+    border: '1px dashed var(--ice-edge)', borderRadius: 8,
+    fontSize: 12, opacity: 0.7,
+  }}>
+    No agents yet. Try <code>permafrost agent create --strategy noop --perp hyperliquid --alloc 1000</code>.
+  </div>
+);
+
+const EmptyDecisions: React.FC<{ connected: boolean }> = ({ connected }) => (
+  <div style={{ padding: 24, fontSize: 12, opacity: 0.7, textAlign: 'center' }}>
+    {connected
+      ? 'Waiting for the first decision tick…'
+      : 'No decisions to show. Start the daemon to see live activity.'}
+  </div>
+);

--- a/apps/desk/src/api/client.ts
+++ b/apps/desk/src/api/client.ts
@@ -1,0 +1,130 @@
+// Permafrost daemon API client.
+//
+// V1 surface — what we need for the Trading Desk's read-only views.
+// Mutations (start/stop/set-mode) come in v2 once the WebSocket /
+// SSE channel is in.
+//
+// All requests go through the Vite dev-proxy when running with
+// `npm run dev` (proxy /v1 -> http://127.0.0.1:8080 in vite.config.ts).
+// In production (when the daemon embeds the built UI under /ui), the
+// same paths work without a proxy.
+
+export type AgentMode = 'paper' | 'live';
+export type AgentStatus = 'idle' | 'running' | 'halted' | 'error';
+
+export interface Agent {
+  id: string;
+  name: string;
+  strategy: string;
+  perp_venue: string;
+  spot_venue: string;
+  mode: AgentMode;
+  status: AgentStatus;
+  alloc_usd: string;
+  network: string;
+  tick_secs: number;
+  updated_at: string;
+}
+
+export interface DecisionLite {
+  id: string;
+  agent_id: string;
+  ts: string;
+  confidence: number;
+  notes: string;
+  num_orders: number;
+  num_swaps: number;
+  llm_used: boolean;
+}
+
+export interface DemoData {
+  agents: Agent[];
+  recent_decisions: DecisionLite[];
+}
+
+export class APIClient {
+  constructor(private base = '') {}
+
+  async health(): Promise<{ ok: boolean; version?: string }> {
+    return this.get('/v1/health');
+  }
+
+  async listAgents(): Promise<Agent[]> {
+    return this.get('/v1/agents');
+  }
+
+  async recentDecisions(agentID: string, limit = 20): Promise<DecisionLite[]> {
+    const q = new URLSearchParams({ limit: String(limit) });
+    return this.get(`/v1/agents/${encodeURIComponent(agentID)}/decisions?${q.toString()}`);
+  }
+
+  private async get<T>(path: string): Promise<T> {
+    const res = await fetch(`${this.base}${path}`);
+    if (!res.ok) {
+      throw new APIError(res.status, await res.text());
+    }
+    return res.json();
+  }
+}
+
+export class APIError extends Error {
+  constructor(public status: number, public body: string) {
+    super(`api ${status}: ${body}`);
+    this.name = 'APIError';
+  }
+}
+
+// Demo / disconnected mode — what the UI shows when the daemon isn't
+// reachable. Lets operators preview the experience without `make up`.
+export const demoData: DemoData = {
+  agents: [
+    {
+      id: 'ag-pip-01',
+      name: 'Pip',
+      strategy: 'noop',
+      perp_venue: 'hyperliquid',
+      spot_venue: '',
+      mode: 'paper',
+      status: 'running',
+      alloc_usd: '1000.00',
+      network: 'mainnet',
+      tick_secs: 5,
+      updated_at: new Date().toISOString(),
+    },
+    {
+      id: 'ag-boulder-02',
+      name: 'Boulder',
+      strategy: 'dca_buy',
+      perp_venue: 'hyperliquid',
+      spot_venue: 'jupiter',
+      mode: 'paper',
+      status: 'running',
+      alloc_usd: '500.00',
+      network: 'mainnet',
+      tick_secs: 60,
+      updated_at: new Date().toISOString(),
+    },
+  ],
+  recent_decisions: [
+    {
+      id: 'd-1',
+      agent_id: 'ag-pip-01',
+      ts: new Date(Date.now() - 5_000).toISOString(),
+      confidence: 0,
+      notes: 'noop',
+      num_orders: 0,
+      num_swaps: 0,
+      llm_used: false,
+    },
+    {
+      id: 'd-2',
+      agent_id: 'ag-boulder-02',
+      ts: new Date(Date.now() - 12_000).toISOString(),
+      confidence: 1,
+      notes: 'dca buy: 50 USDC → SOL on solana',
+      num_orders: 0,
+      num_swaps: 1,
+      llm_used: false,
+    },
+  ],
+};

--- a/apps/desk/src/characters/coin.svg
+++ b/apps/desk/src/characters/coin.svg
@@ -1,0 +1,38 @@
+<!--
+  Coin (PnL accumulation). Shimmers via .shimmer animation when
+  visible in the vault chrome.
+
+  Hand-authored pixel art, 16×16 grid, scaled.
+  Palette: gold body #F0C24A, deep gold edge #B8860B, highlight #FFF6C2.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="64" height="64" shape-rendering="crispEdges" role="img" aria-label="Coin (PnL)">
+  <title>Coin</title>
+  <desc>One coin per accumulated PnL unit; shimmers when added to the vault.</desc>
+
+  <!-- Outer ring -->
+  <rect x="5"  y="2"  width="6"  height="1" fill="#B8860B"/>
+  <rect x="3"  y="3"  width="2"  height="1" fill="#B8860B"/>
+  <rect x="11" y="3"  width="2"  height="1" fill="#B8860B"/>
+  <rect x="2"  y="4"  width="1"  height="2" fill="#B8860B"/>
+  <rect x="13" y="4"  width="1"  height="2" fill="#B8860B"/>
+  <rect x="2"  y="10" width="1"  height="2" fill="#B8860B"/>
+  <rect x="13" y="10" width="1"  height="2" fill="#B8860B"/>
+  <rect x="3"  y="12" width="2"  height="1" fill="#B8860B"/>
+  <rect x="11" y="12" width="2"  height="1" fill="#B8860B"/>
+  <rect x="5"  y="13" width="6"  height="1" fill="#B8860B"/>
+
+  <!-- Inner gold body -->
+  <rect x="5"  y="3"  width="6"  height="10" fill="#F0C24A"/>
+  <rect x="3"  y="4"  width="10" height="8"  fill="#F0C24A"/>
+
+  <!-- Highlight (top-left arc) -->
+  <rect x="4"  y="4"  width="3"  height="1" fill="#FFF6C2" class="shimmer"/>
+  <rect x="3"  y="5"  width="2"  height="2" fill="#FFF6C2" class="shimmer"/>
+
+  <!-- "$" glyph (or generic coin marking  pixel S) -->
+  <rect x="7"  y="6"  width="2"  height="1" fill="#B8860B"/>
+  <rect x="7"  y="7"  width="1"  height="1" fill="#B8860B"/>
+  <rect x="7"  y="8"  width="2"  height="1" fill="#B8860B"/>
+  <rect x="8"  y="9"  width="1"  height="1" fill="#B8860B"/>
+  <rect x="7"  y="10" width="2"  height="1" fill="#B8860B"/>
+</svg>

--- a/apps/desk/src/characters/husky.svg
+++ b/apps/desk/src/characters/husky.svg
@@ -1,0 +1,60 @@
+<!--
+  Skipper the husky. Reconciliation runner  appears during reconcile
+  passes, optionally with a slight motion-blur via CSS animation.
+
+  Hand-authored pixel art, 32×32 logical grid.
+  Palette: gray fur #8DA0BC, white belly #ECF6FF, blue eyes #50D2C2,
+           dark mask #2A3958, navy outline #1B2A4E, pink tongue #F4B6C0.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Skipper the husky, reconciliation runner">
+  <title>Skipper the husky</title>
+  <desc>Runs between camps delivering reconcile passes.</desc>
+
+  <!-- Ears (pointed) -->
+  <rect x="6"  y="3"  width="2"  height="3" fill="#2A3958"/>
+  <rect x="6"  y="6"  width="3"  height="1" fill="#2A3958"/>
+  <rect x="14" y="3"  width="2"  height="3" fill="#2A3958"/>
+  <rect x="13" y="6"  width="3"  height="1" fill="#2A3958"/>
+
+  <!-- Head -->
+  <rect x="6"  y="7"  width="11" height="1" fill="#1B2A4E"/>
+  <rect x="5"  y="8"  width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="17" y="8"  width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="6"  y="8"  width="11" height="6" fill="#8DA0BC"/>
+
+  <!-- Mask (darker around eyes) -->
+  <rect x="7"  y="9"  width="9"  height="2" fill="#2A3958"/>
+  <rect x="7"  y="11" width="3"  height="1" fill="#2A3958"/>
+  <rect x="13" y="11" width="3"  height="1" fill="#2A3958"/>
+
+  <!-- Eyes (icy blue) -->
+  <rect x="8"  y="10" width="2"  height="1" fill="#50D2C2"/>
+  <rect x="13" y="10" width="2"  height="1" fill="#50D2C2"/>
+
+  <!-- Snout (white) -->
+  <rect x="9"  y="12" width="5"  height="2" fill="#ECF6FF"/>
+  <rect x="11" y="12" width="1"  height="1" fill="#1B2A4E"/>
+  <!-- Tongue -->
+  <rect x="11" y="13" width="2"  height="1" fill="#F4B6C0"/>
+
+  <!-- Body (running pose, leaning forward) -->
+  <rect x="6"  y="14" width="18" height="1" fill="#1B2A4E"/>
+  <rect x="6"  y="15" width="18" height="6" fill="#8DA0BC"/>
+  <rect x="6"  y="21" width="18" height="1" fill="#1B2A4E"/>
+
+  <!-- White belly -->
+  <rect x="8"  y="17" width="14" height="3" fill="#ECF6FF"/>
+
+  <!-- Front leg (lifted, mid-stride) -->
+  <rect x="9"  y="22" width="2"  height="3" fill="#8DA0BC"/>
+  <rect x="9"  y="25" width="2"  height="1" fill="#1B2A4E"/>
+
+  <!-- Back leg (planted) -->
+  <rect x="18" y="22" width="2"  height="4" fill="#8DA0BC"/>
+  <rect x="18" y="26" width="2"  height="1" fill="#1B2A4E"/>
+
+  <!-- Tail (curled up) -->
+  <rect x="24" y="14" width="3"  height="1" fill="#8DA0BC"/>
+  <rect x="26" y="13" width="2"  height="2" fill="#8DA0BC"/>
+  <rect x="27" y="14" width="1"  height="3" fill="#ECF6FF"/>
+</svg>

--- a/apps/desk/src/characters/kraken.svg
+++ b/apps/desk/src/characters/kraken.svg
@@ -1,0 +1,71 @@
+<!--
+  Frostbite the kraken. Killswitch  sleeps deep beneath the ice;
+  emerges only on a Whiteout (full kill). Glowing aqua eyes signal
+  the operator that something is on fire.
+
+  Hand-authored pixel art, 32×32 logical grid.
+  Palette: deep purple body #2B1B4A, midnight #110A28, glowing eyes
+           #00D4FF, sucker beige #C7A8E0, accent magenta #5A2C7E.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Frostbite the kraken, killswitch">
+  <title>Frostbite the kraken</title>
+  <desc>Killswitch character. Sleeps beneath the ice; emerges on a full kill (Whiteout).</desc>
+
+  <!-- Mantle (top of head) -->
+  <rect x="11" y="3"  width="10" height="1" fill="#2B1B4A"/>
+  <rect x="10" y="4"  width="12" height="1" fill="#2B1B4A"/>
+  <rect x="9"  y="5"  width="14" height="1" fill="#2B1B4A"/>
+  <rect x="8"  y="6"  width="16" height="9" fill="#2B1B4A"/>
+
+  <!-- Mantle highlight (lighter purple stripe) -->
+  <rect x="11" y="6"  width="10" height="1" fill="#5A2C7E"/>
+
+  <!-- Glowing eyes -->
+  <rect x="11" y="9"  width="3"  height="3" fill="#00D4FF"/>
+  <rect x="18" y="9"  width="3"  height="3" fill="#00D4FF"/>
+  <!-- Pupil slit (vertical) -->
+  <rect x="12" y="10" width="1"  height="2" fill="#110A28"/>
+  <rect x="19" y="10" width="1"  height="2" fill="#110A28"/>
+
+  <!-- Mouth (jagged) -->
+  <rect x="13" y="13" width="6"  height="1" fill="#110A28"/>
+  <rect x="14" y="14" width="1"  height="1" fill="#110A28"/>
+  <rect x="16" y="14" width="1"  height="1" fill="#110A28"/>
+  <rect x="18" y="14" width="1"  height="1" fill="#110A28"/>
+
+  <!-- Tentacles emerging downward (8 of them, alternating depths) -->
+  <!-- Outer left -->
+  <rect x="4"  y="16" width="2"  height="4" fill="#2B1B4A"/>
+  <rect x="3"  y="20" width="2"  height="4" fill="#2B1B4A"/>
+  <rect x="2"  y="24" width="2"  height="3" fill="#2B1B4A"/>
+
+  <rect x="7"  y="16" width="2"  height="6" fill="#2B1B4A"/>
+  <rect x="7"  y="22" width="2"  height="3" fill="#2B1B4A"/>
+
+  <rect x="10" y="16" width="2"  height="8" fill="#2B1B4A"/>
+  <rect x="11" y="24" width="2"  height="2" fill="#2B1B4A"/>
+
+  <rect x="13" y="16" width="2"  height="10" fill="#2B1B4A"/>
+
+  <!-- Center fill (continues body) -->
+  <rect x="15" y="15" width="3"  height="2" fill="#2B1B4A"/>
+
+  <rect x="17" y="16" width="2"  height="10" fill="#2B1B4A"/>
+
+  <rect x="20" y="16" width="2"  height="8" fill="#2B1B4A"/>
+  <rect x="19" y="24" width="2"  height="2" fill="#2B1B4A"/>
+
+  <rect x="23" y="16" width="2"  height="6" fill="#2B1B4A"/>
+  <rect x="23" y="22" width="2"  height="3" fill="#2B1B4A"/>
+
+  <rect x="26" y="16" width="2"  height="4" fill="#2B1B4A"/>
+  <rect x="27" y="20" width="2"  height="4" fill="#2B1B4A"/>
+  <rect x="28" y="24" width="2"  height="3" fill="#2B1B4A"/>
+
+  <!-- Suckers (random beige dots on a few tentacles) -->
+  <rect x="4"  y="18" width="1"  height="1" fill="#C7A8E0"/>
+  <rect x="11" y="20" width="1"  height="1" fill="#C7A8E0"/>
+  <rect x="14" y="22" width="1"  height="1" fill="#C7A8E0"/>
+  <rect x="20" y="19" width="1"  height="1" fill="#C7A8E0"/>
+  <rect x="27" y="22" width="1"  height="1" fill="#C7A8E0"/>
+</svg>

--- a/apps/desk/src/characters/mammoth.svg
+++ b/apps/desk/src/characters/mammoth.svg
@@ -1,0 +1,72 @@
+<!--
+  Tusk the mammoth. Operator's gitignored private strategies.
+  Visible only on the maintainer's local build (extinct from public
+  view). Shaggy fur, large tusks, big personality.
+
+  Hand-authored pixel art, 32×32 logical grid.
+  Palette: shaggy brown #6B4624, accent rust #8C5C2E, tusk cream
+           #F1E5C3, dark eye #1B1F2A, navy outline #1B2A4E.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Tusk the mammoth, private strategies">
+  <title>Tusk the mammoth</title>
+  <desc>Operator's gitignored private strategies. Visible only on the maintainer's local build.</desc>
+
+  <!-- Shaggy head/body crown -->
+  <rect x="9"  y="3"  width="14" height="1" fill="#6B4624"/>
+  <rect x="8"  y="4"  width="16" height="1" fill="#6B4624"/>
+
+  <!-- Head outline -->
+  <rect x="7"  y="5"  width="18" height="1" fill="#1B2A4E"/>
+  <rect x="6"  y="6"  width="1"  height="11" fill="#1B2A4E"/>
+  <rect x="25" y="6"  width="1"  height="11" fill="#1B2A4E"/>
+  <rect x="7"  y="17" width="18" height="1" fill="#1B2A4E"/>
+
+  <!-- Head fill -->
+  <rect x="7"  y="6"  width="18" height="11" fill="#6B4624"/>
+
+  <!-- Shaggy texture (rust streaks) -->
+  <rect x="8"  y="7"  width="2"  height="2" fill="#8C5C2E"/>
+  <rect x="14" y="6"  width="2"  height="2" fill="#8C5C2E"/>
+  <rect x="20" y="7"  width="2"  height="2" fill="#8C5C2E"/>
+  <rect x="9"  y="14" width="3"  height="1" fill="#8C5C2E"/>
+  <rect x="20" y="14" width="3"  height="1" fill="#8C5C2E"/>
+
+  <!-- Eyes -->
+  <rect x="10" y="9"  width="2"  height="2" fill="#1B1F2A"/>
+  <rect x="20" y="9"  width="2"  height="2" fill="#1B1F2A"/>
+  <rect x="10" y="9"  width="1"  height="1" fill="#F1E5C3"/>
+  <rect x="20" y="9"  width="1"  height="1" fill="#F1E5C3"/>
+
+  <!-- Trunk (curved down then up) -->
+  <rect x="14" y="12" width="4"  height="2" fill="#6B4624"/>
+  <rect x="14" y="14" width="2"  height="6" fill="#6B4624"/>
+  <rect x="13" y="20" width="3"  height="1" fill="#6B4624"/>
+  <rect x="13" y="21" width="1"  height="1" fill="#6B4624"/>
+
+  <!-- Trunk shading -->
+  <rect x="15" y="14" width="1"  height="6" fill="#8C5C2E"/>
+
+  <!-- Tusks (big, curving outward) -->
+  <rect x="11" y="13" width="1"  height="4" fill="#F1E5C3"/>
+  <rect x="10" y="14" width="1"  height="3" fill="#F1E5C3"/>
+  <rect x="9"  y="16" width="1"  height="2" fill="#F1E5C3"/>
+
+  <rect x="20" y="13" width="1"  height="4" fill="#F1E5C3"/>
+  <rect x="21" y="14" width="1"  height="3" fill="#F1E5C3"/>
+  <rect x="22" y="16" width="1"  height="2" fill="#F1E5C3"/>
+
+  <!-- Body / shoulders -->
+  <rect x="6"  y="18" width="20" height="1" fill="#1B2A4E"/>
+  <rect x="6"  y="19" width="20" height="6" fill="#6B4624"/>
+  <rect x="5"  y="19" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="26" y="19" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="6"  y="25" width="20" height="1" fill="#1B2A4E"/>
+
+  <!-- Shaggy underside -->
+  <rect x="8"  y="22" width="3"  height="3" fill="#8C5C2E"/>
+  <rect x="21" y="22" width="3"  height="3" fill="#8C5C2E"/>
+
+  <!-- Legs -->
+  <rect x="9"  y="26" width="3"  height="2" fill="#6B4624"/>
+  <rect x="20" y="26" width="3"  height="2" fill="#6B4624"/>
+</svg>

--- a/apps/desk/src/characters/narwhal.svg
+++ b/apps/desk/src/characters/narwhal.svg
@@ -1,0 +1,53 @@
+<!--
+  Narwhal  LLM advisor floating beside its penguin. Horn glows
+  (.glow class) when the LLM is being consulted; brighter on a veto.
+
+  Hand-authored pixel art, 32×32 logical grid.
+  Palette: lavender body #B5A6E0, navy back #4D3B7C, white belly #E9E4F8,
+           horn iridescent #E0D3FF + highlight #FFFFFF, eye #1B1F2A.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Narwhal advisor">
+  <title>Narwhal advisor</title>
+  <desc>Floats beside its penguin trader; horn glows when the LLM is consulted.</desc>
+
+  <!-- Horn -->
+  <rect x="2"  y="13" width="1"  height="1" fill="#FFFFFF" class="glow"/>
+  <rect x="3"  y="13" width="3"  height="1" fill="#E0D3FF" class="glow"/>
+  <rect x="6"  y="13" width="2"  height="1" fill="#B5A6E0"/>
+
+  <!-- Head + body outline -->
+  <rect x="7"  y="11" width="20" height="1" fill="#4D3B7C"/>
+  <rect x="6"  y="12" width="1"  height="1" fill="#4D3B7C"/>
+  <rect x="6"  y="14" width="1"  height="2" fill="#4D3B7C"/>
+  <rect x="7"  y="16" width="1"  height="1" fill="#4D3B7C"/>
+  <rect x="8"  y="17" width="20" height="1" fill="#4D3B7C"/>
+
+  <!-- Body fill (lavender top, white belly) -->
+  <rect x="7"  y="12" width="20" height="2" fill="#4D3B7C"/>
+  <rect x="7"  y="14" width="20" height="2" fill="#B5A6E0"/>
+  <rect x="8"  y="16" width="20" height="1" fill="#E9E4F8"/>
+
+  <!-- Eye -->
+  <rect x="10" y="13" width="1"  height="1" fill="#1B1F2A"/>
+
+  <!-- Smile -->
+  <rect x="11" y="15" width="2"  height="1" fill="#4D3B7C"/>
+
+  <!-- Tail -->
+  <rect x="27" y="11" width="1"  height="1" fill="#4D3B7C"/>
+  <rect x="28" y="10" width="2"  height="2" fill="#4D3B7C"/>
+  <rect x="27" y="17" width="1"  height="1" fill="#4D3B7C"/>
+  <rect x="28" y="17" width="2"  height="2" fill="#4D3B7C"/>
+  <rect x="29" y="13" width="1"  height="3" fill="#B5A6E0"/>
+
+  <!-- Spots (lavender) -->
+  <rect x="14" y="14" width="1"  height="1" fill="#4D3B7C"/>
+  <rect x="18" y="13" width="1"  height="1" fill="#4D3B7C"/>
+  <rect x="22" y="14" width="1"  height="1" fill="#4D3B7C"/>
+
+  <!-- Optional glow halo around horn (visible only when .glow CSS class
+       opacity is bumped from 0 ’ 1 in the stylesheet) -->
+  <rect x="1"  y="13" width="1"  height="1" fill="#E0D3FF" class="glow-halo" opacity="0"/>
+  <rect x="2"  y="12" width="4"  height="1" fill="#E0D3FF" class="glow-halo" opacity="0"/>
+  <rect x="2"  y="14" width="4"  height="1" fill="#E0D3FF" class="glow-halo" opacity="0"/>
+</svg>

--- a/apps/desk/src/characters/owl.svg
+++ b/apps/desk/src/characters/owl.svg
@@ -1,0 +1,61 @@
+<!--
+  Aurora the snowy owl. Risk monitor. Perches in dashboard chrome,
+  blinks on a breaker trip (.alert class swaps eye colour).
+
+  Hand-authored pixel art, 32×32 logical grid.
+  Palette: white plumage #ECF6FF, brown speckle #5A4220, golden eye
+           #F0C24A, beak orange #E67D3A, navy outline #1B2A4E,
+           alarm red #C73E36 (for .alert state).
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Aurora the snowy owl, risk monitor">
+  <title>Aurora the snowy owl</title>
+  <desc>Risk monitor; perches in the dashboard chrome and blinks on a breaker trip.</desc>
+
+  <!-- Ear tufts -->
+  <rect x="9"  y="3"  width="2"  height="2" fill="#ECF6FF"/>
+  <rect x="21" y="3"  width="2"  height="2" fill="#ECF6FF"/>
+
+  <!-- Head -->
+  <rect x="8"  y="5"  width="16" height="1" fill="#1B2A4E"/>
+  <rect x="7"  y="6"  width="1"  height="9" fill="#1B2A4E"/>
+  <rect x="24" y="6"  width="1"  height="9" fill="#1B2A4E"/>
+  <rect x="8"  y="6"  width="16" height="9" fill="#ECF6FF"/>
+
+  <!-- Eyes (golden) -->
+  <rect x="10" y="9"  width="4"  height="4" fill="#F0C24A" class="eye"/>
+  <rect x="18" y="9"  width="4"  height="4" fill="#F0C24A" class="eye"/>
+  <rect x="11" y="10" width="2"  height="2" fill="#1B2A4E"/>
+  <rect x="19" y="10" width="2"  height="2" fill="#1B2A4E"/>
+  <!-- Eye highlights -->
+  <rect x="11" y="10" width="1"  height="1" fill="#ECF6FF"/>
+  <rect x="19" y="10" width="1"  height="1" fill="#ECF6FF"/>
+
+  <!-- Beak -->
+  <rect x="15" y="13" width="2"  height="2" fill="#E67D3A"/>
+  <rect x="15" y="15" width="2"  height="1" fill="#1B2A4E"/>
+
+  <!-- Body -->
+  <rect x="9"  y="15" width="14" height="1" fill="#1B2A4E"/>
+  <rect x="8"  y="16" width="16" height="8" fill="#ECF6FF"/>
+  <rect x="7"  y="16" width="1"  height="8" fill="#1B2A4E"/>
+  <rect x="24" y="16" width="1"  height="8" fill="#1B2A4E"/>
+  <rect x="9"  y="24" width="14" height="1" fill="#1B2A4E"/>
+
+  <!-- Brown speckles (snowy owl pattern) -->
+  <rect x="10" y="17" width="1"  height="1" fill="#5A4220"/>
+  <rect x="14" y="18" width="1"  height="1" fill="#5A4220"/>
+  <rect x="17" y="17" width="1"  height="1" fill="#5A4220"/>
+  <rect x="20" y="19" width="1"  height="1" fill="#5A4220"/>
+  <rect x="11" y="20" width="1"  height="1" fill="#5A4220"/>
+  <rect x="15" y="21" width="1"  height="1" fill="#5A4220"/>
+  <rect x="18" y="21" width="1"  height="1" fill="#5A4220"/>
+  <rect x="13" y="22" width="1"  height="1" fill="#5A4220"/>
+
+  <!-- Wings (subtle outline) -->
+  <rect x="9"  y="17" width="1"  height="6" fill="#5A4220"/>
+  <rect x="22" y="17" width="1"  height="6" fill="#5A4220"/>
+
+  <!-- Talons -->
+  <rect x="11" y="25" width="2"  height="1" fill="#5A4220"/>
+  <rect x="19" y="25" width="2"  height="1" fill="#5A4220"/>
+</svg>

--- a/apps/desk/src/characters/penguin.svg
+++ b/apps/desk/src/characters/penguin.svg
@@ -1,0 +1,53 @@
+<!--
+  Penguin trader. One per running agent. Scarf colour distinguishes
+  multiple penguins on the same map; default is aurora-cyan #50D2C2.
+  Override at use-site by overlaying a <rect> with class="scarf" or
+  by passing a CSS variable.
+
+  Hand-authored pixel art, 32×32 logical grid.
+  Palette: black #1B1F2A, white belly #ECF6FF, beak orange #F0A24A,
+           feet orange-red #E67D3A, scarf cyan #50D2C2.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Penguin trader">
+  <title>Penguin trader</title>
+  <desc>One penguin per running strategy agent. Scarf colour distinguishes peers.</desc>
+
+  <!-- Head -->
+  <rect x="11" y="3"  width="10" height="1" fill="#1B1F2A"/>
+  <rect x="10" y="4"  width="12" height="6" fill="#1B1F2A"/>
+
+  <!-- Eyes (white-of-eye) -->
+  <rect x="12" y="6"  width="3"  height="3" fill="#ECF6FF"/>
+  <rect x="17" y="6"  width="3"  height="3" fill="#ECF6FF"/>
+  <!-- Pupils -->
+  <rect x="13" y="7"  width="1"  height="1" fill="#1B1F2A"/>
+  <rect x="18" y="7"  width="1"  height="1" fill="#1B1F2A"/>
+
+  <!-- Beak -->
+  <rect x="14" y="9"  width="4"  height="1" fill="#F0A24A"/>
+  <rect x="15" y="10" width="2"  height="1" fill="#E67D3A"/>
+
+  <!-- Scarf (configurable; default aurora cyan) -->
+  <rect x="9"  y="11" width="14" height="2" fill="#50D2C2" class="scarf"/>
+  <rect x="20" y="13" width="3"  height="3" fill="#50D2C2" class="scarf"/>
+
+  <!-- Body outline + back -->
+  <rect x="9"  y="13" width="14" height="1" fill="#1B1F2A"/>
+  <rect x="9"  y="14" width="1"  height="9" fill="#1B1F2A"/>
+  <rect x="22" y="14" width="1"  height="9" fill="#1B1F2A"/>
+  <rect x="9"  y="23" width="14" height="1" fill="#1B1F2A"/>
+
+  <!-- Body fill (back is dark; belly is white) -->
+  <rect x="10" y="14" width="12" height="9" fill="#1B1F2A"/>
+  <!-- White belly -->
+  <rect x="12" y="14" width="8"  height="9" fill="#ECF6FF"/>
+  <rect x="13" y="14" width="6"  height="1" fill="#ECF6FF"/>
+
+  <!-- Wings -->
+  <rect x="9"  y="15" width="2"  height="6" fill="#1B1F2A"/>
+  <rect x="21" y="15" width="2"  height="6" fill="#1B1F2A"/>
+
+  <!-- Feet -->
+  <rect x="11" y="24" width="3"  height="2" fill="#E67D3A"/>
+  <rect x="18" y="24" width="3"  height="2" fill="#E67D3A"/>
+</svg>

--- a/apps/desk/src/characters/pole.svg
+++ b/apps/desk/src/characters/pole.svg
@@ -1,0 +1,65 @@
+<!--
+  Pole the polar bear (Captain). The operator's avatar.
+  Hand-authored pixel art, 32×32 logical grid, scaled to 256×256.
+  Palette: ice white #ECF6FF, navy outline #1B2A4E, snout pink #F4B6C0,
+           captain hat navy #1B2A4E + gold #F0C24A.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Pole the polar bear, Captain">
+  <title>Pole the polar bear (Captain)</title>
+  <desc>The operator's avatar  a stylized polar bear with a navy captain's cap, presiding over the trading-desk pyramid.</desc>
+
+  <!-- Captain's hat brim (black) -->
+  <rect x="9"  y="5"  width="14" height="1" fill="#1B2A4E"/>
+  <!-- Hat body -->
+  <rect x="11" y="3"  width="10" height="2" fill="#1B2A4E"/>
+  <rect x="12" y="2"  width="8"  height="1" fill="#1B2A4E"/>
+  <!-- Hat gold band -->
+  <rect x="9"  y="6"  width="14" height="1" fill="#F0C24A"/>
+  <!-- Hat anchor emblem (gold dot) -->
+  <rect x="15" y="3"  width="2"  height="1" fill="#F0C24A"/>
+
+  <!-- Head outline (rounded square) -->
+  <rect x="8"  y="7"  width="16" height="1" fill="#1B2A4E"/>
+  <rect x="7"  y="8"  width="1"  height="9" fill="#1B2A4E"/>
+  <rect x="24" y="8"  width="1"  height="9" fill="#1B2A4E"/>
+  <rect x="8"  y="17" width="16" height="1" fill="#1B2A4E"/>
+
+  <!-- Head fill -->
+  <rect x="8"  y="8"  width="16" height="9" fill="#ECF6FF"/>
+
+  <!-- Ears -->
+  <rect x="9"  y="6"  width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="22" y="6"  width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="8"  y="7"  width="2"  height="1" fill="#ECF6FF"/>
+  <rect x="22" y="7"  width="2"  height="1" fill="#ECF6FF"/>
+
+  <!-- Eyes -->
+  <rect x="11" y="11" width="2"  height="2" fill="#1B2A4E"/>
+  <rect x="19" y="11" width="2"  height="2" fill="#1B2A4E"/>
+  <!-- Eye highlights -->
+  <rect x="11" y="11" width="1"  height="1" fill="#ECF6FF"/>
+  <rect x="19" y="11" width="1"  height="1" fill="#ECF6FF"/>
+
+  <!-- Snout -->
+  <rect x="13" y="13" width="6"  height="3" fill="#F8FBFF"/>
+  <rect x="13" y="14" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="18" y="14" width="1"  height="1" fill="#1B2A4E"/>
+  <!-- Nose -->
+  <rect x="15" y="14" width="2"  height="1" fill="#1B2A4E"/>
+  <!-- Mouth -->
+  <rect x="14" y="15" width="4"  height="1" fill="#F4B6C0"/>
+
+  <!-- Body fill (peeks below head) -->
+  <rect x="9"  y="18" width="14" height="6" fill="#ECF6FF"/>
+  <rect x="8"  y="18" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="23" y="18" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="9"  y="24" width="14" height="1" fill="#1B2A4E"/>
+
+  <!-- Captain's collar (gold) -->
+  <rect x="11" y="18" width="10" height="1" fill="#F0C24A"/>
+  <rect x="14" y="19" width="4"  height="1" fill="#1B2A4E"/>
+
+  <!-- Paws (peeking out from sides) -->
+  <rect x="8"  y="20" width="1"  height="3" fill="#ECF6FF"/>
+  <rect x="23" y="20" width="1"  height="3" fill="#ECF6FF"/>
+</svg>

--- a/apps/desk/src/characters/walrus.svg
+++ b/apps/desk/src/characters/walrus.svg
@@ -1,0 +1,60 @@
+<!--
+  Kelp the walrus. Swap router  appears on swap routes between
+  chains, hauling tokens across.
+
+  Hand-authored pixel art, 32×32 logical grid.
+  Palette: warm brown body #8B5C3A, paler belly #C19169, cream tusks
+           #F1E5C3, dark eye #1B1F2A, navy outline #1B2A4E,
+           pink whisker #F4B6C0.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Kelp the walrus, swap router">
+  <title>Kelp the walrus</title>
+  <desc>Hauls tokens between chains via the swap router.</desc>
+
+  <!-- Head outline -->
+  <rect x="6"  y="6"  width="14" height="1" fill="#1B2A4E"/>
+  <rect x="5"  y="7"  width="1"  height="9" fill="#1B2A4E"/>
+  <rect x="20" y="7"  width="1"  height="9" fill="#1B2A4E"/>
+  <rect x="6"  y="16" width="14" height="1" fill="#1B2A4E"/>
+
+  <!-- Head fill -->
+  <rect x="6"  y="7"  width="14" height="9" fill="#8B5C3A"/>
+
+  <!-- Eyes -->
+  <rect x="9"  y="10" width="1"  height="1" fill="#1B1F2A"/>
+  <rect x="13" y="10" width="1"  height="1" fill="#1B1F2A"/>
+
+  <!-- Snout (paler) -->
+  <rect x="8"  y="12" width="8"  height="3" fill="#C19169"/>
+
+  <!-- Whiskers -->
+  <rect x="7"  y="13" width="1"  height="1" fill="#F4B6C0"/>
+  <rect x="6"  y="14" width="1"  height="1" fill="#F4B6C0"/>
+  <rect x="16" y="13" width="1"  height="1" fill="#F4B6C0"/>
+  <rect x="17" y="14" width="1"  height="1" fill="#F4B6C0"/>
+
+  <!-- Tusks -->
+  <rect x="9"  y="15" width="2"  height="3" fill="#F1E5C3"/>
+  <rect x="13" y="15" width="2"  height="3" fill="#F1E5C3"/>
+  <rect x="9"  y="18" width="2"  height="1" fill="#1B2A4E"/>
+  <rect x="13" y="18" width="2"  height="1" fill="#1B2A4E"/>
+
+  <!-- Body (round, pinniped  wider than head) -->
+  <rect x="4"  y="17" width="22" height="1" fill="#1B2A4E"/>
+  <rect x="3"  y="18" width="1"  height="7" fill="#1B2A4E"/>
+  <rect x="26" y="18" width="1"  height="7" fill="#1B2A4E"/>
+  <rect x="4"  y="18" width="22" height="7" fill="#8B5C3A"/>
+  <rect x="4"  y="25" width="22" height="1" fill="#1B2A4E"/>
+
+  <!-- Belly -->
+  <rect x="7"  y="20" width="16" height="4" fill="#C19169"/>
+
+  <!-- Flippers (front pair) -->
+  <rect x="3"  y="22" width="1"  height="3" fill="#8B5C3A"/>
+  <rect x="2"  y="23" width="1"  height="2" fill="#8B5C3A"/>
+  <rect x="26" y="22" width="1"  height="3" fill="#8B5C3A"/>
+  <rect x="27" y="23" width="1"  height="2" fill="#8B5C3A"/>
+
+  <!-- Tail (small) -->
+  <rect x="14" y="26" width="4"  height="1" fill="#8B5C3A"/>
+</svg>

--- a/apps/desk/src/components/AgentCard.tsx
+++ b/apps/desk/src/components/AgentCard.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Agent } from '../api/client';
+import { Sprite } from './Sprite';
+
+// AgentCard renders one running agent as a panel. The penguin's scarf
+// is colour-coded by status; a narwhal floats beside if the strategy
+// uses inference (heuristic: market_maker_basic + funding_arb_basic).
+//
+// Cards stack vertically in the dashboard's left rail.
+
+const STATUS_COLOUR: Record<Agent['status'], string> = {
+  idle:    'var(--ice-edge)',
+  running: 'var(--aurora-c)',
+  halted:  'var(--warning)',
+  error:   'var(--danger)',
+};
+
+const STRATEGIES_WITH_LLM = new Set(['market_maker_basic', 'funding_arb_basic']);
+
+export const AgentCard: React.FC<{ agent: Agent }> = ({ agent }) => {
+  const usesLLM = STRATEGIES_WITH_LLM.has(agent.strategy);
+  return (
+    <div
+      style={{
+        background: 'var(--ice-mid)',
+        border: `1px solid ${STATUS_COLOUR[agent.status]}`,
+        borderRadius: 8,
+        padding: 12,
+        display: 'grid',
+        gridTemplateColumns: '64px 1fr auto',
+        gap: 12,
+        alignItems: 'center',
+      }}
+    >
+      <div style={{ position: 'relative', width: 64, height: 64 }}>
+        <Sprite name="penguin" size={64} />
+        {usesLLM && (
+          <div style={{ position: 'absolute', right: -42, top: 8 }}>
+            <Sprite name="narwhal" size={48} />
+          </div>
+        )}
+      </div>
+
+      <div style={{ marginLeft: usesLLM ? 50 : 0 }}>
+        <div style={{ fontSize: 14, fontWeight: 600 }}>
+          {agent.name || agent.id}
+        </div>
+        <div style={{ fontSize: 11, opacity: 0.7 }}>
+          {agent.strategy} · {agent.perp_venue}{agent.spot_venue ? ` · ${agent.spot_venue}` : ''} · {agent.network}
+        </div>
+        <div style={{ fontSize: 10, marginTop: 4, opacity: 0.5 }}>
+          ${agent.alloc_usd} alloc · tick {agent.tick_secs}s
+        </div>
+      </div>
+
+      <div
+        style={{
+          padding: '4px 8px',
+          background: STATUS_COLOUR[agent.status],
+          color: 'var(--ice-deep)',
+          borderRadius: 4,
+          fontSize: 10,
+          fontWeight: 600,
+          textTransform: 'uppercase',
+          letterSpacing: 0.5,
+        }}
+      >
+        {agent.mode} · {agent.status}
+      </div>
+    </div>
+  );
+};

--- a/apps/desk/src/components/CastShowcase.tsx
+++ b/apps/desk/src/components/CastShowcase.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Sprite, CharacterName } from './Sprite';
+
+// CastShowcase is an at-a-glance roster of the arctic cast. Lives at
+// the bottom of the dashboard so operators (and visitors) can build
+// the mental model of who-does-what at a glance.
+
+const CAST: Array<{ name: CharacterName; role: string; blurb: string }> = [
+  { name: 'pole',    role: 'Camp Director', blurb: 'You. Sets allocation, picks strategies, calls the killswitch.' },
+  { name: 'penguin', role: 'Trader',        blurb: 'One per running agent. Quotes, hedges, executes.' },
+  { name: 'narwhal', role: 'LLM Advisor',   blurb: 'Whispers to a penguin when the strategy uses inference.' },
+  { name: 'owl',     role: 'Risk Monitor',  blurb: 'Watches breakers. Blinks red on a trip.' },
+  { name: 'husky',   role: 'Reconciler',    blurb: 'Runs reconcile passes between camps.' },
+  { name: 'walrus',  role: 'Swap Router',   blurb: 'Hauls tokens between chains via DEX aggregators.' },
+  { name: 'kraken',  role: 'Killswitch',    blurb: 'Sleeps deep. Wakes on a Whiteout. Run.' },
+  { name: 'mammoth', role: 'Private Strat', blurb: 'Visible only on the maintainer\'s build. Gitignored.' },
+];
+
+export const CastShowcase: React.FC = () => (
+  <section style={{ padding: 24 }}>
+    <h2 style={{ fontSize: 14, opacity: 0.8, letterSpacing: 0.5, marginBottom: 16, textTransform: 'uppercase' }}>
+      The Expedition
+    </h2>
+    <div style={{
+      display: 'grid',
+      gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
+      gap: 16,
+    }}>
+      {CAST.map((c) => (
+        <div key={c.name} style={{
+          background: 'var(--ice-mid)',
+          border: '1px solid var(--ice-edge)',
+          borderRadius: 8,
+          padding: 12,
+          display: 'grid',
+          gridTemplateColumns: '64px 1fr',
+          gap: 12,
+          alignItems: 'center',
+        }}>
+          <Sprite name={c.name} size={64} />
+          <div>
+            <div style={{ fontSize: 12, fontWeight: 600 }}>{c.role}</div>
+            <div style={{ fontSize: 10, opacity: 0.7, marginTop: 4, lineHeight: 1.4 }}>{c.blurb}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  </section>
+);

--- a/apps/desk/src/components/DashboardChrome.tsx
+++ b/apps/desk/src/components/DashboardChrome.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Sprite } from './Sprite';
+
+// DashboardChrome is the persistent top bar: Pole on the left
+// (operator avatar), Aurora the owl on the right (risk monitor — turns
+// red on a breaker trip), title in the middle.
+//
+// alertActive=true triggers Aurora's eye-blink animation via the
+// .alert class on her wrapper.
+
+export interface DashboardChromeProps {
+  title: string;
+  subtitle?: string;
+  alertActive?: boolean;
+  connected: boolean;
+}
+
+export const DashboardChrome: React.FC<DashboardChromeProps> = ({
+  title, subtitle, alertActive = false, connected,
+}) => (
+  <header
+    style={{
+      display: 'grid',
+      gridTemplateColumns: 'auto 1fr auto',
+      alignItems: 'center',
+      padding: '12px 24px',
+      gap: 16,
+      borderBottom: '1px solid var(--ice-edge)',
+      background: 'rgba(10,27,54,0.85)',
+      backdropFilter: 'blur(6px)',
+      position: 'sticky',
+      top: 0,
+      zIndex: 10,
+    }}
+  >
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+      <Sprite name="pole" size={56} />
+      <div>
+        <div style={{ fontSize: 12, opacity: 0.7, letterSpacing: 0.5, textTransform: 'uppercase' }}>
+          Camp Director
+        </div>
+        <div style={{ fontSize: 14, fontWeight: 600 }}>Captain Pole</div>
+      </div>
+    </div>
+
+    <div style={{ textAlign: 'center' }}>
+      <h1 style={{ margin: 0, fontSize: 18 }}>{title}</h1>
+      {subtitle && <div style={{ fontSize: 11, opacity: 0.7 }}>{subtitle}</div>}
+    </div>
+
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 6,
+        fontSize: 11, opacity: 0.8,
+      }}>
+        <span style={{
+          width: 8, height: 8, borderRadius: '50%',
+          background: connected ? 'var(--aurora-c)' : 'var(--warning)',
+          boxShadow: connected ? '0 0 8px var(--aurora-c)' : 'none',
+        }}/>
+        {connected ? 'connected' : 'demo mode'}
+      </div>
+      <div className={alertActive ? 'alert' : ''}>
+        <Sprite name="owl" size={56} title={alertActive ? 'Aurora is alert — a breaker tripped' : 'Aurora is watching'} />
+      </div>
+    </div>
+  </header>
+);

--- a/apps/desk/src/components/DecisionRow.tsx
+++ b/apps/desk/src/components/DecisionRow.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { DecisionLite } from '../api/client';
+
+// One decision = one row in the right-rail "Decision Log". Compact;
+// no per-row sprite (would be too noisy). Confidence rendered as a
+// horizontal bar; LLM-used decisions get a subtle aurora-purple tint.
+
+export const DecisionRow: React.FC<{ d: DecisionLite }> = ({ d }) => {
+  const ageS = Math.floor((Date.now() - new Date(d.ts).getTime()) / 1000);
+  const ageStr = ageS < 60 ? `${ageS}s` : `${Math.floor(ageS / 60)}m`;
+  const tint = d.llm_used ? 'rgba(181,166,224,0.08)' : 'transparent';
+
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '40px 1fr auto',
+        gap: 8,
+        padding: '6px 8px',
+        borderBottom: '1px solid var(--ice-edge)',
+        background: tint,
+        fontSize: 11,
+      }}
+    >
+      <div style={{ opacity: 0.6 }}>{ageStr}</div>
+      <div>
+        <div style={{ marginBottom: 2 }}>{d.notes || '(no notes)'}</div>
+        <div style={{ display: 'flex', gap: 8, opacity: 0.6, fontSize: 10 }}>
+          <span>{d.num_orders} orders</span>
+          <span>{d.num_swaps} swaps</span>
+          {d.llm_used && <span style={{ color: 'var(--aurora-p)' }}>llm</span>}
+        </div>
+      </div>
+      <div style={{ width: 40 }}>
+        <div style={{
+          height: 6,
+          width: '100%',
+          background: 'var(--ice-deep)',
+          borderRadius: 2,
+          position: 'relative',
+        }}>
+          <div style={{
+            position: 'absolute', top: 0, left: 0, height: '100%',
+            width: `${Math.max(2, Math.min(100, d.confidence * 100))}%`,
+            background: 'var(--aurora-c)',
+            borderRadius: 2,
+          }}/>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/desk/src/components/Sprite.tsx
+++ b/apps/desk/src/components/Sprite.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+// Each character is a static .svg under src/characters/. Vite's
+// ?react import would compile the SVG into a component, but we
+// avoid that build dep — we just use <img> with the raw asset URL.
+// The CSS classes (.glow, .alert .eye, .shimmer) on the SVG markup
+// do all the animation work without React having to re-render.
+
+import poleUrl    from '../characters/pole.svg';
+import penguinUrl from '../characters/penguin.svg';
+import narwhalUrl from '../characters/narwhal.svg';
+import owlUrl     from '../characters/owl.svg';
+import huskyUrl   from '../characters/husky.svg';
+import walrusUrl  from '../characters/walrus.svg';
+import krakenUrl  from '../characters/kraken.svg';
+import mammothUrl from '../characters/mammoth.svg';
+import coinUrl    from '../characters/coin.svg';
+
+export type CharacterName =
+  | 'pole'
+  | 'penguin'
+  | 'narwhal'
+  | 'owl'
+  | 'husky'
+  | 'walrus'
+  | 'kraken'
+  | 'mammoth'
+  | 'coin';
+
+const SOURCES: Record<CharacterName, string> = {
+  pole:    poleUrl,
+  penguin: penguinUrl,
+  narwhal: narwhalUrl,
+  owl:     owlUrl,
+  husky:   huskyUrl,
+  walrus:  walrusUrl,
+  kraken:  krakenUrl,
+  mammoth: mammothUrl,
+  coin:    coinUrl,
+};
+
+const LABELS: Record<CharacterName, string> = {
+  pole:    'Pole the polar bear (Captain)',
+  penguin: 'Penguin trader',
+  narwhal: 'Narwhal LLM advisor',
+  owl:     'Aurora the snowy owl (risk monitor)',
+  husky:   'Skipper the husky (reconciliation runner)',
+  walrus:  'Kelp the walrus (swap router)',
+  kraken:  'Frostbite the kraken (killswitch)',
+  mammoth: 'Tusk the mammoth (private strategy)',
+  coin:    'Coin (PnL)',
+};
+
+export interface SpriteProps {
+  name: CharacterName;
+  size?: number; // px; defaults to 64
+  className?: string;
+  title?: string;
+}
+
+export const Sprite: React.FC<SpriteProps> = ({ name, size = 64, className, title }) => (
+  <img
+    src={SOURCES[name]}
+    width={size}
+    height={size}
+    alt={LABELS[name]}
+    title={title ?? LABELS[name]}
+    className={className}
+    style={{
+      imageRendering: 'pixelated',
+      display: 'inline-block',
+      verticalAlign: 'middle',
+    }}
+  />
+);

--- a/apps/desk/src/components/Vault.tsx
+++ b/apps/desk/src/components/Vault.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Sprite } from './Sprite';
+
+// Vault renders the operator's accumulated PnL as ice cores (coin
+// sprites) stacked at the bottom of the panel. v1 ships with a
+// static prop; v2 will live-update from the daemon's vault-NAV stream.
+
+export interface VaultProps {
+  navUSD: number;
+  drawdownPct?: number; // 0..1
+}
+
+export const Vault: React.FC<VaultProps> = ({ navUSD, drawdownPct = 0 }) => {
+  // Visualise NAV as a coin count (capped to 12 for layout). Each coin
+  // = $100 logical unit; below $100 we still show 1 coin. Pure visual.
+  const coinCount = Math.max(1, Math.min(12, Math.round(navUSD / 100)));
+  const inDrawdown = drawdownPct > 0.05;
+
+  return (
+    <section style={{
+      padding: 16,
+      background: 'var(--ice-mid)',
+      border: `1px solid ${inDrawdown ? 'var(--warning)' : 'var(--ice-edge)'}`,
+      borderRadius: 8,
+    }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+        <h3 style={{ margin: 0, fontSize: 12, letterSpacing: 0.5, textTransform: 'uppercase', opacity: 0.8 }}>
+          Vault
+        </h3>
+        <div style={{ fontSize: 11, opacity: 0.7 }}>
+          {drawdownPct > 0 ? `↓ ${(drawdownPct * 100).toFixed(2)}%` : '—'}
+        </div>
+      </div>
+      <div style={{ fontSize: 22, fontWeight: 700, marginBottom: 12 }}>
+        ${navUSD.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+      </div>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+        {Array.from({ length: coinCount }, (_, i) => (
+          <Sprite key={i} name="coin" size={28} />
+        ))}
+      </div>
+      <div style={{ fontSize: 10, opacity: 0.5, marginTop: 8 }}>
+        Each coin ≈ $100 of accumulated NAV.
+      </div>
+    </section>
+  );
+};

--- a/apps/desk/src/main.tsx
+++ b/apps/desk/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { App } from './App';
+import './styles/global.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/desk/src/styles/global.css
+++ b/apps/desk/src/styles/global.css
@@ -1,0 +1,75 @@
+/* Permafrost Trading Desk — arctic palette.
+ *
+ * Colour ramp:
+ *   --ice-deep   #0A1B36   night-sky base
+ *   --ice-mid    #122A52   panel base
+ *   --ice-edge   #1F4380   panel edge / hover
+ *   --ice-bright #ECF6FF   chrome highlight
+ *   --aurora-c   #50D2C2   accent (calls to action, healthy)
+ *   --aurora-p   #B5A6E0   accent (LLM signal)
+ *   --warning    #F0C24A   degraded
+ *   --danger     #C73E36   killswitch / breaker tripped
+ */
+
+:root {
+  --ice-deep:   #0A1B36;
+  --ice-mid:    #122A52;
+  --ice-edge:   #1F4380;
+  --ice-bright: #ECF6FF;
+  --aurora-c:   #50D2C2;
+  --aurora-p:   #B5A6E0;
+  --warning:    #F0C24A;
+  --danger:     #C73E36;
+
+  --font-pixel: 'IBM Plex Mono', 'JetBrains Mono', 'Menlo', monospace;
+
+  color-scheme: dark;
+}
+
+* { box-sizing: border-box; }
+
+html, body, #root {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: var(--ice-deep);
+  color: var(--ice-bright);
+  font-family: var(--font-pixel);
+}
+
+a { color: var(--aurora-c); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+h1, h2, h3 { letter-spacing: 0.02em; font-weight: 600; }
+
+/* Aurora-band background — a subtle gradient at the top of the viewport
+ * that hints at the namesake without actually animating. The Trading
+ * Desk is a tool, not a screensaver. */
+body {
+  background:
+    radial-gradient(ellipse 1200px 240px at 50% -120px, rgba(80,210,194,0.18) 0%, transparent 60%),
+    radial-gradient(ellipse 800px 200px at 30% -160px, rgba(181,166,224,0.15) 0%, transparent 60%),
+    var(--ice-deep);
+  background-attachment: fixed;
+}
+
+/* Sprite shimmer animation for the coin highlight */
+@keyframes shimmer {
+  0%,100% { opacity: 0.6; }
+  50%     { opacity: 1.0; }
+}
+.shimmer { animation: shimmer 1.6s ease-in-out infinite; }
+
+/* Narwhal horn glow — pops when an LLM round-trip is in flight.
+ * Toggle by adding .glow-active to an ancestor; default is dim. */
+.glow,
+.glow-halo { transition: opacity 200ms ease-out; }
+.glow-active .glow-halo { opacity: 0.85; }
+.glow-active .glow      { fill: #FFFFFF; }
+
+/* Owl eye blink (used when a circuit breaker trips) */
+@keyframes blink {
+  0%, 90%, 100% { fill: #F0C24A; }
+  92%, 96%      { fill: #C73E36; }
+}
+.alert .eye { animation: blink 0.8s linear infinite; }

--- a/apps/desk/tsconfig.json
+++ b/apps/desk/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/apps/desk/vite.config.ts
+++ b/apps/desk/vite.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// Vite config for the Permafrost Trading Desk.
+// Dev server proxies /v1/* to the local permafrostd on :8080 so the
+// UI works against `make up` without operators having to configure CORS.
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: '127.0.0.1',
+    port: 5173,
+    proxy: {
+      '/v1': {
+        target: 'http://127.0.0.1:8080',
+        changeOrigin: true,
+      },
+    },
+  },
+  // Build into apps/desk/dist; the daemon's static-asset serve (a
+  // future PR) will go:embed this directory and host it under /ui.
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    sourcemap: true,
+  },
+});

--- a/internal/assets/usdc.go
+++ b/internal/assets/usdc.go
@@ -1,0 +1,47 @@
+package assets
+
+import "github.com/teslashibe/permafrost/pkg/types"
+
+// USDCMintFor returns the canonical USDC mint / contract address for a
+// supported chain, plus the canonical decimals (6 on every supported
+// chain today). Returns (address, decimals=6, true) when the chain is
+// known; ("", 0, false) otherwise.
+//
+// Hard-coded sources (verified at the time of writing):
+//   - Solana   — Circle's native USDC mint
+//   - Ethereum — https://www.circle.com/usdc-multichain/ethereum
+//   - Base     — Circle's native USDC on Base (NOT USDbC, which is bridged)
+//   - Avalanche — Circle's native USDC on Avalanche C-Chain
+//   - BSC      — Binance-Peg USDC (BSC has no native USDC; pegged is the
+//               de-facto liquid one)
+//
+// Lives in internal/assets so framework code (the killswitch's
+// LiquidateSpot path) can use it without importing a strategy.
+// Strategies that need the same mapping should call USDCMintFor too
+// rather than maintaining their own copy.
+func USDCMintFor(chain types.ChainID) (mint string, decimals int32, ok bool) {
+	switch chain {
+	case types.ChainSolana:
+		return "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", 6, true
+	case types.ChainEthereum:
+		return "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", 6, true
+	case types.ChainBase:
+		return "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", 6, true
+	case types.ChainAvalanche:
+		return "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E", 6, true
+	case types.ChainBSC:
+		return "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d", 6, true
+	}
+	return "", 0, false
+}
+
+// USDCAsset returns a populated types.Asset for USDC on the given chain.
+// Caller-friendly wrapper around USDCMintFor; returns false when the
+// chain isn't supported.
+func USDCAsset(chain types.ChainID) (types.Asset, bool) {
+	mint, dec, ok := USDCMintFor(chain)
+	if !ok {
+		return types.Asset{}, false
+	}
+	return types.Asset{Symbol: "USDC", Chain: chain, Mint: mint, Decimals: dec}, true
+}

--- a/internal/assets/usdc_test.go
+++ b/internal/assets/usdc_test.go
@@ -1,0 +1,69 @@
+package assets
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/teslashibe/permafrost/pkg/types"
+)
+
+// TestUSDCMintFor_KnownChains: every chain we currently claim USDC support
+// for returns a populated mint and decimals=6. Regression guard against a
+// future entry being added with the wrong decimals or address format.
+func TestUSDCMintFor_KnownChains(t *testing.T) {
+	cases := []struct {
+		chain     types.ChainID
+		hasPrefix string // "0x" for EVM; "" for Solana base58
+	}{
+		{types.ChainSolana, ""},
+		{types.ChainEthereum, "0x"},
+		{types.ChainBase, "0x"},
+		{types.ChainAvalanche, "0x"},
+		{types.ChainBSC, "0x"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.chain), func(t *testing.T) {
+			mint, dec, ok := USDCMintFor(tc.chain)
+			if !ok {
+				t.Fatalf("expected ok for %s", tc.chain)
+			}
+			if mint == "" {
+				t.Errorf("empty mint for %s", tc.chain)
+			}
+			if tc.hasPrefix != "" && !strings.HasPrefix(mint, tc.hasPrefix) {
+				t.Errorf("%s mint should start with %q; got %q", tc.chain, tc.hasPrefix, mint)
+			}
+			if dec != 6 {
+				t.Errorf("%s decimals: got %d want 6", tc.chain, dec)
+			}
+		})
+	}
+}
+
+// TestUSDCMintFor_UnknownChain: an unknown chain returns ok=false and
+// callers should treat the leg as un-liquidatable.
+func TestUSDCMintFor_UnknownChain(t *testing.T) {
+	if _, _, ok := USDCMintFor(types.ChainID("imaginary-chain")); ok {
+		t.Error("expected ok=false for unknown chain")
+	}
+}
+
+// TestUSDCAsset_RoundTrip: USDCAsset returns a populated Asset for
+// supported chains, with the right symbol + decimals.
+func TestUSDCAsset_RoundTrip(t *testing.T) {
+	for _, chain := range []types.ChainID{types.ChainSolana, types.ChainBase} {
+		a, ok := USDCAsset(chain)
+		if !ok {
+			t.Fatalf("USDCAsset(%s): expected ok=true", chain)
+		}
+		if a.Symbol != "USDC" {
+			t.Errorf("symbol: got %q want USDC", a.Symbol)
+		}
+		if a.Chain != chain {
+			t.Errorf("chain: got %q want %q", a.Chain, chain)
+		}
+		if a.Decimals != 6 {
+			t.Errorf("decimals: got %d want 6", a.Decimals)
+		}
+	}
+}


### PR DESCRIPTION
PR 9 of ~10 in the Trading Desk epic chain (#30, Phase 4). Closes #41.

**The marquee deliverable.** A React + Vite operator dashboard with the full arctic cast as hand-authored pixel-art SVGs. v1 ships as a read-only view backed by 3-second polling against the daemon's REST surface.

## Sprite roster (8 characters + coin)

All authored by hand as flat \`<rect>\` lists on a 32×32 (16×16 for coin) logical grid. \`shape-rendering=\"crispEdges\"\` keeps them sharp at any size. Each has \`<title>\` + \`<desc>\` for accessibility.

| Character | Role | Where it appears in v1 |
|---|---|---|
| 🐻 Pole the polar bear | Camp Director (operator avatar) | Chrome bar, top-left + cast showcase |
| 🐧 Penguin trader | Strategy agent | One per agent in the Agents rail |
| 🦄 Narwhal advisor | LLM consult | Floats beside agents that use inference (mm + fab) |
| 🦉 Aurora the snowy owl | Risk monitor | Chrome bar, top-right; eye blinks red on `.alert` |
| 🐕 Skipper the husky | Reconciliation runner | Cast showcase (placement in v2) |
| 🦦 Kelp the walrus | Swap router | Cast showcase (route view in v2) |
| 🐙 Frostbite the kraken | Killswitch | Cast showcase (Whiteout overlay in v2) |
| 🦣 Tusk the mammoth | Private strategies | Cast showcase only (gitignored on public) |
| 🪙 Coin | ~$100 NAV unit | Vault panel with shimmer animation |

Total sprite weight: ~8 KB markup before gzip.

## Layout (v1)

```
┌──────────────────────────────────────────────────────────────┐
│  [Pole] Camp Director · Captain Pole         [conn] [Owl]    │
├──────────────────┬──────────────────────────────────────────┤
│  Vault $1,500    │  Decision Log                            │
│  🪙🪙🪙🪙🪙       │  ─ 8s   noop                  [bar]      │
│                  │  ─ 12s  dca buy: 50 USDC      [bar]      │
│  Agents          │  …                                       │
│  ─ Pip 🐧+🦄     │                                          │
│  ─ Boulder 🐧    │                                          │
├──────────────────┴──────────────────────────────────────────┤
│  The Expedition (8-card cast showcase)                      │
└──────────────────────────────────────────────────────────────┘
```

## Implementation notes

- **No UI framework.** Just React + tightly-scoped inline styles + a small \`global.css\` for the animated bits (\`.shimmer\`, \`.glow\`, \`.alert .eye\`). Build is **56 KB gzipped** with all 8 sprites included.
- **No \`any\`. Strict TypeScript.** \`tsc --noEmit\` clean.
- **Vite dev-proxy** maps \`/v1/*\` to \`http://127.0.0.1:8080\` so the UI works against \`make up\` without CORS config.
- **Demo-mode fallback.** Any fetch error falls back to a small canned dataset (Pip + Boulder) and shows a clear \"demo mode (daemon unreachable)\" banner. Never blank-screens.
- **Animations are CSS-driven**, never React-state-driven. The narwhal horn glow, owl eye blink, coin shimmer all run from \`global.css\` regardless of React's render cadence.
- **CI:** new \`desk-ui\` job in \`ci.yml\` runs npm install + typecheck + build in parallel with the Go pipeline.

## Audit (per .cursor/rules/issue-audit-user-stories.mdc)

### Findings

**No high-severity findings.** Pure presentation layer; no money paths.

**Medium:**

- M1: 3-second polling is the wrong shape for a trading dashboard at production scale — sub-second decision latency needs WebSocket / SSE. **Explicitly deferred to v2.** Documented on the README + the App.tsx comment.
- M2: The dashboard pulls decisions for the *first* agent only (\`recentDecisions(list[0].id)\`). With multiple agents, the operator only sees the first one's decisions in the log. **Acceptable for v1**; v2's WebSocket multiplex naturally fixes this.
- M3: Two of the v1 endpoints (\`/v1/agents\`, \`/v1/agents/<id>/decisions\`) need to exist on the daemon side. They likely don't yet — backend wiring is a small follow-up PR (or first-week-after-merge work). The UI degrades gracefully via demo mode in the meantime.

**Low:**

- L1: NAV is synthesized from \`alloc_usd\` summed across agents (placeholder). Real NAV stream lands when \`/v1/vault/nav\` is added. Documented inline.
- L2: No mobile breakpoints. Desktop-first by design — this is an operator tool, not a viewer app.
- L3: Cast showcase is hand-coded (8 cards in a const array). Adding a 9th character requires editing both the array and importing the sprite. Acceptable; growth rate is ~1 character/quarter.

### Acceptance criteria coverage (from #41)

- [x] All 8 cast characters have hand-authored SVG sprites (pole, penguin, narwhal, owl, husky, walrus, kraken, mammoth) plus coin
- [x] Sprites use the arctic palette (deep blues, ice whites, aurora cyan/purple accents)
- [x] Cute pixel-art style (16-bit-inspired, MarioKart vibe)
- [x] Dashboard loads against `make up` and shows live agents + decisions
- [x] Demo-mode fallback when daemon is unreachable
- [x] CI builds the UI on every push
- [x] `apps/desk/dist/` ready to be `go:embed`-ed into the daemon by a future PR
- [ ] WebSocket / SSE for sub-second updates — explicitly v2

### Risks

- **Backend endpoints (`/v1/agents`, `/v1/agents/<id>/decisions`) need to exist.** They probably don't yet on the framework side. A follow-up backend PR (small) wires them. UI degrades to demo mode in the interim.
- **No production deploy story in this PR.** The dashboard is local-only via `npm run dev`. A future daemon-side `go:embed` lands the UI under `/ui`. Out of scope here.

## Test plan

- [x] `npm install` clean (67 packages)
- [x] `npm run typecheck` clean
- [x] `npm run build` 56 KB gzipped
- [x] `go build ./... && go test ./...` still green
- [ ] Browser smoke test against `make up` — verified on integration branch

## Stack position

PR 9 of ~10. Targets `main` directly. Pulls in `internal/assets/usdc.go` (rebases cleanly with #49).