### PR TITLE
Brand & narrative: arctic cast docs + LLM-as-agent thesis (closes #43)

### DIFF
--- a/apps/docs/docs/brand/cast.md
+++ b/apps/docs/docs/brand/cast.md
@@ -1,0 +1,124 @@
+---
+sidebar_position: 2
+title: The Cast
+---
+
+# The Cast
+
+Permafrost uses an arctic / polar-expedition metaphor for the system.
+Each character represents one piece of the architecture; the visual
+language is consistent across the [Trading Desk UI](https://github.com/teslashibe/permafrost/tree/main/apps/desk),
+the docs, and the CLI's flavour text.
+
+The visual style is deliberately playful — hand-authored pixel art,
+MarioKart-inspired but Nintendo-IP-free. Cute, distinct, immediately
+readable.
+
+## The leadership
+
+### <img src="/img/brand/pole.svg" alt="Pole the polar bear" width="64" height="64" style={{verticalAlign: 'middle'}} /> Pole the polar bear (Captain)
+
+The **Camp Director** — your avatar. Pole presides over the trading
+desk, holds the keystore, sets allocations, picks strategies, and
+calls the killswitch. Top of the hierarchy.
+
+In the UI, Pole sits in the top-left of the dashboard chrome,
+permanently. He's the one constant on every screen.
+
+### <img src="/img/brand/owl.svg" alt="Aurora the snowy owl" width="64" height="64" style={{verticalAlign: 'middle'}} /> Aurora the snowy owl (Risk Monitor)
+
+Aurora perches in the top-right of the dashboard chrome and watches
+the circuit breakers. When a breaker trips — drawdown, daily loss,
+funding flip, RPC degradation — her eyes blink red and the operator
+knows something is wrong before they read the breaker name.
+
+She doesn't *fix* anything; she just sees everything.
+
+## The traders
+
+### <img src="/img/brand/penguin.svg" alt="Penguin trader" width="64" height="64" style={{verticalAlign: 'middle'}} /> Penguin traders
+
+One penguin per running agent. Penguins quote, hedge, execute. Each
+penguin has a coloured scarf to distinguish it from its peers (Pip
+gets aurora-cyan, Boulder gets warm-orange, etc).
+
+Pip is the canonical first agent (the demo wizard creates one on
+first run). Boulder is the canonical second agent (`dca_buy`-style
+patient accumulation).
+
+### <img src="/img/brand/narwhal.svg" alt="Narwhal advisor" width="64" height="64" style={{verticalAlign: 'middle'}} /> Narwhal advisors (LLM)
+
+A narwhal floats beside any penguin whose strategy uses inference.
+When the LLM is being consulted, the narwhal's horn glows; when it
+returns a veto, the horn flashes brighter.
+
+The narwhal is the *visual* form of the [LLM-as-agent](./llm-as-agent)
+thesis: inference is a participant in the decision loop, not a
+standalone module bolted on the side.
+
+## The support staff
+
+### <img src="/img/brand/husky.svg" alt="Skipper the husky" width="64" height="64" style={{verticalAlign: 'middle'}} /> Skipper the husky (Reconciliation)
+
+Runs between camps delivering reconcile passes — comparing the
+framework's view of positions and balances against what the venues
+actually report. Catches drift, missed fills, partial swaps.
+
+### <img src="/img/brand/walrus.svg" alt="Kelp the walrus" width="64" height="64" style={{verticalAlign: 'middle'}} /> Kelp the walrus (Swap Router)
+
+Hauls tokens between chains via the configured DEX aggregators
+(Jupiter on Solana, 1inch on EVM). Big, dependable, can carry a lot.
+
+## The hazards
+
+### <img src="/img/brand/kraken.svg" alt="Frostbite the kraken" width="64" height="64" style={{verticalAlign: 'middle'}} /> Frostbite the kraken (Killswitch)
+
+Sleeps deep beneath the ice. When he wakes, the expedition is over —
+he cancels every open order, flattens every short, and (if
+configured) liquidates every spot leg back to USDC.
+
+You hope to never see Frostbite. When you do see him, the right
+response is to read the killswitch reason and figure out what
+you missed.
+
+The full-screen "Whiteout" overlay (UI v2) is Frostbite emerging.
+
+### <img src="/img/brand/mammoth.svg" alt="Tusk the mammoth" width="64" height="64" style={{verticalAlign: 'middle'}} /> Tusk the mammoth (Private Strategies)
+
+Tusk is *extinct from public view*. The maintainer's gitignored
+strategies under `strategies/private/` are mammoths — present in
+the local build, invisible to the upstream. The visual is a
+permanent reminder that the open-source repo intentionally doesn't
+ship every strategy in production.
+
+If you're reading this on the public docs site, you'll never see a
+mammoth instance in the dashboard. If you're reading this on the
+maintainer's local build, you might.
+
+## The currency
+
+### <img src="/img/brand/coin.svg" alt="Coin" width="32" height="32" style={{verticalAlign: 'middle'}} /> Coins
+
+One coin ≈ $100 of accumulated NAV. The vault panel renders coins
+stacked at the bottom; they shimmer when added.
+
+The coin metaphor predates the rest of the cast — it was always
+going to be there. The arctic theme just gave it a more concrete
+home.
+
+## Why this matters
+
+Trading is dense, fast, and unforgiving. The mental load on the
+operator is enormous — there are dozens of breakers, every venue
+has a different latency profile, the LLM is sometimes saying
+something useful and sometimes filling air. Names and faces compress
+that load.
+
+\"Pip's narwhal vetoed at 14:32\" is one sentence and it tells you:
+- which agent (Pip)
+- that the agent uses inference (narwhal)
+- what happened (veto)
+- when (14:32)
+
+without any of those words being technical jargon. That's the
+whole point.

--- a/apps/docs/docs/brand/llm-as-agent.md
+++ b/apps/docs/docs/brand/llm-as-agent.md
@@ -1,0 +1,82 @@
+---
+sidebar_position: 1
+title: LLM-as-agent
+---
+
+# LLM-as-agent
+
+Permafrost is built on a thesis: the next generation of trading systems
+will treat the LLM not as a feature, but as an **agent** — a first-class
+participant in the decision loop, with structured input, structured
+output, and structured accountability.
+
+## What that means
+
+A traditional algorithmic trading bot has a deterministic policy:
+> "if funding > 50bps and basis > 30bps then short."
+
+A Permafrost strategy can have a deterministic policy *and* a soft
+veto from an LLM that has read the news, the whale flows, the
+policy-maker schedule, and the funding history of the past 30 days.
+
+```
+strategy.Decide(input)
+   │
+   ├─ deterministic check ─────► OK to enter
+   │
+   └─ LLM advisor: "any reason to skip?" ──► JSON {veto:false, reason:"..."}
+                                            │
+                                       enter trade
+```
+
+The LLM doesn't *make* the trade. It vetoes the trade. That's a much
+narrower, much more debuggable role than "ask the AI what to do."
+
+## Why this is the right shape
+
+- **Decision provenance.** Every order links back to (input, prompt,
+  model_id, response). You can replay the LLM call after the fact. No
+  black boxes.
+- **JSON-schema enforcement.** The LLM response is constrained by the
+  provider (OpenRouter / OpenAI / Groq) at the token level. No
+  hallucinated fields, no \"sure, here's a trade\" prose response when
+  you needed a boolean.
+- **Bounded blast radius.** If the LLM is wrong, the worst case is a
+  missed trade. The LLM is never the only thing between the strategy
+  and the venue.
+- **Cost-controlled.** A veto is one round-trip per refresh cycle.
+  At a 60-second tick rate, that's $0.005 per cycle on a cheap model
+  — meaningful but not ruinous.
+
+## Why other shapes fail
+
+**\"Let the LLM generate the trade.\"** Latency and reliability fall
+off a cliff. Costs explode. Provenance becomes \"you asked the model
+and it made up a number.\" When the trade is wrong, the post-mortem
+is unproductive.
+
+**\"Use the LLM for sentiment scoring only.\"** Strictly weaker than
+the veto pattern: a sentiment score still has to be turned into a
+decision rule, and the rule was already what you had.
+
+**\"Train a custom model on your historical trades.\"** Fine, but
+that's an ML pipeline, not an LLM. Permafrost supports both — your
+custom model can speak the same JSON-schema veto interface as a
+hosted LLM. (See [`pkg/inference`](https://github.com/teslashibe/permafrost/tree/main/pkg/inference).)
+
+## The expedition metaphor
+
+We use an arctic / polar-expedition metaphor for the system because
+the literal Permafrost name is begging for it. The operator is the
+**Camp Director** ([Pole the polar bear](./cast)). The strategies are
+**penguin traders** working the ice. Each penguin that uses LLM
+inference has a **narwhal advisor** floating beside it, whose horn
+glows when the LLM is being consulted.
+
+The metaphor is intentionally a little playful. Trading is a serious
+field but it's not a sacred one — and the more concrete the mental
+model, the easier it is to onboard new operators. Pip the penguin
+quoted a bid; Pip's narwhal said \"funding flip in 30 seconds, skip\";
+Pip didn't quote. That's the whole story, told in five seconds.
+
+See [the cast](./cast) for the full character roster.

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -61,6 +61,14 @@ const sidebars: SidebarsConfig = {
         'reference/cli',
       ],
     },
+    {
+      type: 'category',
+      label: 'Brand & Narrative',
+      items: [
+        'brand/llm-as-agent',
+        'brand/cast',
+      ],
+    },
   ],
 };
 

--- a/apps/docs/static/img/brand/coin.svg
+++ b/apps/docs/static/img/brand/coin.svg
@@ -1,0 +1,38 @@
+<!--
+  Coin (PnL accumulation). Shimmers via .shimmer animation when
+  visible in the vault chrome.
+
+  Hand-authored pixel art, 16×16 grid, scaled.
+  Palette: gold body #F0C24A, deep gold edge #B8860B, highlight #FFF6C2.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="64" height="64" shape-rendering="crispEdges" role="img" aria-label="Coin (PnL)">
+  <title>Coin</title>
+  <desc>One coin per accumulated PnL unit; shimmers when added to the vault.</desc>
+
+  <!-- Outer ring -->
+  <rect x="5"  y="2"  width="6"  height="1" fill="#B8860B"/>
+  <rect x="3"  y="3"  width="2"  height="1" fill="#B8860B"/>
+  <rect x="11" y="3"  width="2"  height="1" fill="#B8860B"/>
+  <rect x="2"  y="4"  width="1"  height="2" fill="#B8860B"/>
+  <rect x="13" y="4"  width="1"  height="2" fill="#B8860B"/>
+  <rect x="2"  y="10" width="1"  height="2" fill="#B8860B"/>
+  <rect x="13" y="10" width="1"  height="2" fill="#B8860B"/>
+  <rect x="3"  y="12" width="2"  height="1" fill="#B8860B"/>
+  <rect x="11" y="12" width="2"  height="1" fill="#B8860B"/>
+  <rect x="5"  y="13" width="6"  height="1" fill="#B8860B"/>
+
+  <!-- Inner gold body -->
+  <rect x="5"  y="3"  width="6"  height="10" fill="#F0C24A"/>
+  <rect x="3"  y="4"  width="10" height="8"  fill="#F0C24A"/>
+
+  <!-- Highlight (top-left arc) -->
+  <rect x="4"  y="4"  width="3"  height="1" fill="#FFF6C2" class="shimmer"/>
+  <rect x="3"  y="5"  width="2"  height="2" fill="#FFF6C2" class="shimmer"/>
+
+  <!-- "$" glyph (or generic coin marking  pixel S) -->
+  <rect x="7"  y="6"  width="2"  height="1" fill="#B8860B"/>
+  <rect x="7"  y="7"  width="1"  height="1" fill="#B8860B"/>
+  <rect x="7"  y="8"  width="2"  height="1" fill="#B8860B"/>
+  <rect x="8"  y="9"  width="1"  height="1" fill="#B8860B"/>
+  <rect x="7"  y="10" width="2"  height="1" fill="#B8860B"/>
+</svg>

--- a/apps/docs/static/img/brand/husky.svg
+++ b/apps/docs/static/img/brand/husky.svg
@@ -1,0 +1,60 @@
+<!--
+  Skipper the husky. Reconciliation runner  appears during reconcile
+  passes, optionally with a slight motion-blur via CSS animation.
+
+  Hand-authored pixel art, 32×32 logical grid.
+  Palette: gray fur #8DA0BC, white belly #ECF6FF, blue eyes #50D2C2,
+           dark mask #2A3958, navy outline #1B2A4E, pink tongue #F4B6C0.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Skipper the husky, reconciliation runner">
+  <title>Skipper the husky</title>
+  <desc>Runs between camps delivering reconcile passes.</desc>
+
+  <!-- Ears (pointed) -->
+  <rect x="6"  y="3"  width="2"  height="3" fill="#2A3958"/>
+  <rect x="6"  y="6"  width="3"  height="1" fill="#2A3958"/>
+  <rect x="14" y="3"  width="2"  height="3" fill="#2A3958"/>
+  <rect x="13" y="6"  width="3"  height="1" fill="#2A3958"/>
+
+  <!-- Head -->
+  <rect x="6"  y="7"  width="11" height="1" fill="#1B2A4E"/>
+  <rect x="5"  y="8"  width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="17" y="8"  width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="6"  y="8"  width="11" height="6" fill="#8DA0BC"/>
+
+  <!-- Mask (darker around eyes) -->
+  <rect x="7"  y="9"  width="9"  height="2" fill="#2A3958"/>
+  <rect x="7"  y="11" width="3"  height="1" fill="#2A3958"/>
+  <rect x="13" y="11" width="3"  height="1" fill="#2A3958"/>
+
+  <!-- Eyes (icy blue) -->
+  <rect x="8"  y="10" width="2"  height="1" fill="#50D2C2"/>
+  <rect x="13" y="10" width="2"  height="1" fill="#50D2C2"/>
+
+  <!-- Snout (white) -->
+  <rect x="9"  y="12" width="5"  height="2" fill="#ECF6FF"/>
+  <rect x="11" y="12" width="1"  height="1" fill="#1B2A4E"/>
+  <!-- Tongue -->
+  <rect x="11" y="13" width="2"  height="1" fill="#F4B6C0"/>
+
+  <!-- Body (running pose, leaning forward) -->
+  <rect x="6"  y="14" width="18" height="1" fill="#1B2A4E"/>
+  <rect x="6"  y="15" width="18" height="6" fill="#8DA0BC"/>
+  <rect x="6"  y="21" width="18" height="1" fill="#1B2A4E"/>
+
+  <!-- White belly -->
+  <rect x="8"  y="17" width="14" height="3" fill="#ECF6FF"/>
+
+  <!-- Front leg (lifted, mid-stride) -->
+  <rect x="9"  y="22" width="2"  height="3" fill="#8DA0BC"/>
+  <rect x="9"  y="25" width="2"  height="1" fill="#1B2A4E"/>
+
+  <!-- Back leg (planted) -->
+  <rect x="18" y="22" width="2"  height="4" fill="#8DA0BC"/>
+  <rect x="18" y="26" width="2"  height="1" fill="#1B2A4E"/>
+
+  <!-- Tail (curled up) -->
+  <rect x="24" y="14" width="3"  height="1" fill="#8DA0BC"/>
+  <rect x="26" y="13" width="2"  height="2" fill="#8DA0BC"/>
+  <rect x="27" y="14" width="1"  height="3" fill="#ECF6FF"/>
+</svg>

--- a/apps/docs/static/img/brand/kraken.svg
+++ b/apps/docs/static/img/brand/kraken.svg
@@ -1,0 +1,71 @@
+<!--
+  Frostbite the kraken. Killswitch  sleeps deep beneath the ice;
+  emerges only on a Whiteout (full kill). Glowing aqua eyes signal
+  the operator that something is on fire.
+
+  Hand-authored pixel art, 32×32 logical grid.
+  Palette: deep purple body #2B1B4A, midnight #110A28, glowing eyes
+           #00D4FF, sucker beige #C7A8E0, accent magenta #5A2C7E.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Frostbite the kraken, killswitch">
+  <title>Frostbite the kraken</title>
+  <desc>Killswitch character. Sleeps beneath the ice; emerges on a full kill (Whiteout).</desc>
+
+  <!-- Mantle (top of head) -->
+  <rect x="11" y="3"  width="10" height="1" fill="#2B1B4A"/>
+  <rect x="10" y="4"  width="12" height="1" fill="#2B1B4A"/>
+  <rect x="9"  y="5"  width="14" height="1" fill="#2B1B4A"/>
+  <rect x="8"  y="6"  width="16" height="9" fill="#2B1B4A"/>
+
+  <!-- Mantle highlight (lighter purple stripe) -->
+  <rect x="11" y="6"  width="10" height="1" fill="#5A2C7E"/>
+
+  <!-- Glowing eyes -->
+  <rect x="11" y="9"  width="3"  height="3" fill="#00D4FF"/>
+  <rect x="18" y="9"  width="3"  height="3" fill="#00D4FF"/>
+  <!-- Pupil slit (vertical) -->
+  <rect x="12" y="10" width="1"  height="2" fill="#110A28"/>
+  <rect x="19" y="10" width="1"  height="2" fill="#110A28"/>
+
+  <!-- Mouth (jagged) -->
+  <rect x="13" y="13" width="6"  height="1" fill="#110A28"/>
+  <rect x="14" y="14" width="1"  height="1" fill="#110A28"/>
+  <rect x="16" y="14" width="1"  height="1" fill="#110A28"/>
+  <rect x="18" y="14" width="1"  height="1" fill="#110A28"/>
+
+  <!-- Tentacles emerging downward (8 of them, alternating depths) -->
+  <!-- Outer left -->
+  <rect x="4"  y="16" width="2"  height="4" fill="#2B1B4A"/>
+  <rect x="3"  y="20" width="2"  height="4" fill="#2B1B4A"/>
+  <rect x="2"  y="24" width="2"  height="3" fill="#2B1B4A"/>
+
+  <rect x="7"  y="16" width="2"  height="6" fill="#2B1B4A"/>
+  <rect x="7"  y="22" width="2"  height="3" fill="#2B1B4A"/>
+
+  <rect x="10" y="16" width="2"  height="8" fill="#2B1B4A"/>
+  <rect x="11" y="24" width="2"  height="2" fill="#2B1B4A"/>
+
+  <rect x="13" y="16" width="2"  height="10" fill="#2B1B4A"/>
+
+  <!-- Center fill (continues body) -->
+  <rect x="15" y="15" width="3"  height="2" fill="#2B1B4A"/>
+
+  <rect x="17" y="16" width="2"  height="10" fill="#2B1B4A"/>
+
+  <rect x="20" y="16" width="2"  height="8" fill="#2B1B4A"/>
+  <rect x="19" y="24" width="2"  height="2" fill="#2B1B4A"/>
+
+  <rect x="23" y="16" width="2"  height="6" fill="#2B1B4A"/>
+  <rect x="23" y="22" width="2"  height="3" fill="#2B1B4A"/>
+
+  <rect x="26" y="16" width="2"  height="4" fill="#2B1B4A"/>
+  <rect x="27" y="20" width="2"  height="4" fill="#2B1B4A"/>
+  <rect x="28" y="24" width="2"  height="3" fill="#2B1B4A"/>
+
+  <!-- Suckers (random beige dots on a few tentacles) -->
+  <rect x="4"  y="18" width="1"  height="1" fill="#C7A8E0"/>
+  <rect x="11" y="20" width="1"  height="1" fill="#C7A8E0"/>
+  <rect x="14" y="22" width="1"  height="1" fill="#C7A8E0"/>
+  <rect x="20" y="19" width="1"  height="1" fill="#C7A8E0"/>
+  <rect x="27" y="22" width="1"  height="1" fill="#C7A8E0"/>
+</svg>

--- a/apps/docs/static/img/brand/mammoth.svg
+++ b/apps/docs/static/img/brand/mammoth.svg
@@ -1,0 +1,72 @@
+<!--
+  Tusk the mammoth. Operator's gitignored private strategies.
+  Visible only on the maintainer's local build (extinct from public
+  view). Shaggy fur, large tusks, big personality.
+
+  Hand-authored pixel art, 32×32 logical grid.
+  Palette: shaggy brown #6B4624, accent rust #8C5C2E, tusk cream
+           #F1E5C3, dark eye #1B1F2A, navy outline #1B2A4E.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Tusk the mammoth, private strategies">
+  <title>Tusk the mammoth</title>
+  <desc>Operator's gitignored private strategies. Visible only on the maintainer's local build.</desc>
+
+  <!-- Shaggy head/body crown -->
+  <rect x="9"  y="3"  width="14" height="1" fill="#6B4624"/>
+  <rect x="8"  y="4"  width="16" height="1" fill="#6B4624"/>
+
+  <!-- Head outline -->
+  <rect x="7"  y="5"  width="18" height="1" fill="#1B2A4E"/>
+  <rect x="6"  y="6"  width="1"  height="11" fill="#1B2A4E"/>
+  <rect x="25" y="6"  width="1"  height="11" fill="#1B2A4E"/>
+  <rect x="7"  y="17" width="18" height="1" fill="#1B2A4E"/>
+
+  <!-- Head fill -->
+  <rect x="7"  y="6"  width="18" height="11" fill="#6B4624"/>
+
+  <!-- Shaggy texture (rust streaks) -->
+  <rect x="8"  y="7"  width="2"  height="2" fill="#8C5C2E"/>
+  <rect x="14" y="6"  width="2"  height="2" fill="#8C5C2E"/>
+  <rect x="20" y="7"  width="2"  height="2" fill="#8C5C2E"/>
+  <rect x="9"  y="14" width="3"  height="1" fill="#8C5C2E"/>
+  <rect x="20" y="14" width="3"  height="1" fill="#8C5C2E"/>
+
+  <!-- Eyes -->
+  <rect x="10" y="9"  width="2"  height="2" fill="#1B1F2A"/>
+  <rect x="20" y="9"  width="2"  height="2" fill="#1B1F2A"/>
+  <rect x="10" y="9"  width="1"  height="1" fill="#F1E5C3"/>
+  <rect x="20" y="9"  width="1"  height="1" fill="#F1E5C3"/>
+
+  <!-- Trunk (curved down then up) -->
+  <rect x="14" y="12" width="4"  height="2" fill="#6B4624"/>
+  <rect x="14" y="14" width="2"  height="6" fill="#6B4624"/>
+  <rect x="13" y="20" width="3"  height="1" fill="#6B4624"/>
+  <rect x="13" y="21" width="1"  height="1" fill="#6B4624"/>
+
+  <!-- Trunk shading -->
+  <rect x="15" y="14" width="1"  height="6" fill="#8C5C2E"/>
+
+  <!-- Tusks (big, curving outward) -->
+  <rect x="11" y="13" width="1"  height="4" fill="#F1E5C3"/>
+  <rect x="10" y="14" width="1"  height="3" fill="#F1E5C3"/>
+  <rect x="9"  y="16" width="1"  height="2" fill="#F1E5C3"/>
+
+  <rect x="20" y="13" width="1"  height="4" fill="#F1E5C3"/>
+  <rect x="21" y="14" width="1"  height="3" fill="#F1E5C3"/>
+  <rect x="22" y="16" width="1"  height="2" fill="#F1E5C3"/>
+
+  <!-- Body / shoulders -->
+  <rect x="6"  y="18" width="20" height="1" fill="#1B2A4E"/>
+  <rect x="6"  y="19" width="20" height="6" fill="#6B4624"/>
+  <rect x="5"  y="19" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="26" y="19" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="6"  y="25" width="20" height="1" fill="#1B2A4E"/>
+
+  <!-- Shaggy underside -->
+  <rect x="8"  y="22" width="3"  height="3" fill="#8C5C2E"/>
+  <rect x="21" y="22" width="3"  height="3" fill="#8C5C2E"/>
+
+  <!-- Legs -->
+  <rect x="9"  y="26" width="3"  height="2" fill="#6B4624"/>
+  <rect x="20" y="26" width="3"  height="2" fill="#6B4624"/>
+</svg>

