### PR TITLE
Trading Desk: make every sprite draggable too

### DIFF
--- a/apps/desk/src/components/Actor.tsx
+++ b/apps/desk/src/components/Actor.tsx
@@ -1,11 +1,17 @@
 import React, { ReactNode } from 'react';
 import { Sprite, CharacterName } from './Sprite';
+import { useDraggable } from '../hooks/useDraggable';
 
 // Actor positions a sprite at (x, y) in viewport-percent coordinates.
 // Animation classes (idle / walking / running-across / swim / perched
 // / glowing / alert / halted) drive the CSS keyframes from
 // global.css. Optional nameplate is shown on hover; optional speech
 // bubble appears for `speech-pop` duration when set.
+//
+// If dragId is supplied, the actor becomes draggable by the user --
+// click-and-drag anywhere on the sprite moves it, and the position
+// is persisted in localStorage under the supplied id (use the
+// "actor:<name>" namespace to avoid collisions with HUD ids).
 
 export interface ActorProps {
   name: CharacterName;
@@ -22,25 +28,45 @@ export interface ActorProps {
   zIndex?: number;
   /** Inline CSS variables (e.g. --cx / --cy for coin-fly destination). */
   style?: React.CSSProperties;
+  /**
+   * If provided, the actor is draggable by the user. Position is
+   * stored in localStorage under `permafrost-desk:<dragId>`. Use a
+   * stable id like `actor:pole` or `actor:penguin:<agent-id>`.
+   */
+  dragId?: string;
   children?: ReactNode;
 }
 
 export const Actor: React.FC<ActorProps> = ({
-  name, size = 64, x, y, state = '', nameplate, speech, zIndex, style, children,
-}) => (
-  <div
-    className={`actor ${state}`}
-    style={{
-      left: `${x}%`,
-      top: `${y}%`,
-      transform: 'translate(-50%, -50%)',
-      zIndex,
-      ...style,
-    }}
-  >
-    <Sprite name={name} size={size} />
-    {nameplate && <div className="nameplate">{nameplate}</div>}
-    {speech && <div className="speech">{speech}</div>}
-    {children}
-  </div>
-);
+  name, size = 64, x, y, state = '', nameplate, speech, zIndex, style, dragId, children,
+}) => {
+  // Always call the hook (rules of hooks) but pass an empty id if
+  // not draggable -- the hook short-circuits in that case and
+  // returns inert handlers + an empty style override.
+  const drag = useDraggable(dragId ?? '');
+  const isDraggable = !!dragId;
+
+  return (
+    <div
+      ref={isDraggable ? drag.ref : undefined}
+      className={`actor ${state}${isDraggable ? ' draggable' : ''}`}
+      onPointerDown={isDraggable ? drag.handleProps.onPointerDown : undefined}
+      style={{
+        left: `${x}%`,
+        top: `${y}%`,
+        transform: 'translate(-50%, -50%)',
+        zIndex,
+        ...(isDraggable ? drag.handleProps.style : null),
+        ...style,
+        // Spread drag.style LAST so a user-set position overrides
+        // the base x/y placement (and the centering transform).
+        ...(isDraggable ? drag.style : null),
+      }}
+    >
+      <Sprite name={name} size={size} />
+      {nameplate && <div className="nameplate">{nameplate}</div>}
+      {speech && <div className="speech">{speech}</div>}
+      {children}
+    </div>
+  );
+};

