### PR TITLE
Trading Desk: stack the rotating hint above the disconnect toast

### DIFF
--- a/apps/desk/src/components/World.tsx
+++ b/apps/desk/src/components/World.tsx
@@ -338,7 +338,9 @@ const SpriteHint: React.FC = () => {
   const h = HINTS[i];
   return (
     <div style={{
-      position: 'fixed', bottom: 12, left: '50%', transform: 'translateX(-50%)',
+      // Pinned ABOVE the disconnect-footer (which sits at bottom: 12)
+      // so the two never overlap when the daemon is unreachable.
+      position: 'fixed', bottom: 56, left: '50%', transform: 'translateX(-50%)',
       zIndex: 40, fontSize: 11, opacity: 0.85,
       display: 'flex', alignItems: 'center', gap: 8,
       background: 'rgba(10,27,54,0.78)', padding: '6px 14px', borderRadius: 14,

--- a/apps/desk/src/styles/global.css
+++ b/apps/desk/src/styles/global.css
@@ -598,12 +598,12 @@ img { -webkit-user-drag: none; user-select: none; }
   100% { opacity: 1; }
 }
 
-/* Disconnected banner -- pinned to TOP-CENTER under the chrome bar so
- * it never collides with the rotating sprite-hint pinned at the
- * bottom. Subtle warning colour. */
+/* Disconnected banner -- pinned to BOTTOM-CENTER. Sits underneath
+ * the rotating sprite-hint (which lives at bottom: 56px). Stacked
+ * vertically so they never overlap. */
 .disconnect-footer {
   position: fixed;
-  top: 56px; left: 50%; transform: translateX(-50%);
+  bottom: 12px; left: 50%; transform: translateX(-50%);
   z-index: 40;
   font-size: 10px;
   background: rgba(240,194,74,0.15);
@@ -613,6 +613,7 @@ img { -webkit-user-drag: none; user-select: none; }
   color: var(--warning);
   max-width: 70vw;
   text-align: center;
+  backdrop-filter: blur(4px);
 }
 
 /* Tooltip-style hover info pinned to a corner */


### PR DESCRIPTION
Per user feedback. Toast was pinned to the top under the chrome bar where it overlapped the title text. Move it back to bottom-center and stack cleanly above the rotating sprite hint:

```
bottom: 56px  ->  rotating sprite hint
bottom: 12px  ->  yellow disconnect toast (only shown when offline)
```

Both get backdrop-filter blur so they read against the bright ice surface.

Verified in the in-IDE browser.