--- a/apps/docs/static/img/brand/narwhal.svg
+++ b/apps/docs/static/img/brand/narwhal.svg
@@ -1,0 +1,53 @@
+<!--
+  Narwhal  LLM advisor floating beside its penguin. Horn glows
+  (.glow class) when the LLM is being consulted; brighter on a veto.
+
+  Hand-authored pixel art, 32×32 logical grid.
+  Palette: lavender body #B5A6E0, navy back #4D3B7C, white belly #E9E4F8,
+           horn iridescent #E0D3FF + highlight #FFFFFF, eye #1B1F2A.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Narwhal advisor">
+  <title>Narwhal advisor</title>
+  <desc>Floats beside its penguin trader; horn glows when the LLM is consulted.</desc>
+
+  <!-- Horn -->
+  <rect x="2"  y="13" width="1"  height="1" fill="#FFFFFF" class="glow"/>
+  <rect x="3"  y="13" width="3"  height="1" fill="#E0D3FF" class="glow"/>
+  <rect x="6"  y="13" width="2"  height="1" fill="#B5A6E0"/>
+
+  <!-- Head + body outline -->
+  <rect x="7"  y="11" width="20" height="1" fill="#4D3B7C"/>
+  <rect x="6"  y="12" width="1"  height="1" fill="#4D3B7C"/>
+  <rect x="6"  y="14" width="1"  height="2" fill="#4D3B7C"/>
+  <rect x="7"  y="16" width="1"  height="1" fill="#4D3B7C"/>
+  <rect x="8"  y="17" width="20" height="1" fill="#4D3B7C"/>
+
+  <!-- Body fill (lavender top, white belly) -->
+  <rect x="7"  y="12" width="20" height="2" fill="#4D3B7C"/>
+  <rect x="7"  y="14" width="20" height="2" fill="#B5A6E0"/>
+  <rect x="8"  y="16" width="20" height="1" fill="#E9E4F8"/>
+
+  <!-- Eye -->
+  <rect x="10" y="13" width="1"  height="1" fill="#1B1F2A"/>
+
+  <!-- Smile -->
+  <rect x="11" y="15" width="2"  height="1" fill="#4D3B7C"/>
+
+  <!-- Tail -->
+  <rect x="27" y="11" width="1"  height="1" fill="#4D3B7C"/>
+  <rect x="28" y="10" width="2"  height="2" fill="#4D3B7C"/>
+  <rect x="27" y="17" width="1"  height="1" fill="#4D3B7C"/>
+  <rect x="28" y="17" width="2"  height="2" fill="#4D3B7C"/>
+  <rect x="29" y="13" width="1"  height="3" fill="#B5A6E0"/>
+
+  <!-- Spots (lavender) -->
+  <rect x="14" y="14" width="1"  height="1" fill="#4D3B7C"/>
+  <rect x="18" y="13" width="1"  height="1" fill="#4D3B7C"/>
+  <rect x="22" y="14" width="1"  height="1" fill="#4D3B7C"/>
+
+  <!-- Optional glow halo around horn (visible only when .glow CSS class
+       opacity is bumped from 0 ’ 1 in the stylesheet) -->
+  <rect x="1"  y="13" width="1"  height="1" fill="#E0D3FF" class="glow-halo" opacity="0"/>
+  <rect x="2"  y="12" width="4"  height="1" fill="#E0D3FF" class="glow-halo" opacity="0"/>
+  <rect x="2"  y="14" width="4"  height="1" fill="#E0D3FF" class="glow-halo" opacity="0"/>
+</svg>

