### PR TITLE
Pole sprite: tall sat-up profile + red wooly hat with pom-pom

### DIFF
--- a/apps/desk/src/characters/pole.svg
+++ b/apps/desk/src/characters/pole.svg
@@ -1,121 +1,163 @@
 <!--
-  Pole the Polar Bear. Sat side-profile bear, facing right, with a
-  cyan scarf around his neck. No hat. Hand-authored pixel art on a
-  32x32 grid scaled to 256x256.
-  Palette: ice white #ECF6FF, navy outline #1B2A4E, snout cream #F8FBFF,
-           scarf cyan #50D2C2 + dark cyan #2BA694, nose pink #F4B6C0,
-           soft shadow #D8E5F5.
+  Pole the Polar Bear. Sat upright in side profile, facing right,
+  snout angled slightly up (regal/contemplative pose, matching the
+  user's reference photo). Wears a red wooly hat with a white
+  pom-pom on top, plus the cyan scarf around his neck.
+  Hand-authored pixel art on a 32x32 grid scaled to 256x256.
+  Palette: ice white #ECF6FF, soft shadow #D8E5F5, navy outline
+           #1B2A4E, snout cream #F8FBFF, pink mouth/toe-bean #F4B6C0,
+           hat red #DC2626, hat dark red #991B1B, hat shadow #7F1D1D,
+           pom-pom white #FFFFFF, scarf cyan #50D2C2 + dark #2BA694.
 -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Pole the Polar Bear">
   <title>Pole the Polar Bear</title>
-  <desc>The operator's avatar -- a side-profile sat polar bear with a cyan scarf, watching the camp.</desc>
+  <desc>Sat upright in profile with a red wooly hat and a cyan scarf, watching the camp.</desc>
 
   <!-- ============================================================
-       Ear (single, on top of head; side profile)
+       Pom-pom on top of the hat (white tuft)
        ============================================================ -->
-  <rect x="19" y="4"  width="3" height="1" fill="#1B2A4E"/>
-  <rect x="18" y="5"  width="1" height="2" fill="#1B2A4E"/>
-  <rect x="22" y="5"  width="1" height="2" fill="#1B2A4E"/>
-  <rect x="19" y="5"  width="3" height="2" fill="#ECF6FF"/>
-  <rect x="20" y="6"  width="1" height="1" fill="#F4B6C0"/>
+  <rect x="13" y="0" width="2" height="1" fill="#ECF6FF"/>
+  <rect x="12" y="1" width="4" height="1" fill="#FFFFFF"/>
+  <rect x="13" y="2" width="2" height="1" fill="#FFFFFF"/>
 
   <!-- ============================================================
-       Head outline (rounded, slightly elongated)
+       Red wooly hat (rounded dome over the skull, with a darker
+       wool-roll cuff at the brim)
        ============================================================ -->
-  <rect x="18" y="7"  width="6"  height="1" fill="#1B2A4E"/>
-  <rect x="17" y="8"  width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="24" y="8"  width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="16" y="9"  width="1"  height="3" fill="#1B2A4E"/>
-  <rect x="25" y="9"  width="1"  height="2" fill="#1B2A4E"/>
-  <!-- Snout extends right, lower section -->
-  <rect x="26" y="11" width="1"  height="3" fill="#1B2A4E"/>
-  <rect x="27" y="13" width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="22" y="15" width="5"  height="1" fill="#1B2A4E"/>
-  <rect x="17" y="14" width="5"  height="1" fill="#1B2A4E"/>
-
-  <!-- Head fill (white) -->
-  <rect x="18" y="8"  width="6"  height="1" fill="#ECF6FF"/>
-  <rect x="17" y="9"  width="8"  height="2" fill="#ECF6FF"/>
-  <rect x="17" y="11" width="9"  height="3" fill="#ECF6FF"/>
-  <rect x="22" y="14" width="5"  height="1" fill="#F8FBFF"/>
-
-  <!-- Eye (single, side profile) -->
-  <rect x="20" y="10" width="1" height="2" fill="#1B2A4E"/>
-  <rect x="20" y="10" width="1" height="1" fill="#FFFFFF"/>
-
-  <!-- Snout/nose tip -->
-  <rect x="27" y="12" width="1" height="1" fill="#1B2A4E"/>
-  <rect x="26" y="13" width="2" height="1" fill="#F8FBFF"/>
-  <rect x="25" y="14" width="2" height="1" fill="#F8FBFF"/>
-
-  <!-- Mouth -->
-  <rect x="24" y="14" width="1" height="1" fill="#1B2A4E"/>
-  <rect x="22" y="13" width="2" height="1" fill="#F4B6C0"/>
+  <!-- Hat dome -->
+  <rect x="11" y="3"  width="5"  height="1" fill="#DC2626"/>
+  <rect x="10" y="4"  width="7"  height="1" fill="#DC2626"/>
+  <rect x="9"  y="5"  width="9"  height="1" fill="#DC2626"/>
+  <rect x="8"  y="6"  width="11" height="1" fill="#DC2626"/>
+  <!-- Highlight on the dome (wool sheen) -->
+  <rect x="12" y="3"  width="2"  height="1" fill="#EF4444"/>
+  <rect x="11" y="4"  width="3"  height="1" fill="#EF4444"/>
+  <rect x="10" y="5"  width="3"  height="1" fill="#EF4444"/>
+  <!-- Brim cuff (darker red, rolled wool) -->
+  <rect x="8"  y="7"  width="11" height="2" fill="#991B1B"/>
+  <rect x="8"  y="8"  width="11" height="1" fill="#7F1D1D"/>
+  <!-- Brim highlights (knit pattern dots) -->
+  <rect x="10" y="7"  width="1"  height="1" fill="#DC2626"/>
+  <rect x="13" y="7"  width="1"  height="1" fill="#DC2626"/>
+  <rect x="16" y="7"  width="1"  height="1" fill="#DC2626"/>
 
   <!-- ============================================================
-       Scarf (cyan, wraps around neck and a tail trails left)
+       Ear (single, visible at the back of the head, peeking out
+       below the hat brim on the back-left side)
        ============================================================ -->
-  <!-- Main scarf body -->
-  <rect x="14" y="15" width="11" height="1" fill="#2BA694"/>
-  <rect x="13" y="16" width="13" height="2" fill="#50D2C2"/>
-  <rect x="13" y="18" width="13" height="1" fill="#2BA694"/>
+  <rect x="7"  y="9"  width="2" height="2" fill="#1B2A4E"/>
+  <rect x="8"  y="10" width="1" height="1" fill="#F4B6C0"/>
+
+  <!-- ============================================================
+       Head outline + fill (rounded with a long muzzle extending up
+       and to the right - bear looking up at the sky, reference-
+       photo pose)
+       ============================================================ -->
+  <!-- Head outline (top + sides) -->
+  <rect x="9"  y="9"  width="9"  height="1" fill="#1B2A4E"/>
+  <rect x="18" y="9"  width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="19" y="10" width="1"  height="1" fill="#1B2A4E"/>
+  <!-- Snout outline (extends up and right) -->
+  <rect x="20" y="10" width="2" height="1" fill="#1B2A4E"/>
+  <rect x="22" y="11" width="2" height="1" fill="#1B2A4E"/>
+  <rect x="24" y="12" width="1" height="1" fill="#1B2A4E"/>
+  <rect x="25" y="13" width="1" height="1" fill="#1B2A4E"/>
+  <rect x="22" y="14" width="4" height="1" fill="#1B2A4E"/>
+  <rect x="20" y="15" width="3" height="1" fill="#1B2A4E"/>
+  <rect x="9"  y="15" width="11" height="1" fill="#1B2A4E"/>
+
+  <!-- Head fill -->
+  <rect x="9"  y="10" width="10" height="5" fill="#ECF6FF"/>
+  <rect x="19" y="11" width="1"  height="4" fill="#ECF6FF"/>
+  <rect x="20" y="11" width="2"  height="3" fill="#ECF6FF"/>
+  <rect x="22" y="12" width="2"  height="2" fill="#F8FBFF"/>
+  <rect x="24" y="13" width="1"  height="1" fill="#F8FBFF"/>
+
+  <!-- Forehead shading (just under the hat brim) -->
+  <rect x="9"  y="10" width="9"  height="1" fill="#D8E5F5"/>
+
+  <!-- Eye (single, looking up to match the reference pose) -->
+  <rect x="14" y="11" width="2" height="2" fill="#1B2A4E"/>
+  <rect x="14" y="11" width="1" height="1" fill="#FFFFFF"/>
+
+  <!-- Nose (dark tip of the snout) -->
+  <rect x="24" y="12" width="1" height="1" fill="#1B2A4E"/>
+  <rect x="23" y="13" width="1" height="1" fill="#F8FBFF"/>
+
+  <!-- Mouth (gentle smile, pink hint) -->
+  <rect x="22" y="13" width="1" height="1" fill="#1B2A4E"/>
+  <rect x="20" y="13" width="2" height="1" fill="#F4B6C0"/>
+
+  <!-- ============================================================
+       Neck (short, white, joins head to body)
+       ============================================================ -->
+  <rect x="11" y="16" width="8" height="1" fill="#ECF6FF"/>
+
+  <!-- ============================================================
+       Cyan scarf around the neck, with a fringed tail trailing
+       to the back-left
+       ============================================================ -->
+  <!-- Main scarf wrap -->
+  <rect x="10" y="17" width="11" height="1" fill="#2BA694"/>
+  <rect x="9"  y="18" width="13" height="2" fill="#50D2C2"/>
+  <rect x="9"  y="20" width="13" height="1" fill="#2BA694"/>
   <!-- Scarf knot on the left side -->
-  <rect x="11" y="17" width="3"  height="3" fill="#50D2C2"/>
-  <rect x="11" y="17" width="3"  height="1" fill="#2BA694"/>
-  <rect x="11" y="20" width="3"  height="1" fill="#2BA694"/>
-  <!-- Scarf tail trailing down-left (a few pixels of fringe) -->
-  <rect x="9"  y="20" width="2"  height="2" fill="#50D2C2"/>
-  <rect x="9"  y="22" width="2"  height="1" fill="#2BA694"/>
-  <rect x="10" y="23" width="1"  height="2" fill="#50D2C2"/>
+  <rect x="7"  y="18" width="2"  height="3" fill="#50D2C2"/>
+  <rect x="7"  y="18" width="2"  height="1" fill="#2BA694"/>
+  <rect x="7"  y="20" width="2"  height="1" fill="#2BA694"/>
+  <!-- Scarf tail dangling down-left -->
+  <rect x="5"  y="21" width="2"  height="2" fill="#50D2C2"/>
+  <rect x="5"  y="23" width="2"  height="1" fill="#2BA694"/>
+  <rect x="6"  y="24" width="1"  height="1" fill="#50D2C2"/>
 
   <!-- ============================================================
-       Body (sat side profile, big round haunches on the left,
-       chest curving down on the right)
+       Body (sitting upright). Chest is narrow at the top, body
+       widens through the torso, haunches are widest at the base.
        ============================================================ -->
-  <!-- Body outline -->
-  <rect x="6"  y="17" width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="5"  y="18" width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="4"  y="20" width="1"  height="4" fill="#1B2A4E"/>
-  <rect x="3"  y="24" width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="4"  y="26" width="2"  height="1" fill="#1B2A4E"/>
-  <rect x="6"  y="27" width="11" height="1" fill="#1B2A4E"/>
-  <rect x="17" y="26" width="2"  height="1" fill="#1B2A4E"/>
-  <rect x="19" y="25" width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="20" y="24" width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="21" y="20" width="1"  height="4" fill="#1B2A4E"/>
-  <rect x="20" y="19" width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="14" y="19" width="6"  height="1" fill="#1B2A4E"/>
-  <rect x="7"  y="19" width="6"  height="1" fill="#1B2A4E"/>
+  <!-- Chest outline -->
+  <rect x="11" y="20" width="10" height="1" fill="#1B2A4E"/>
+  <!-- Body sides (taper outward as we move down) -->
+  <rect x="10" y="21" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="21" y="21" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="9"  y="23" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="22" y="23" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="8"  y="25" width="1"  height="3" fill="#1B2A4E"/>
+  <rect x="23" y="25" width="1"  height="3" fill="#1B2A4E"/>
 
-  <!-- Body fill (white, with subtle belly shading) -->
-  <rect x="6"  y="18" width="15" height="1" fill="#ECF6FF"/>
-  <rect x="5"  y="20" width="16" height="4" fill="#ECF6FF"/>
-  <rect x="4"  y="24" width="17" height="2" fill="#ECF6FF"/>
-  <rect x="6"  y="26" width="13" height="1" fill="#ECF6FF"/>
-  <!-- Belly shading -->
-  <rect x="14" y="22" width="6"  height="3" fill="#D8E5F5"/>
+  <!-- Body fill -->
+  <rect x="11" y="21" width="10" height="2" fill="#ECF6FF"/>
+  <rect x="10" y="23" width="12" height="2" fill="#ECF6FF"/>
+  <rect x="9"  y="25" width="14" height="3" fill="#ECF6FF"/>
+
+  <!-- Belly shading (gives the body an oval look from the side) -->
+  <rect x="15" y="23" width="7" height="4" fill="#D8E5F5"/>
 
   <!-- ============================================================
-       Front paw (one visible at the bottom-right of body)
+       Front paws (two visible side-by-side at the front-right base)
        ============================================================ -->
-  <rect x="15" y="25" width="3"  height="2" fill="#ECF6FF"/>
-  <rect x="14" y="26" width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="18" y="25" width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="15" y="27" width="3"  height="1" fill="#1B2A4E"/>
-  <rect x="16" y="26" width="1"  height="1" fill="#F4B6C0"/>
-
-  <!-- Hind leg / haunch (visible at the bottom-left of body) -->
-  <rect x="6"  y="25" width="3"  height="2" fill="#ECF6FF"/>
-  <rect x="5"  y="26" width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="9"  y="25" width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="6"  y="27" width="3"  height="1" fill="#1B2A4E"/>
-  <rect x="7"  y="26" width="1"  height="1" fill="#F4B6C0"/>
+  <!-- Right front paw -->
+  <rect x="19" y="28" width="4" height="2" fill="#ECF6FF"/>
+  <rect x="18" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="23" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="19" y="30" width="4" height="1" fill="#1B2A4E"/>
+  <rect x="20" y="29" width="1" height="1" fill="#F4B6C0"/>
+  <rect x="21" y="29" width="1" height="1" fill="#F4B6C0"/>
 
   <!-- ============================================================
-       Tail (small white nub at the back-left)
+       Hind paw (visible at the back-left base, curling under the
+       body where the bear is sitting)
        ============================================================ -->
-  <rect x="2"  y="22" width="2"  height="2" fill="#ECF6FF"/>
-  <rect x="2"  y="22" width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="3"  y="22" width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="2"  y="24" width="2"  height="1" fill="#1B2A4E"/>
+  <rect x="9"  y="28" width="4" height="2" fill="#ECF6FF"/>
+  <rect x="8"  y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="13" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="9"  y="30" width="4" height="1" fill="#1B2A4E"/>
+  <rect x="10" y="29" width="1" height="1" fill="#F4B6C0"/>
+  <rect x="11" y="29" width="1" height="1" fill="#F4B6C0"/>
+
+  <!-- ============================================================
+       Tail (small white nub peeking at the back-left of the haunch)
+       ============================================================ -->
+  <rect x="6"  y="25" width="2" height="2" fill="#ECF6FF"/>
+  <rect x="5"  y="25" width="1" height="2" fill="#1B2A4E"/>
+  <rect x="6"  y="27" width="2" height="1" fill="#1B2A4E"/>
 </svg>

--- a/apps/docs/static/img/brand/pole.svg
+++ b/apps/docs/static/img/brand/pole.svg
@@ -1,65 +1,163 @@
 <!--
-  Pole the polar bear (Captain). The operator's avatar.
-  Hand-authored pixel art, 32x32 logical grid, scaled to 256x256.
-  Palette: ice white #ECF6FF, navy outline #1B2A4E, snout pink #F4B6C0,
-           captain hat navy #1B2A4E + gold #F0C24A.
+  Pole the Polar Bear. Sat upright in side profile, facing right,
+  snout angled slightly up (regal/contemplative pose, matching the
+  user's reference photo). Wears a red wooly hat with a white
+  pom-pom on top, plus the cyan scarf around his neck.
+  Hand-authored pixel art on a 32x32 grid scaled to 256x256.
+  Palette: ice white #ECF6FF, soft shadow #D8E5F5, navy outline
+           #1B2A4E, snout cream #F8FBFF, pink mouth/toe-bean #F4B6C0,
+           hat red #DC2626, hat dark red #991B1B, hat shadow #7F1D1D,
+           pom-pom white #FFFFFF, scarf cyan #50D2C2 + dark #2BA694.
 -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Pole the polar bear, Captain">
-  <title>Pole the polar bear (Captain)</title>
-  <desc>The operator's avatar  a stylized polar bear with a navy captain's cap, presiding over the trading-desk pyramid.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Pole the Polar Bear">
+  <title>Pole the Polar Bear</title>
+  <desc>Sat upright in profile with a red wooly hat and a cyan scarf, watching the camp.</desc>
 
-  <!-- Captain's hat brim (black) -->
-  <rect x="9"  y="5"  width="14" height="1" fill="#1B2A4E"/>
-  <!-- Hat body -->
-  <rect x="11" y="3"  width="10" height="2" fill="#1B2A4E"/>
-  <rect x="12" y="2"  width="8"  height="1" fill="#1B2A4E"/>
-  <!-- Hat gold band -->
-  <rect x="9"  y="6"  width="14" height="1" fill="#F0C24A"/>
-  <!-- Hat anchor emblem (gold dot) -->
-  <rect x="15" y="3"  width="2"  height="1" fill="#F0C24A"/>
+  <!-- ============================================================
+       Pom-pom on top of the hat (white tuft)
+       ============================================================ -->
+  <rect x="13" y="0" width="2" height="1" fill="#ECF6FF"/>
+  <rect x="12" y="1" width="4" height="1" fill="#FFFFFF"/>
+  <rect x="13" y="2" width="2" height="1" fill="#FFFFFF"/>
 
-  <!-- Head outline (rounded square) -->
-  <rect x="8"  y="7"  width="16" height="1" fill="#1B2A4E"/>
-  <rect x="7"  y="8"  width="1"  height="9" fill="#1B2A4E"/>
-  <rect x="24" y="8"  width="1"  height="9" fill="#1B2A4E"/>
-  <rect x="8"  y="17" width="16" height="1" fill="#1B2A4E"/>
+  <!-- ============================================================
+       Red wooly hat (rounded dome over the skull, with a darker
+       wool-roll cuff at the brim)
+       ============================================================ -->
+  <!-- Hat dome -->
+  <rect x="11" y="3"  width="5"  height="1" fill="#DC2626"/>
+  <rect x="10" y="4"  width="7"  height="1" fill="#DC2626"/>
+  <rect x="9"  y="5"  width="9"  height="1" fill="#DC2626"/>
+  <rect x="8"  y="6"  width="11" height="1" fill="#DC2626"/>
+  <!-- Highlight on the dome (wool sheen) -->
+  <rect x="12" y="3"  width="2"  height="1" fill="#EF4444"/>
+  <rect x="11" y="4"  width="3"  height="1" fill="#EF4444"/>
+  <rect x="10" y="5"  width="3"  height="1" fill="#EF4444"/>
+  <!-- Brim cuff (darker red, rolled wool) -->
+  <rect x="8"  y="7"  width="11" height="2" fill="#991B1B"/>
+  <rect x="8"  y="8"  width="11" height="1" fill="#7F1D1D"/>
+  <!-- Brim highlights (knit pattern dots) -->
+  <rect x="10" y="7"  width="1"  height="1" fill="#DC2626"/>
+  <rect x="13" y="7"  width="1"  height="1" fill="#DC2626"/>
+  <rect x="16" y="7"  width="1"  height="1" fill="#DC2626"/>
+
+  <!-- ============================================================
+       Ear (single, visible at the back of the head, peeking out
+       below the hat brim on the back-left side)
+       ============================================================ -->
+  <rect x="7"  y="9"  width="2" height="2" fill="#1B2A4E"/>
+  <rect x="8"  y="10" width="1" height="1" fill="#F4B6C0"/>
+
+  <!-- ============================================================
+       Head outline + fill (rounded with a long muzzle extending up
+       and to the right - bear looking up at the sky, reference-
+       photo pose)
+       ============================================================ -->
+  <!-- Head outline (top + sides) -->
+  <rect x="9"  y="9"  width="9"  height="1" fill="#1B2A4E"/>
+  <rect x="18" y="9"  width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="19" y="10" width="1"  height="1" fill="#1B2A4E"/>
+  <!-- Snout outline (extends up and right) -->
+  <rect x="20" y="10" width="2" height="1" fill="#1B2A4E"/>
+  <rect x="22" y="11" width="2" height="1" fill="#1B2A4E"/>
+  <rect x="24" y="12" width="1" height="1" fill="#1B2A4E"/>
+  <rect x="25" y="13" width="1" height="1" fill="#1B2A4E"/>
+  <rect x="22" y="14" width="4" height="1" fill="#1B2A4E"/>
+  <rect x="20" y="15" width="3" height="1" fill="#1B2A4E"/>
+  <rect x="9"  y="15" width="11" height="1" fill="#1B2A4E"/>
 
   <!-- Head fill -->
-  <rect x="8"  y="8"  width="16" height="9" fill="#ECF6FF"/>
+  <rect x="9"  y="10" width="10" height="5" fill="#ECF6FF"/>
+  <rect x="19" y="11" width="1"  height="4" fill="#ECF6FF"/>
+  <rect x="20" y="11" width="2"  height="3" fill="#ECF6FF"/>
+  <rect x="22" y="12" width="2"  height="2" fill="#F8FBFF"/>
+  <rect x="24" y="13" width="1"  height="1" fill="#F8FBFF"/>
 
-  <!-- Ears -->
-  <rect x="9"  y="6"  width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="22" y="6"  width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="8"  y="7"  width="2"  height="1" fill="#ECF6FF"/>
-  <rect x="22" y="7"  width="2"  height="1" fill="#ECF6FF"/>
+  <!-- Forehead shading (just under the hat brim) -->
+  <rect x="9"  y="10" width="9"  height="1" fill="#D8E5F5"/>
 
-  <!-- Eyes -->
-  <rect x="11" y="11" width="2"  height="2" fill="#1B2A4E"/>
-  <rect x="19" y="11" width="2"  height="2" fill="#1B2A4E"/>
-  <!-- Eye highlights -->
-  <rect x="11" y="11" width="1"  height="1" fill="#ECF6FF"/>
-  <rect x="19" y="11" width="1"  height="1" fill="#ECF6FF"/>
+  <!-- Eye (single, looking up to match the reference pose) -->
+  <rect x="14" y="11" width="2" height="2" fill="#1B2A4E"/>
+  <rect x="14" y="11" width="1" height="1" fill="#FFFFFF"/>
 
-  <!-- Snout -->
-  <rect x="13" y="13" width="6"  height="3" fill="#F8FBFF"/>
-  <rect x="13" y="14" width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="18" y="14" width="1"  height="1" fill="#1B2A4E"/>
-  <!-- Nose -->
-  <rect x="15" y="14" width="2"  height="1" fill="#1B2A4E"/>
-  <!-- Mouth -->
-  <rect x="14" y="15" width="4"  height="1" fill="#F4B6C0"/>
+  <!-- Nose (dark tip of the snout) -->
+  <rect x="24" y="12" width="1" height="1" fill="#1B2A4E"/>
+  <rect x="23" y="13" width="1" height="1" fill="#F8FBFF"/>
 
-  <!-- Body fill (peeks below head) -->
-  <rect x="9"  y="18" width="14" height="6" fill="#ECF6FF"/>
-  <rect x="8"  y="18" width="1"  height="6" fill="#1B2A4E"/>
-  <rect x="23" y="18" width="1"  height="6" fill="#1B2A4E"/>
-  <rect x="9"  y="24" width="14" height="1" fill="#1B2A4E"/>
+  <!-- Mouth (gentle smile, pink hint) -->
+  <rect x="22" y="13" width="1" height="1" fill="#1B2A4E"/>
+  <rect x="20" y="13" width="2" height="1" fill="#F4B6C0"/>
 
-  <!-- Captain's collar (gold) -->
-  <rect x="11" y="18" width="10" height="1" fill="#F0C24A"/>
-  <rect x="14" y="19" width="4"  height="1" fill="#1B2A4E"/>
+  <!-- ============================================================
+       Neck (short, white, joins head to body)
+       ============================================================ -->
+  <rect x="11" y="16" width="8" height="1" fill="#ECF6FF"/>
 
-  <!-- Paws (peeking out from sides) -->
-  <rect x="8"  y="20" width="1"  height="3" fill="#ECF6FF"/>
-  <rect x="23" y="20" width="1"  height="3" fill="#ECF6FF"/>
+  <!-- ============================================================
+       Cyan scarf around the neck, with a fringed tail trailing
+       to the back-left
+       ============================================================ -->
+  <!-- Main scarf wrap -->
+  <rect x="10" y="17" width="11" height="1" fill="#2BA694"/>
+  <rect x="9"  y="18" width="13" height="2" fill="#50D2C2"/>
+  <rect x="9"  y="20" width="13" height="1" fill="#2BA694"/>
+  <!-- Scarf knot on the left side -->
+  <rect x="7"  y="18" width="2"  height="3" fill="#50D2C2"/>
+  <rect x="7"  y="18" width="2"  height="1" fill="#2BA694"/>
+  <rect x="7"  y="20" width="2"  height="1" fill="#2BA694"/>
+  <!-- Scarf tail dangling down-left -->
+  <rect x="5"  y="21" width="2"  height="2" fill="#50D2C2"/>
+  <rect x="5"  y="23" width="2"  height="1" fill="#2BA694"/>
+  <rect x="6"  y="24" width="1"  height="1" fill="#50D2C2"/>
+
+  <!-- ============================================================
+       Body (sitting upright). Chest is narrow at the top, body
+       widens through the torso, haunches are widest at the base.
+       ============================================================ -->
+  <!-- Chest outline -->
+  <rect x="11" y="20" width="10" height="1" fill="#1B2A4E"/>
+  <!-- Body sides (taper outward as we move down) -->
+  <rect x="10" y="21" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="21" y="21" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="9"  y="23" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="22" y="23" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="8"  y="25" width="1"  height="3" fill="#1B2A4E"/>
+  <rect x="23" y="25" width="1"  height="3" fill="#1B2A4E"/>
+
+  <!-- Body fill -->
+  <rect x="11" y="21" width="10" height="2" fill="#ECF6FF"/>
+  <rect x="10" y="23" width="12" height="2" fill="#ECF6FF"/>
+  <rect x="9"  y="25" width="14" height="3" fill="#ECF6FF"/>
+
+  <!-- Belly shading (gives the body an oval look from the side) -->
+  <rect x="15" y="23" width="7" height="4" fill="#D8E5F5"/>
+
+  <!-- ============================================================
+       Front paws (two visible side-by-side at the front-right base)
+       ============================================================ -->
+  <!-- Right front paw -->
+  <rect x="19" y="28" width="4" height="2" fill="#ECF6FF"/>
+  <rect x="18" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="23" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="19" y="30" width="4" height="1" fill="#1B2A4E"/>
+  <rect x="20" y="29" width="1" height="1" fill="#F4B6C0"/>
+  <rect x="21" y="29" width="1" height="1" fill="#F4B6C0"/>
+
+  <!-- ============================================================
+       Hind paw (visible at the back-left base, curling under the
+       body where the bear is sitting)
+       ============================================================ -->
+  <rect x="9"  y="28" width="4" height="2" fill="#ECF6FF"/>
+  <rect x="8"  y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="13" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="9"  y="30" width="4" height="1" fill="#1B2A4E"/>
+  <rect x="10" y="29" width="1" height="1" fill="#F4B6C0"/>
+  <rect x="11" y="29" width="1" height="1" fill="#F4B6C0"/>
+
+  <!-- ============================================================
+       Tail (small white nub peeking at the back-left of the haunch)
+       ============================================================ -->
+  <rect x="6"  y="25" width="2" height="2" fill="#ECF6FF"/>
+  <rect x="5"  y="25" width="1" height="2" fill="#1B2A4E"/>
+  <rect x="6"  y="27" width="2" height="1" fill="#1B2A4E"/>
 </svg>


### PR DESCRIPTION
Per user feedback + a reference photo of a polar bear sat in profile looking up at the sky. Previous design had Pole lying sideways with just a scarf; this redesign matches the reference posture.

## What changed

- **Tall sitting posture** (haunches-on-the-ground, body upright) instead of side-lying. Body tapers narrow at the chest, wider through the torso, widest at the haunches — proper bear-sit silhouette.
- **Snout angled up-and-right**, matching the contemplative pose in the reference photo (bear looking at the sky).
- **Red wooly hat** covering the top of the skull, with a darker red rolled wool cuff at the brim (knit-pattern dots), and a **white pom-pom** on top.
- **Cyan scarf preserved** from the previous design (with the knot + dangling fringe trailing down-left).
- **Front paws** planted side-by-side at the front-right base; one **hind paw** visible at the back-left base.
- One **ear** peeking out below the hat at the back of the head.
- Tiny **tail nub** at the back-left.
- Pink toe beans, pink mouth dab, white eye highlight — same cute touches as before.

## Files

- `apps/desk/src/characters/pole.svg` — Trading Desk world
- `apps/docs/static/img/brand/pole.svg` — cast docs page (kept in sync)

## Verification

- SVG renders cleanly (verified in the in-IDE browser at `/src/characters/pole.svg`)
- World view shows Pole with the new hat at the left-front of the ice
- Docs build clean: `npm run build` succeeds with zero broken-link errors

## Test plan

- [x] Visual smoke test of the sprite in isolation
- [x] Visual smoke test in the world view
- [x] Docs site build clean