--- a/apps/desk/src/components/Hud.tsx
+++ b/apps/desk/src/components/Hud.tsx
@@ -35,7 +35,7 @@ const DragHandle: React.FC = () => (
 export const VaultHud: React.FC<{ navUSD: number; drawdownPct?: number }> = ({
   navUSD, drawdownPct = 0,
 }) => {
-  const drag = useDraggable('vault');
+  const drag = useDraggable('hud:vault');
   const coinCount = Math.max(1, Math.min(16, Math.round(navUSD / 100)));
   const inDrawdown = drawdownPct > 0.05;
   return (
@@ -70,7 +70,7 @@ const STATUS_COLOUR: Record<Agent['status'], string> = {
 };
 
 export const AgentLegendHud: React.FC<{ agents: Agent[] }> = ({ agents }) => {
-  const drag = useDraggable('legend');
+  const drag = useDraggable('hud:legend');
   return (
     <div ref={drag.ref} className="hud legend" style={drag.style}>
       <h3 {...drag.handleProps}>Camp roster<DragHandle /></h3>
@@ -105,7 +105,7 @@ export const AgentLegendHud: React.FC<{ agents: Agent[] }> = ({ agents }) => {
 // Fixed height so the panel doesn't grow as more decisions arrive
 // (the body scrolls instead).
 export const DecisionLogHud: React.FC<{ decisions: DecisionLite[] }> = ({ decisions }) => {
-  const drag = useDraggable('log');
+  const drag = useDraggable('hud:log');
   return (
     <div ref={drag.ref} className="hud log" style={drag.style}>
       <h3 {...drag.handleProps}>Decision log<DragHandle /></h3>
@@ -152,7 +152,7 @@ const CAST_ENTRIES: Array<{ name: import('./Sprite').CharacterName; label: strin
 ];
 
 export const CastHud: React.FC = () => {
-  const drag = useDraggable('cast');
+  const drag = useDraggable('hud:cast');
   return (
     <div ref={drag.ref} className="hud cast" style={drag.style}>
       <h3 {...drag.handleProps}>The expedition<DragHandle /></h3>

--- a/apps/desk/src/components/World.tsx
+++ b/apps/desk/src/components/World.tsx
@@ -171,9 +171,12 @@ export const World: React.FC<WorldProps> = ({ agents, decisions, alertActive }) 
           nameplate={`${a.name || a.id.slice(0, 12)} - ${a.strategy}`}
           speech={speeches[a.id]}
           zIndex={20}
+          dragId={`actor:penguin:${a.id}`}
         />
         {/* Permanent narwhal companion for LLM-using strategies,
-            floating in the sky above the workstation. */}
+            floating in the sky above the workstation. Draggable
+            independently -- if the user drags the penguin, the
+            narwhal stays where the user puts it (and vice versa). */}
         {usesLLM && (
           <Actor
             name="narwhal"
@@ -183,6 +186,7 @@ export const World: React.FC<WorldProps> = ({ agents, decisions, alertActive }) 
             state="perched"
             nameplate={`${a.name || a.id.slice(0, 12)}'s LLM advisor`}
             zIndex={19}
+            dragId={`actor:narwhal:${a.id}`}
           />
         )}
       </React.Fragment>
@@ -198,7 +202,8 @@ export const World: React.FC<WorldProps> = ({ agents, decisions, alertActive }) 
 
       {/* === permanent characters === */}
 
-      {/* Pole the Polar Bear sits stage-left, watches the camp. */}
+      {/* Pole the Polar Bear sits stage-left, watches the camp.
+          Draggable. */}
       <Actor
         name="pole"
         x={12}
@@ -207,10 +212,11 @@ export const World: React.FC<WorldProps> = ({ agents, decisions, alertActive }) 
         state="idle"
         nameplate="Pole the Polar Bear"
         zIndex={25}
+        dragId="actor:pole"
       />
 
       {/* Aurora the snowy owl floats high above the right side of
-          the ice (no iceberg perch any more -- she just hovers). */}
+          the ice. Draggable. */}
       <Actor
         name="owl"
         x={87}
@@ -219,9 +225,11 @@ export const World: React.FC<WorldProps> = ({ agents, decisions, alertActive }) 
         state={`perched ${alertActive ? 'alert' : ''}`}
         nameplate={alertActive ? 'Aurora is ALERT' : 'Aurora is watching'}
         zIndex={26}
+        dragId="actor:owl"
       />
 
-      {/* Kelp the walrus on a small ice patch in front of Pole. */}
+      {/* Kelp the walrus on a small ice patch in front of Pole.
+          Draggable. */}
       <Actor
         name="walrus"
         x={23}
@@ -230,6 +238,7 @@ export const World: React.FC<WorldProps> = ({ agents, decisions, alertActive }) 
         state="idle"
         nameplate="Kelp - swap router"
         zIndex={22}
+        dragId="actor:walrus"
       />
 
       {/* Skipper trots rightward forever via a single infinite CSS
@@ -285,7 +294,7 @@ export const World: React.FC<WorldProps> = ({ agents, decisions, alertActive }) 
 
       {/* Tusk lurks at the back-right of the ice IF a private strategy
           is registered. Maintainer easter egg -- visible only on
-          the maintainer's local build. */}
+          the maintainer's local build. Draggable. */}
       {agents.some(a => a.strategy === 'funding_arb_basic') && (
         <Actor
           name="mammoth"
@@ -295,6 +304,7 @@ export const World: React.FC<WorldProps> = ({ agents, decisions, alertActive }) 
           state="idle"
           nameplate="Tusk - private"
           zIndex={15}
+          dragId="actor:tusk"
         />
       )}
 

--- a/apps/desk/src/hooks/useDraggable.ts
+++ b/apps/desk/src/hooks/useDraggable.ts
@@ -39,11 +39,14 @@ export interface DraggableHandle {
 }
 
 export function useDraggable(id: string): DraggableHandle {
-  const storageKey = `permafrost-desk:hud:${id}`;
+  // Caller passes a fully-qualified id including its namespace
+  // (e.g. "hud:vault", "actor:pole", "actor:penguin:ag-pip-01") so
+  // sprites and HUDs can share this hook without colliding.
+  const storageKey = id ? `permafrost-desk:${id}` : '';
   const ref = useRef<HTMLDivElement>(null);
 
   const [pos, setPos] = useState<Pos | null>(() => {
-    if (typeof window === 'undefined') return null;
+    if (!id || typeof window === 'undefined') return null;
     try {
       const raw = localStorage.getItem(storageKey);
       if (!raw) return null;
@@ -121,16 +124,21 @@ export function useDraggable(id: string): DraggableHandle {
 
   // Persist whenever the user-set position changes.
   useEffect(() => {
-    if (pos === null) return;
+    if (!id || pos === null) return;
     try {
       localStorage.setItem(storageKey, JSON.stringify(pos));
     } catch {
       /* ignore */
     }
-  }, [pos, storageKey]);
+  }, [pos, storageKey, id]);
 
+  // When pos is set, override the host element's transform too.
+  // Actors use `transform: translate(-50%, -50%)` to centre on their
+  // (x%, y%) position; without overriding that, a dragged actor would
+  // jump by half its size on the first move. Setting transform: none
+  // makes the user-set top/left the literal top-left of the element.
   const style: React.CSSProperties = pos
-    ? { top: pos.top, left: pos.left, right: 'auto', bottom: 'auto' }
+    ? { top: pos.top, left: pos.left, right: 'auto', bottom: 'auto', transform: 'none' }
     : {};
 
   return {
@@ -138,7 +146,7 @@ export function useDraggable(id: string): DraggableHandle {
     style,
     handleProps: {
       onPointerDown,
-      style: { cursor: 'move', userSelect: 'none', touchAction: 'none' },
+      style: { cursor: 'grab', userSelect: 'none', touchAction: 'none' },
     },
   };
 }

--- a/apps/desk/src/styles/global.css
+++ b/apps/desk/src/styles/global.css
@@ -251,7 +251,16 @@ img { -webkit-user-drag: none; user-select: none; }
 .actor img {
   display: block;
   image-rendering: pixelated;
+  /* Don't let the IMG eat the parent's pointer events -- if it does,
+   * the user can't drag-from-the-img and we lose the drag handle. */
+  pointer-events: none;
 }
+
+/* Draggable actor affordance: cursor: grab on hover, slight lift on
+ * hover so the sprite reads as "grabbable". Skipper (running-across)
+ * is NOT draggable so this never applies to him. */
+.actor.draggable      { cursor: grab; }
+.actor.draggable:hover { filter: drop-shadow(0 6px 10px rgba(80,210,194,0.45)); }
 
 /* Workstation -- small ice block under each penguin agent so they
  * look like they're standing at a trading desk rather than floating. */


### PR DESCRIPTION
Per user feedback. Every fixed character in the world (Pole, Aurora, Kelp, Tusk, every penguin agent, every narwhal advisor) is now individually draggable, just like the HUDs. Each one persists its position to localStorage so the layout survives page reloads.

## What's draggable

| Sprite | Storage key |
|---|---|
| Pole the Polar Bear | `actor:pole` |
| Aurora the snowy owl | `actor:owl` |
| Kelp the walrus | `actor:walrus` |
| Tusk the mammoth | `actor:tusk` |
| Each penguin agent | `actor:penguin:<agent-id>` |
| Each narwhal advisor | `actor:narwhal:<agent-id>` |

(Per-agent ids mean each penguin and its narwhal can be moved independently.)

## What's NOT draggable

- **Skipper the husky** — the animated reconciliation runner trotting across on a CSS keyframe.
- **Transient effects** (narwhal swim, coin fly).

## UX

- Hover any sprite (except Skipper) → cursor turns to `grab`, sprite gets a cyan-glow drop-shadow.
- Click and drag → sprite follows the pointer. Bounds-clamped to viewport.
- Release → position saved to localStorage.
- Reload → whole camp comes back exactly how the user arranged it (sprites + HUDs together).

## Implementation

- `useDraggable()` now takes a fully-qualified id (no implicit `hud:` prefix). HUD callers use `hud:vault` etc; sprite callers use `actor:pole` etc.
- Hook no-ops gracefully when id is empty (Actor passes `''` when not draggable).
- When pos is set, hook now also outputs `transform: 'none'` so dragged actors don't jump by half their size on the first move (the base `transform: translate(-50%, -50%)` would otherwise compound with the user-set top/left).
- Actor.tsx accepts `dragId`; when set, wires the hook + adds `.draggable` class.
- `.actor img { pointer-events: none }` so the user can drag from the sprite img without losing the parent's pointer handler.

## Verification

- `tsc --noEmit` clean
- Dev server hot-reloads
- Sprites have the new hover affordance, no console errors

## Note on existing HUD positions

HUD storage keys move from `permafrost-desk:hud:<id>` (implicit prefix) to the same path but via the new hook signature. Existing positions in localStorage may be lost on first reload — HUDs reset to defaults; users re-drag once.