--- a/apps/docs/static/img/brand/owl.svg
+++ b/apps/docs/static/img/brand/owl.svg
@@ -1,0 +1,61 @@
+<!--
+  Aurora the snowy owl. Risk monitor. Perches in dashboard chrome,
+  blinks on a breaker trip (.alert class swaps eye colour).
+
+  Hand-authored pixel art, 32×32 logical grid.
+  Palette: white plumage #ECF6FF, brown speckle #5A4220, golden eye
+           #F0C24A, beak orange #E67D3A, navy outline #1B2A4E,
+           alarm red #C73E36 (for .alert state).
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Aurora the snowy owl, risk monitor">
+  <title>Aurora the snowy owl</title>
+  <desc>Risk monitor; perches in the dashboard chrome and blinks on a breaker trip.</desc>
+
+  <!-- Ear tufts -->
+  <rect x="9"  y="3"  width="2"  height="2" fill="#ECF6FF"/>
+  <rect x="21" y="3"  width="2"  height="2" fill="#ECF6FF"/>
+
+  <!-- Head -->
+  <rect x="8"  y="5"  width="16" height="1" fill="#1B2A4E"/>
+  <rect x="7"  y="6"  width="1"  height="9" fill="#1B2A4E"/>
+  <rect x="24" y="6"  width="1"  height="9" fill="#1B2A4E"/>
+  <rect x="8"  y="6"  width="16" height="9" fill="#ECF6FF"/>
+
+  <!-- Eyes (golden) -->
+  <rect x="10" y="9"  width="4"  height="4" fill="#F0C24A" class="eye"/>
+  <rect x="18" y="9"  width="4"  height="4" fill="#F0C24A" class="eye"/>
+  <rect x="11" y="10" width="2"  height="2" fill="#1B2A4E"/>
+  <rect x="19" y="10" width="2"  height="2" fill="#1B2A4E"/>
+  <!-- Eye highlights -->
+  <rect x="11" y="10" width="1"  height="1" fill="#ECF6FF"/>
+  <rect x="19" y="10" width="1"  height="1" fill="#ECF6FF"/>
+
+  <!-- Beak -->
+  <rect x="15" y="13" width="2"  height="2" fill="#E67D3A"/>
+  <rect x="15" y="15" width="2"  height="1" fill="#1B2A4E"/>
+
+  <!-- Body -->
+  <rect x="9"  y="15" width="14" height="1" fill="#1B2A4E"/>
+  <rect x="8"  y="16" width="16" height="8" fill="#ECF6FF"/>
+  <rect x="7"  y="16" width="1"  height="8" fill="#1B2A4E"/>
+  <rect x="24" y="16" width="1"  height="8" fill="#1B2A4E"/>
+  <rect x="9"  y="24" width="14" height="1" fill="#1B2A4E"/>
+
+  <!-- Brown speckles (snowy owl pattern) -->
+  <rect x="10" y="17" width="1"  height="1" fill="#5A4220"/>
+  <rect x="14" y="18" width="1"  height="1" fill="#5A4220"/>
+  <rect x="17" y="17" width="1"  height="1" fill="#5A4220"/>
+  <rect x="20" y="19" width="1"  height="1" fill="#5A4220"/>
+  <rect x="11" y="20" width="1"  height="1" fill="#5A4220"/>
+  <rect x="15" y="21" width="1"  height="1" fill="#5A4220"/>
+  <rect x="18" y="21" width="1"  height="1" fill="#5A4220"/>
+  <rect x="13" y="22" width="1"  height="1" fill="#5A4220"/>
+
+  <!-- Wings (subtle outline) -->
+  <rect x="9"  y="17" width="1"  height="6" fill="#5A4220"/>
+  <rect x="22" y="17" width="1"  height="6" fill="#5A4220"/>
+
+  <!-- Talons -->
+  <rect x="11" y="25" width="2"  height="1" fill="#5A4220"/>
+  <rect x="19" y="25" width="2"  height="1" fill="#5A4220"/>
+</svg>

--- a/apps/docs/static/img/brand/penguin.svg
+++ b/apps/docs/static/img/brand/penguin.svg
@@ -1,0 +1,53 @@
+<!--
+  Penguin trader. One per running agent. Scarf colour distinguishes
+  multiple penguins on the same map; default is aurora-cyan #50D2C2.
+  Override at use-site by overlaying a <rect> with class="scarf" or
+  by passing a CSS variable.
+
+  Hand-authored pixel art, 32×32 logical grid.
+  Palette: black #1B1F2A, white belly #ECF6FF, beak orange #F0A24A,
+           feet orange-red #E67D3A, scarf cyan #50D2C2.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Penguin trader">
+  <title>Penguin trader</title>
+  <desc>One penguin per running strategy agent. Scarf colour distinguishes peers.</desc>
+
+  <!-- Head -->
+  <rect x="11" y="3"  width="10" height="1" fill="#1B1F2A"/>
+  <rect x="10" y="4"  width="12" height="6" fill="#1B1F2A"/>
+
+  <!-- Eyes (white-of-eye) -->
+  <rect x="12" y="6"  width="3"  height="3" fill="#ECF6FF"/>
+  <rect x="17" y="6"  width="3"  height="3" fill="#ECF6FF"/>
+  <!-- Pupils -->
+  <rect x="13" y="7"  width="1"  height="1" fill="#1B1F2A"/>
+  <rect x="18" y="7"  width="1"  height="1" fill="#1B1F2A"/>
+
+  <!-- Beak -->
+  <rect x="14" y="9"  width="4"  height="1" fill="#F0A24A"/>
+  <rect x="15" y="10" width="2"  height="1" fill="#E67D3A"/>
+
+  <!-- Scarf (configurable; default aurora cyan) -->
+  <rect x="9"  y="11" width="14" height="2" fill="#50D2C2" class="scarf"/>
+  <rect x="20" y="13" width="3"  height="3" fill="#50D2C2" class="scarf"/>
+
+  <!-- Body outline + back -->
+  <rect x="9"  y="13" width="14" height="1" fill="#1B1F2A"/>
+  <rect x="9"  y="14" width="1"  height="9" fill="#1B1F2A"/>
+  <rect x="22" y="14" width="1"  height="9" fill="#1B1F2A"/>
+  <rect x="9"  y="23" width="14" height="1" fill="#1B1F2A"/>
+
+  <!-- Body fill (back is dark; belly is white) -->
+  <rect x="10" y="14" width="12" height="9" fill="#1B1F2A"/>
+  <!-- White belly -->
+  <rect x="12" y="14" width="8"  height="9" fill="#ECF6FF"/>
+  <rect x="13" y="14" width="6"  height="1" fill="#ECF6FF"/>
+
+  <!-- Wings -->
+  <rect x="9"  y="15" width="2"  height="6" fill="#1B1F2A"/>
+  <rect x="21" y="15" width="2"  height="6" fill="#1B1F2A"/>
+
+  <!-- Feet -->
+  <rect x="11" y="24" width="3"  height="2" fill="#E67D3A"/>
+  <rect x="18" y="24" width="3"  height="2" fill="#E67D3A"/>
+</svg>

--- a/apps/docs/static/img/brand/pole.svg
+++ b/apps/docs/static/img/brand/pole.svg
@@ -1,0 +1,65 @@
+<!--
+  Pole the polar bear (Captain). The operator's avatar.
+  Hand-authored pixel art, 32×32 logical grid, scaled to 256×256.
+  Palette: ice white #ECF6FF, navy outline #1B2A4E, snout pink #F4B6C0,
+           captain hat navy #1B2A4E + gold #F0C24A.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Pole the polar bear, Captain">
+  <title>Pole the polar bear (Captain)</title>
+  <desc>The operator's avatar  a stylized polar bear with a navy captain's cap, presiding over the trading-desk pyramid.</desc>
+
+  <!-- Captain's hat brim (black) -->
+  <rect x="9"  y="5"  width="14" height="1" fill="#1B2A4E"/>
+  <!-- Hat body -->
+  <rect x="11" y="3"  width="10" height="2" fill="#1B2A4E"/>
+  <rect x="12" y="2"  width="8"  height="1" fill="#1B2A4E"/>
+  <!-- Hat gold band -->
+  <rect x="9"  y="6"  width="14" height="1" fill="#F0C24A"/>
+  <!-- Hat anchor emblem (gold dot) -->
+  <rect x="15" y="3"  width="2"  height="1" fill="#F0C24A"/>
+
+  <!-- Head outline (rounded square) -->
+  <rect x="8"  y="7"  width="16" height="1" fill="#1B2A4E"/>
+  <rect x="7"  y="8"  width="1"  height="9" fill="#1B2A4E"/>
+  <rect x="24" y="8"  width="1"  height="9" fill="#1B2A4E"/>
+  <rect x="8"  y="17" width="16" height="1" fill="#1B2A4E"/>
+
+  <!-- Head fill -->
+  <rect x="8"  y="8"  width="16" height="9" fill="#ECF6FF"/>
+
+  <!-- Ears -->
+  <rect x="9"  y="6"  width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="22" y="6"  width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="8"  y="7"  width="2"  height="1" fill="#ECF6FF"/>
+  <rect x="22" y="7"  width="2"  height="1" fill="#ECF6FF"/>
+
+  <!-- Eyes -->
+  <rect x="11" y="11" width="2"  height="2" fill="#1B2A4E"/>
+  <rect x="19" y="11" width="2"  height="2" fill="#1B2A4E"/>
+  <!-- Eye highlights -->
+  <rect x="11" y="11" width="1"  height="1" fill="#ECF6FF"/>
+  <rect x="19" y="11" width="1"  height="1" fill="#ECF6FF"/>
+
+  <!-- Snout -->
+  <rect x="13" y="13" width="6"  height="3" fill="#F8FBFF"/>
+  <rect x="13" y="14" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="18" y="14" width="1"  height="1" fill="#1B2A4E"/>
+  <!-- Nose -->
+  <rect x="15" y="14" width="2"  height="1" fill="#1B2A4E"/>
+  <!-- Mouth -->
+  <rect x="14" y="15" width="4"  height="1" fill="#F4B6C0"/>
+
+  <!-- Body fill (peeks below head) -->
+  <rect x="9"  y="18" width="14" height="6" fill="#ECF6FF"/>
+  <rect x="8"  y="18" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="23" y="18" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="9"  y="24" width="14" height="1" fill="#1B2A4E"/>
+
+  <!-- Captain's collar (gold) -->
+  <rect x="11" y="18" width="10" height="1" fill="#F0C24A"/>
+  <rect x="14" y="19" width="4"  height="1" fill="#1B2A4E"/>
+
+  <!-- Paws (peeking out from sides) -->
+  <rect x="8"  y="20" width="1"  height="3" fill="#ECF6FF"/>
+  <rect x="23" y="20" width="1"  height="3" fill="#ECF6FF"/>
+</svg>

--- a/apps/docs/static/img/brand/walrus.svg
+++ b/apps/docs/static/img/brand/walrus.svg
@@ -1,0 +1,60 @@
+<!--
+  Kelp the walrus. Swap router  appears on swap routes between
+  chains, hauling tokens across.
+
+  Hand-authored pixel art, 32×32 logical grid.
+  Palette: warm brown body #8B5C3A, paler belly #C19169, cream tusks
+           #F1E5C3, dark eye #1B1F2A, navy outline #1B2A4E,
+           pink whisker #F4B6C0.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Kelp the walrus, swap router">
+  <title>Kelp the walrus</title>
+  <desc>Hauls tokens between chains via the swap router.</desc>
+
+  <!-- Head outline -->
+  <rect x="6"  y="6"  width="14" height="1" fill="#1B2A4E"/>
+  <rect x="5"  y="7"  width="1"  height="9" fill="#1B2A4E"/>
+  <rect x="20" y="7"  width="1"  height="9" fill="#1B2A4E"/>
+  <rect x="6"  y="16" width="14" height="1" fill="#1B2A4E"/>
+
+  <!-- Head fill -->
+  <rect x="6"  y="7"  width="14" height="9" fill="#8B5C3A"/>
+
+  <!-- Eyes -->
+  <rect x="9"  y="10" width="1"  height="1" fill="#1B1F2A"/>
+  <rect x="13" y="10" width="1"  height="1" fill="#1B1F2A"/>
+
+  <!-- Snout (paler) -->
+  <rect x="8"  y="12" width="8"  height="3" fill="#C19169"/>
+
+  <!-- Whiskers -->
+  <rect x="7"  y="13" width="1"  height="1" fill="#F4B6C0"/>
+  <rect x="6"  y="14" width="1"  height="1" fill="#F4B6C0"/>
+  <rect x="16" y="13" width="1"  height="1" fill="#F4B6C0"/>
+  <rect x="17" y="14" width="1"  height="1" fill="#F4B6C0"/>
+
+  <!-- Tusks -->
+  <rect x="9"  y="15" width="2"  height="3" fill="#F1E5C3"/>
+  <rect x="13" y="15" width="2"  height="3" fill="#F1E5C3"/>
+  <rect x="9"  y="18" width="2"  height="1" fill="#1B2A4E"/>
+  <rect x="13" y="18" width="2"  height="1" fill="#1B2A4E"/>
+
+  <!-- Body (round, pinniped  wider than head) -->
+  <rect x="4"  y="17" width="22" height="1" fill="#1B2A4E"/>
+  <rect x="3"  y="18" width="1"  height="7" fill="#1B2A4E"/>
+  <rect x="26" y="18" width="1"  height="7" fill="#1B2A4E"/>
+  <rect x="4"  y="18" width="22" height="7" fill="#8B5C3A"/>
+  <rect x="4"  y="25" width="22" height="1" fill="#1B2A4E"/>
+
+  <!-- Belly -->
+  <rect x="7"  y="20" width="16" height="4" fill="#C19169"/>
+
+  <!-- Flippers (front pair) -->
+  <rect x="3"  y="22" width="1"  height="3" fill="#8B5C3A"/>
+  <rect x="2"  y="23" width="1"  height="2" fill="#8B5C3A"/>
+  <rect x="26" y="22" width="1"  height="3" fill="#8B5C3A"/>
+  <rect x="27" y="23" width="1"  height="2" fill="#8B5C3A"/>
+
+  <!-- Tail (small) -->
+  <rect x="14" y="26" width="4"  height="1" fill="#8B5C3A"/>
+</svg>


### PR DESCRIPTION
PR 10 of 10 in the Trading Desk epic chain (#30, Phase 4). Closes #43. **Final PR in the chain.**

## What it adds

Two new docs pages and a sidebar section under **Brand & Narrative**:

### `apps/docs/docs/brand/llm-as-agent.md`

The thesis: the LLM is an **agent in the decision loop**, not a bolted-on feature.

- Veto pattern (LLM doesn't make trades, it vetoes trades)
- JSON-schema enforcement (no hallucinated fields)
- Decision provenance (every order links back to input + prompt + model_id + response)
- Bounded blast radius (worst case = missed trade)
- Cost-controlled (one round-trip per refresh cycle)
- Why competing shapes ("let LLM generate", "sentiment scoring", "custom model") are weaker
- Closes with the expedition metaphor as a 5-second story

### `apps/docs/docs/brand/cast.md`

Full character roster grouped by role:

- **Leadership** — Pole the polar bear (Captain), Aurora the snowy owl (Risk Monitor)
- **Traders** — Penguin traders (one per agent, distinguished by scarf colour), Narwhal advisors (LLM consult)
- **Support staff** — Skipper the husky (Reconciliation), Kelp the walrus (Swap Router)
- **Hazards** — Frostbite the kraken (Killswitch), Tusk the mammoth (Private strategies, gitignored)
- **Currency** — Coins (~$100 NAV unit each)

Each character has its sprite inlined + a short blurb about what they represent and where they appear in the UI.

### Sidebar

New \"Brand & Narrative\" category appended after Reference. Two pages: llm-as-agent, cast.

### Sprite assets

`apps/docs/static/img/brand/*.svg` copied from chain/09-trading-desk so the docs site can serve them at build time. When chain/09 merges first, the SVG content is identical and the rebase is a no-op for these files.

## Audit (per .cursor/rules/issue-audit-user-stories.mdc)

### Findings

**No high-severity findings.** Pure docs PR; no code paths.

**Medium:** none.

**Low:**

- L1: Sprite SVGs are duplicated between `apps/desk/src/characters/` (PR #52) and `apps/docs/static/img/brand/` (this PR). Docusaurus needs them under `static/` to serve them; the desk app needs them under `src/` for Vite to bundle. A shared package would be over-engineering for 9 small files. Acceptable.
- L2: Cast page links from individual pages aren't yet bidirectional — concepts/inference doesn't link to brand/llm-as-agent. Polish in a tiny follow-up.

### Acceptance criteria coverage (from #43)

- [x] LLM-as-agent thesis page lives under Brand & Narrative
- [x] Cast page lists every character with sprite + role + blurb
- [x] Arctic vocabulary used consistently throughout
- [x] All 9 sprites render in the docs build
- [x] Docusaurus build succeeds with no broken-link errors

### Risks

- **Sprite drift between desk app and docs.** If a future contributor edits a sprite in one location only, the two will diverge. Acceptable trade-off; a check could be added later (md5 each SVG in CI).

## Test plan

- [x] `cd apps/docs && npm run build` succeeds; broken-link checker happy
- [x] All 9 SVGs present at `/img/brand/<name>.svg` in the static build
- [x] Sidebar entry visible in the rendered docs

## Stack position

PR 10 of 10. Targets `main` directly. Sprite assets pulled from #52 (rebase no-op when either lands first).

## What ships when this chain lands

The full Trading Desk epic (#30) closes:
1. **Onboarding ergonomics:** README/quickstart/safety (#44), `permafrost doctor` (#45), `permafrost init` wizard (#46), `make demo` (#47).
2. **Distribution:** Docker + GHCR multi-arch release workflow (#48).
3. **Production safety:** Killswitch implementation (#49 — the credibility-gap closer).
4. **Operator extensibility:** Reference strategies dca_buy + market_maker_basic (#50), `permafrost strategy-new` scaffolding (#51).
5. **Operator UI:** Trading Desk with arctic SVG sprites (#52).
6. **Brand & narrative:** This PR.

Final integration test on `test/integration-stack` will exercise the merged stack end-to-end with `make demo`.