### PR TITLE
Pole sprite v3: 3/4-view to match the reference drawing

### DIFF
--- a/apps/desk/src/characters/pole.svg
+++ b/apps/desk/src/characters/pole.svg
@@ -1,163 +1,171 @@
 <!--
-  Pole the Polar Bear. Sat upright in side profile, facing right,
-  snout angled slightly up (regal/contemplative pose, matching the
-  user's reference photo). Wears a red wooly hat with a white
-  pom-pom on top, plus the cyan scarf around his neck.
+  Pole the Polar Bear (v3). Big readable face: round head, two visible
+  ears, two clear eyes, prominent black nose, gentle smile. Sat upright
+  on haunches with two front paws planted together and two hind paws
+  visible at the sides. Wears a red wooly hat (with white pom-pom)
+  and a cyan scarf around the neck. Iterated to match the user's
+  reference line drawing.
   Hand-authored pixel art on a 32x32 grid scaled to 256x256.
   Palette: ice white #ECF6FF, soft shadow #D8E5F5, navy outline
            #1B2A4E, snout cream #F8FBFF, pink mouth/toe-bean #F4B6C0,
-           hat red #DC2626, hat dark red #991B1B, hat shadow #7F1D1D,
-           pom-pom white #FFFFFF, scarf cyan #50D2C2 + dark #2BA694.
+           hat red #DC2626, hat highlight #EF4444, hat dark #991B1B,
+           hat shadow #7F1D1D, pom-pom white #FFFFFF,
+           scarf cyan #50D2C2 + dark #2BA694.
 -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Pole the Polar Bear">
   <title>Pole the Polar Bear</title>
-  <desc>Sat upright in profile with a red wooly hat and a cyan scarf, watching the camp.</desc>
+  <desc>Sat upright in 3/4 view with a round friendly face, a red wooly hat, and a cyan scarf.</desc>
 
   <!-- ============================================================
-       Pom-pom on top of the hat (white tuft)
+       Pom-pom on top of the hat
        ============================================================ -->
-  <rect x="13" y="0" width="2" height="1" fill="#ECF6FF"/>
-  <rect x="12" y="1" width="4" height="1" fill="#FFFFFF"/>
-  <rect x="13" y="2" width="2" height="1" fill="#FFFFFF"/>
+  <rect x="15" y="0" width="2" height="1" fill="#ECF6FF"/>
+  <rect x="14" y="1" width="4" height="1" fill="#FFFFFF"/>
+  <rect x="15" y="2" width="2" height="1" fill="#FFFFFF"/>
 
   <!-- ============================================================
-       Red wooly hat (rounded dome over the skull, with a darker
-       wool-roll cuff at the brim)
+       Red wooly hat (kept short so the face has room)
        ============================================================ -->
-  <!-- Hat dome -->
-  <rect x="11" y="3"  width="5"  height="1" fill="#DC2626"/>
-  <rect x="10" y="4"  width="7"  height="1" fill="#DC2626"/>
-  <rect x="9"  y="5"  width="9"  height="1" fill="#DC2626"/>
-  <rect x="8"  y="6"  width="11" height="1" fill="#DC2626"/>
-  <!-- Highlight on the dome (wool sheen) -->
-  <rect x="12" y="3"  width="2"  height="1" fill="#EF4444"/>
-  <rect x="11" y="4"  width="3"  height="1" fill="#EF4444"/>
-  <rect x="10" y="5"  width="3"  height="1" fill="#EF4444"/>
-  <!-- Brim cuff (darker red, rolled wool) -->
-  <rect x="8"  y="7"  width="11" height="2" fill="#991B1B"/>
-  <rect x="8"  y="8"  width="11" height="1" fill="#7F1D1D"/>
-  <!-- Brim highlights (knit pattern dots) -->
-  <rect x="10" y="7"  width="1"  height="1" fill="#DC2626"/>
-  <rect x="13" y="7"  width="1"  height="1" fill="#DC2626"/>
-  <rect x="16" y="7"  width="1"  height="1" fill="#DC2626"/>
+  <rect x="13" y="3"  width="6"  height="1" fill="#DC2626"/>
+  <rect x="11" y="4"  width="10" height="1" fill="#DC2626"/>
+  <rect x="10" y="5"  width="12" height="1" fill="#DC2626"/>
+  <!-- Highlights (knit sheen) -->
+  <rect x="13" y="4"  width="3"  height="1" fill="#EF4444"/>
+  <rect x="12" y="5"  width="3"  height="1" fill="#EF4444"/>
+  <!-- Brim cuff -->
+  <rect x="9"  y="6"  width="14" height="1" fill="#991B1B"/>
+  <rect x="9"  y="7"  width="14" height="1" fill="#7F1D1D"/>
+  <!-- Knit dots on the brim -->
+  <rect x="11" y="6"  width="1" height="1" fill="#DC2626"/>
+  <rect x="14" y="6"  width="1" height="1" fill="#DC2626"/>
+  <rect x="17" y="6"  width="1" height="1" fill="#DC2626"/>
+  <rect x="20" y="6"  width="1" height="1" fill="#DC2626"/>
 
   <!-- ============================================================
-       Ear (single, visible at the back of the head, peeking out
-       below the hat brim on the back-left side)
+       Ears (two, peeking out either side just below the brim).
+       Larger so they read at a glance.
        ============================================================ -->
-  <rect x="7"  y="9"  width="2" height="2" fill="#1B2A4E"/>
-  <rect x="8"  y="10" width="1" height="1" fill="#F4B6C0"/>
+  <!-- Left ear -->
+  <rect x="7"  y="8"  width="3" height="1" fill="#1B2A4E"/>
+  <rect x="6"  y="9"  width="4" height="2" fill="#1B2A4E"/>
+  <rect x="7"  y="9"  width="3" height="1" fill="#ECF6FF"/>
+  <rect x="7"  y="10" width="2" height="1" fill="#F4B6C0"/>
+  <!-- Right ear -->
+  <rect x="22" y="8"  width="3" height="1" fill="#1B2A4E"/>
+  <rect x="22" y="9"  width="4" height="2" fill="#1B2A4E"/>
+  <rect x="22" y="9"  width="3" height="1" fill="#ECF6FF"/>
+  <rect x="23" y="10" width="2" height="1" fill="#F4B6C0"/>
 
   <!-- ============================================================
-       Head outline + fill (rounded with a long muzzle extending up
-       and to the right - bear looking up at the sky, reference-
-       photo pose)
+       Head (big and round). Outline first, then white fill.
        ============================================================ -->
-  <!-- Head outline (top + sides) -->
-  <rect x="9"  y="9"  width="9"  height="1" fill="#1B2A4E"/>
-  <rect x="18" y="9"  width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="19" y="10" width="1"  height="1" fill="#1B2A4E"/>
-  <!-- Snout outline (extends up and right) -->
-  <rect x="20" y="10" width="2" height="1" fill="#1B2A4E"/>
-  <rect x="22" y="11" width="2" height="1" fill="#1B2A4E"/>
-  <rect x="24" y="12" width="1" height="1" fill="#1B2A4E"/>
-  <rect x="25" y="13" width="1" height="1" fill="#1B2A4E"/>
-  <rect x="22" y="14" width="4" height="1" fill="#1B2A4E"/>
-  <rect x="20" y="15" width="3" height="1" fill="#1B2A4E"/>
-  <rect x="9"  y="15" width="11" height="1" fill="#1B2A4E"/>
+  <!-- Head outline (rounded square) -->
+  <rect x="10" y="8"  width="12" height="1" fill="#1B2A4E"/>
+  <rect x="9"  y="9"  width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="22" y="9"  width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="8"  y="11" width="1"  height="4" fill="#1B2A4E"/>
+  <rect x="23" y="11" width="1"  height="4" fill="#1B2A4E"/>
+  <rect x="9"  y="15" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="22" y="15" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="10" y="16" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="21" y="16" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="11" y="17" width="10" height="1" fill="#1B2A4E"/>
 
-  <!-- Head fill -->
-  <rect x="9"  y="10" width="10" height="5" fill="#ECF6FF"/>
-  <rect x="19" y="11" width="1"  height="4" fill="#ECF6FF"/>
-  <rect x="20" y="11" width="2"  height="3" fill="#ECF6FF"/>
-  <rect x="22" y="12" width="2"  height="2" fill="#F8FBFF"/>
-  <rect x="24" y="13" width="1"  height="1" fill="#F8FBFF"/>
+  <!-- Head fill (white) -->
+  <rect x="10" y="9"  width="12" height="2" fill="#ECF6FF"/>
+  <rect x="9"  y="11" width="14" height="4" fill="#ECF6FF"/>
+  <rect x="10" y="15" width="12" height="1" fill="#ECF6FF"/>
+  <rect x="11" y="16" width="10" height="1" fill="#ECF6FF"/>
 
-  <!-- Forehead shading (just under the hat brim) -->
-  <rect x="9"  y="10" width="9"  height="1" fill="#D8E5F5"/>
-
-  <!-- Eye (single, looking up to match the reference pose) -->
-  <rect x="14" y="11" width="2" height="2" fill="#1B2A4E"/>
-  <rect x="14" y="11" width="1" height="1" fill="#FFFFFF"/>
-
-  <!-- Nose (dark tip of the snout) -->
-  <rect x="24" y="12" width="1" height="1" fill="#1B2A4E"/>
-  <rect x="23" y="13" width="1" height="1" fill="#F8FBFF"/>
-
-  <!-- Mouth (gentle smile, pink hint) -->
-  <rect x="22" y="13" width="1" height="1" fill="#1B2A4E"/>
-  <rect x="20" y="13" width="2" height="1" fill="#F4B6C0"/>
+  <!-- Forehead shading just under the hat -->
+  <rect x="9"  y="9"  width="14" height="1" fill="#D8E5F5"/>
 
   <!-- ============================================================
-       Neck (short, white, joins head to body)
+       Eyes (two, 2x2 black with a 1px white highlight - big enough
+       to read clearly at sprite scale)
        ============================================================ -->
-  <rect x="11" y="16" width="8" height="1" fill="#ECF6FF"/>
+  <rect x="12" y="11" width="2" height="2" fill="#1B2A4E"/>
+  <rect x="18" y="11" width="2" height="2" fill="#1B2A4E"/>
+  <rect x="12" y="11" width="1" height="1" fill="#FFFFFF"/>
+  <rect x="18" y="11" width="1" height="1" fill="#FFFFFF"/>
 
   <!-- ============================================================
-       Cyan scarf around the neck, with a fringed tail trailing
-       to the back-left
+       Snout cream patch + prominent black nose + smile
        ============================================================ -->
-  <!-- Main scarf wrap -->
-  <rect x="10" y="17" width="11" height="1" fill="#2BA694"/>
-  <rect x="9"  y="18" width="13" height="2" fill="#50D2C2"/>
-  <rect x="9"  y="20" width="13" height="1" fill="#2BA694"/>
-  <!-- Scarf knot on the left side -->
-  <rect x="7"  y="18" width="2"  height="3" fill="#50D2C2"/>
-  <rect x="7"  y="18" width="2"  height="1" fill="#2BA694"/>
-  <rect x="7"  y="20" width="2"  height="1" fill="#2BA694"/>
-  <!-- Scarf tail dangling down-left -->
-  <rect x="5"  y="21" width="2"  height="2" fill="#50D2C2"/>
-  <rect x="5"  y="23" width="2"  height="1" fill="#2BA694"/>
-  <rect x="6"  y="24" width="1"  height="1" fill="#50D2C2"/>
+  <!-- Snout patch (lighter cream over the lower face) -->
+  <rect x="12" y="13" width="8" height="3" fill="#F8FBFF"/>
+  <!-- Nose: 3-pixel wide rounded rectangle at the snout's centre -->
+  <rect x="14" y="13" width="4" height="2" fill="#1B2A4E"/>
+  <rect x="14" y="13" width="1" height="1" fill="#FFFFFF"/>
+  <rect x="15" y="15" width="2" height="1" fill="#1B2A4E"/>
+  <!-- Smile: clear upturned curve below the nose -->
+  <rect x="13" y="16" width="1" height="1" fill="#1B2A4E"/>
+  <rect x="14" y="16" width="4" height="1" fill="#F4B6C0"/>
+  <rect x="18" y="16" width="1" height="1" fill="#1B2A4E"/>
 
   <!-- ============================================================
-       Body (sitting upright). Chest is narrow at the top, body
-       widens through the torso, haunches are widest at the base.
+       Cyan scarf around the neck. Fringed knot trails to the right.
        ============================================================ -->
-  <!-- Chest outline -->
-  <rect x="11" y="20" width="10" height="1" fill="#1B2A4E"/>
-  <!-- Body sides (taper outward as we move down) -->
-  <rect x="10" y="21" width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="21" y="21" width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="9"  y="23" width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="22" y="23" width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="8"  y="25" width="1"  height="3" fill="#1B2A4E"/>
-  <rect x="23" y="25" width="1"  height="3" fill="#1B2A4E"/>
+  <rect x="11" y="18" width="10" height="1" fill="#2BA694"/>
+  <rect x="10" y="19" width="12" height="2" fill="#50D2C2"/>
+  <rect x="11" y="21" width="10" height="1" fill="#2BA694"/>
+  <!-- Knot on the right side -->
+  <rect x="22" y="19" width="2"  height="3" fill="#50D2C2"/>
+  <rect x="22" y="19" width="2"  height="1" fill="#2BA694"/>
+  <rect x="22" y="21" width="2"  height="1" fill="#2BA694"/>
+  <!-- Trailing scarf tail (fringed) -->
+  <rect x="24" y="22" width="2"  height="2" fill="#50D2C2"/>
+  <rect x="24" y="24" width="2"  height="1" fill="#2BA694"/>
+  <rect x="25" y="25" width="1"  height="2" fill="#50D2C2"/>
+
+  <!-- ============================================================
+       Body (round, sat-bear silhouette). Narrow at chest, wider
+       at haunches, soft rounded shoulders.
+       ============================================================ -->
+  <!-- Top of body -->
+  <rect x="12" y="22" width="8"  height="1" fill="#1B2A4E"/>
+  <!-- Body sides taper outward -->
+  <rect x="11" y="23" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="20" y="23" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="10" y="24" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="21" y="24" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="9"  y="26" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="22" y="26" width="1"  height="2" fill="#1B2A4E"/>
 
   <!-- Body fill -->
-  <rect x="11" y="21" width="10" height="2" fill="#ECF6FF"/>
-  <rect x="10" y="23" width="12" height="2" fill="#ECF6FF"/>
-  <rect x="9"  y="25" width="14" height="3" fill="#ECF6FF"/>
+  <rect x="12" y="23" width="8"  height="1" fill="#ECF6FF"/>
+  <rect x="11" y="24" width="10" height="2" fill="#ECF6FF"/>
+  <rect x="10" y="26" width="12" height="2" fill="#ECF6FF"/>
 
-  <!-- Belly shading (gives the body an oval look from the side) -->
-  <rect x="15" y="23" width="7" height="4" fill="#D8E5F5"/>
+  <!-- Belly oval (soft shadow) -->
+  <rect x="13" y="24" width="6"  height="3" fill="#D8E5F5"/>
 
   <!-- ============================================================
-       Front paws (two visible side-by-side at the front-right base)
+       Front paws (two, planted side-by-side at the centre-bottom,
+       matching the reference)
        ============================================================ -->
+  <!-- Left front paw -->
+  <rect x="12" y="28" width="3" height="2" fill="#ECF6FF"/>
+  <rect x="11" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="15" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="12" y="30" width="3" height="1" fill="#1B2A4E"/>
+  <rect x="13" y="29" width="1" height="1" fill="#F4B6C0"/>
   <!-- Right front paw -->
-  <rect x="19" y="28" width="4" height="2" fill="#ECF6FF"/>
-  <rect x="18" y="28" width="1" height="3" fill="#1B2A4E"/>
-  <rect x="23" y="28" width="1" height="3" fill="#1B2A4E"/>
-  <rect x="19" y="30" width="4" height="1" fill="#1B2A4E"/>
-  <rect x="20" y="29" width="1" height="1" fill="#F4B6C0"/>
-  <rect x="21" y="29" width="1" height="1" fill="#F4B6C0"/>
+  <rect x="17" y="28" width="3" height="2" fill="#ECF6FF"/>
+  <rect x="16" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="20" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="17" y="30" width="3" height="1" fill="#1B2A4E"/>
+  <rect x="18" y="29" width="1" height="1" fill="#F4B6C0"/>
 
   <!-- ============================================================
-       Hind paw (visible at the back-left base, curling under the
-       body where the bear is sitting)
+       Hind paws (visible at the sides, peeking out from the haunches)
        ============================================================ -->
-  <rect x="9"  y="28" width="4" height="2" fill="#ECF6FF"/>
-  <rect x="8"  y="28" width="1" height="3" fill="#1B2A4E"/>
-  <rect x="13" y="28" width="1" height="3" fill="#1B2A4E"/>
-  <rect x="9"  y="30" width="4" height="1" fill="#1B2A4E"/>
-  <rect x="10" y="29" width="1" height="1" fill="#F4B6C0"/>
-  <rect x="11" y="29" width="1" height="1" fill="#F4B6C0"/>
-
-  <!-- ============================================================
-       Tail (small white nub peeking at the back-left of the haunch)
-       ============================================================ -->
-  <rect x="6"  y="25" width="2" height="2" fill="#ECF6FF"/>
-  <rect x="5"  y="25" width="1" height="2" fill="#1B2A4E"/>
-  <rect x="6"  y="27" width="2" height="1" fill="#1B2A4E"/>
+  <!-- Left hind -->
+  <rect x="8"  y="28" width="3" height="2" fill="#ECF6FF"/>
+  <rect x="7"  y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="8"  y="30" width="3" height="1" fill="#1B2A4E"/>
+  <!-- Right hind -->
+  <rect x="21" y="28" width="3" height="2" fill="#ECF6FF"/>
+  <rect x="24" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="21" y="30" width="3" height="1" fill="#1B2A4E"/>
 </svg>

--- a/apps/docs/static/img/brand/pole.svg
+++ b/apps/docs/static/img/brand/pole.svg
@@ -1,163 +1,171 @@
 <!--
-  Pole the Polar Bear. Sat upright in side profile, facing right,
-  snout angled slightly up (regal/contemplative pose, matching the
-  user's reference photo). Wears a red wooly hat with a white
-  pom-pom on top, plus the cyan scarf around his neck.
+  Pole the Polar Bear (v3). Big readable face: round head, two visible
+  ears, two clear eyes, prominent black nose, gentle smile. Sat upright
+  on haunches with two front paws planted together and two hind paws
+  visible at the sides. Wears a red wooly hat (with white pom-pom)
+  and a cyan scarf around the neck. Iterated to match the user's
+  reference line drawing.
   Hand-authored pixel art on a 32x32 grid scaled to 256x256.
   Palette: ice white #ECF6FF, soft shadow #D8E5F5, navy outline
            #1B2A4E, snout cream #F8FBFF, pink mouth/toe-bean #F4B6C0,
-           hat red #DC2626, hat dark red #991B1B, hat shadow #7F1D1D,
-           pom-pom white #FFFFFF, scarf cyan #50D2C2 + dark #2BA694.
+           hat red #DC2626, hat highlight #EF4444, hat dark #991B1B,
+           hat shadow #7F1D1D, pom-pom white #FFFFFF,
+           scarf cyan #50D2C2 + dark #2BA694.
 -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Pole the Polar Bear">
   <title>Pole the Polar Bear</title>
-  <desc>Sat upright in profile with a red wooly hat and a cyan scarf, watching the camp.</desc>
+  <desc>Sat upright in 3/4 view with a round friendly face, a red wooly hat, and a cyan scarf.</desc>
 
   <!-- ============================================================
-       Pom-pom on top of the hat (white tuft)
+       Pom-pom on top of the hat
        ============================================================ -->
-  <rect x="13" y="0" width="2" height="1" fill="#ECF6FF"/>
-  <rect x="12" y="1" width="4" height="1" fill="#FFFFFF"/>
-  <rect x="13" y="2" width="2" height="1" fill="#FFFFFF"/>
+  <rect x="15" y="0" width="2" height="1" fill="#ECF6FF"/>
+  <rect x="14" y="1" width="4" height="1" fill="#FFFFFF"/>
+  <rect x="15" y="2" width="2" height="1" fill="#FFFFFF"/>
 
   <!-- ============================================================
-       Red wooly hat (rounded dome over the skull, with a darker
-       wool-roll cuff at the brim)
+       Red wooly hat (kept short so the face has room)
        ============================================================ -->
-  <!-- Hat dome -->
-  <rect x="11" y="3"  width="5"  height="1" fill="#DC2626"/>
-  <rect x="10" y="4"  width="7"  height="1" fill="#DC2626"/>
-  <rect x="9"  y="5"  width="9"  height="1" fill="#DC2626"/>
-  <rect x="8"  y="6"  width="11" height="1" fill="#DC2626"/>
-  <!-- Highlight on the dome (wool sheen) -->
-  <rect x="12" y="3"  width="2"  height="1" fill="#EF4444"/>
-  <rect x="11" y="4"  width="3"  height="1" fill="#EF4444"/>
-  <rect x="10" y="5"  width="3"  height="1" fill="#EF4444"/>
-  <!-- Brim cuff (darker red, rolled wool) -->
-  <rect x="8"  y="7"  width="11" height="2" fill="#991B1B"/>
-  <rect x="8"  y="8"  width="11" height="1" fill="#7F1D1D"/>
-  <!-- Brim highlights (knit pattern dots) -->
-  <rect x="10" y="7"  width="1"  height="1" fill="#DC2626"/>
-  <rect x="13" y="7"  width="1"  height="1" fill="#DC2626"/>
-  <rect x="16" y="7"  width="1"  height="1" fill="#DC2626"/>
+  <rect x="13" y="3"  width="6"  height="1" fill="#DC2626"/>
+  <rect x="11" y="4"  width="10" height="1" fill="#DC2626"/>
+  <rect x="10" y="5"  width="12" height="1" fill="#DC2626"/>
+  <!-- Highlights (knit sheen) -->
+  <rect x="13" y="4"  width="3"  height="1" fill="#EF4444"/>
+  <rect x="12" y="5"  width="3"  height="1" fill="#EF4444"/>
+  <!-- Brim cuff -->
+  <rect x="9"  y="6"  width="14" height="1" fill="#991B1B"/>
+  <rect x="9"  y="7"  width="14" height="1" fill="#7F1D1D"/>
+  <!-- Knit dots on the brim -->
+  <rect x="11" y="6"  width="1" height="1" fill="#DC2626"/>
+  <rect x="14" y="6"  width="1" height="1" fill="#DC2626"/>
+  <rect x="17" y="6"  width="1" height="1" fill="#DC2626"/>
+  <rect x="20" y="6"  width="1" height="1" fill="#DC2626"/>
 
   <!-- ============================================================
-       Ear (single, visible at the back of the head, peeking out
-       below the hat brim on the back-left side)
+       Ears (two, peeking out either side just below the brim).
+       Larger so they read at a glance.
        ============================================================ -->
-  <rect x="7"  y="9"  width="2" height="2" fill="#1B2A4E"/>
-  <rect x="8"  y="10" width="1" height="1" fill="#F4B6C0"/>
+  <!-- Left ear -->
+  <rect x="7"  y="8"  width="3" height="1" fill="#1B2A4E"/>
+  <rect x="6"  y="9"  width="4" height="2" fill="#1B2A4E"/>
+  <rect x="7"  y="9"  width="3" height="1" fill="#ECF6FF"/>
+  <rect x="7"  y="10" width="2" height="1" fill="#F4B6C0"/>
+  <!-- Right ear -->
+  <rect x="22" y="8"  width="3" height="1" fill="#1B2A4E"/>
+  <rect x="22" y="9"  width="4" height="2" fill="#1B2A4E"/>
+  <rect x="22" y="9"  width="3" height="1" fill="#ECF6FF"/>
+  <rect x="23" y="10" width="2" height="1" fill="#F4B6C0"/>
 
   <!-- ============================================================
-       Head outline + fill (rounded with a long muzzle extending up
-       and to the right - bear looking up at the sky, reference-
-       photo pose)
+       Head (big and round). Outline first, then white fill.
        ============================================================ -->
-  <!-- Head outline (top + sides) -->
-  <rect x="9"  y="9"  width="9"  height="1" fill="#1B2A4E"/>
-  <rect x="18" y="9"  width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="19" y="10" width="1"  height="1" fill="#1B2A4E"/>
-  <!-- Snout outline (extends up and right) -->
-  <rect x="20" y="10" width="2" height="1" fill="#1B2A4E"/>
-  <rect x="22" y="11" width="2" height="1" fill="#1B2A4E"/>
-  <rect x="24" y="12" width="1" height="1" fill="#1B2A4E"/>
-  <rect x="25" y="13" width="1" height="1" fill="#1B2A4E"/>
-  <rect x="22" y="14" width="4" height="1" fill="#1B2A4E"/>
-  <rect x="20" y="15" width="3" height="1" fill="#1B2A4E"/>
-  <rect x="9"  y="15" width="11" height="1" fill="#1B2A4E"/>
+  <!-- Head outline (rounded square) -->
+  <rect x="10" y="8"  width="12" height="1" fill="#1B2A4E"/>
+  <rect x="9"  y="9"  width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="22" y="9"  width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="8"  y="11" width="1"  height="4" fill="#1B2A4E"/>
+  <rect x="23" y="11" width="1"  height="4" fill="#1B2A4E"/>
+  <rect x="9"  y="15" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="22" y="15" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="10" y="16" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="21" y="16" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="11" y="17" width="10" height="1" fill="#1B2A4E"/>
 
-  <!-- Head fill -->
-  <rect x="9"  y="10" width="10" height="5" fill="#ECF6FF"/>
-  <rect x="19" y="11" width="1"  height="4" fill="#ECF6FF"/>
-  <rect x="20" y="11" width="2"  height="3" fill="#ECF6FF"/>
-  <rect x="22" y="12" width="2"  height="2" fill="#F8FBFF"/>
-  <rect x="24" y="13" width="1"  height="1" fill="#F8FBFF"/>
+  <!-- Head fill (white) -->
+  <rect x="10" y="9"  width="12" height="2" fill="#ECF6FF"/>
+  <rect x="9"  y="11" width="14" height="4" fill="#ECF6FF"/>
+  <rect x="10" y="15" width="12" height="1" fill="#ECF6FF"/>
+  <rect x="11" y="16" width="10" height="1" fill="#ECF6FF"/>
 
-  <!-- Forehead shading (just under the hat brim) -->
-  <rect x="9"  y="10" width="9"  height="1" fill="#D8E5F5"/>
-
-  <!-- Eye (single, looking up to match the reference pose) -->
-  <rect x="14" y="11" width="2" height="2" fill="#1B2A4E"/>
-  <rect x="14" y="11" width="1" height="1" fill="#FFFFFF"/>
-
-  <!-- Nose (dark tip of the snout) -->
-  <rect x="24" y="12" width="1" height="1" fill="#1B2A4E"/>
-  <rect x="23" y="13" width="1" height="1" fill="#F8FBFF"/>
-
-  <!-- Mouth (gentle smile, pink hint) -->
-  <rect x="22" y="13" width="1" height="1" fill="#1B2A4E"/>
-  <rect x="20" y="13" width="2" height="1" fill="#F4B6C0"/>
+  <!-- Forehead shading just under the hat -->
+  <rect x="9"  y="9"  width="14" height="1" fill="#D8E5F5"/>
 
   <!-- ============================================================
-       Neck (short, white, joins head to body)
+       Eyes (two, 2x2 black with a 1px white highlight - big enough
+       to read clearly at sprite scale)
        ============================================================ -->
-  <rect x="11" y="16" width="8" height="1" fill="#ECF6FF"/>
+  <rect x="12" y="11" width="2" height="2" fill="#1B2A4E"/>
+  <rect x="18" y="11" width="2" height="2" fill="#1B2A4E"/>
+  <rect x="12" y="11" width="1" height="1" fill="#FFFFFF"/>
+  <rect x="18" y="11" width="1" height="1" fill="#FFFFFF"/>
 
   <!-- ============================================================
-       Cyan scarf around the neck, with a fringed tail trailing
-       to the back-left
+       Snout cream patch + prominent black nose + smile
        ============================================================ -->
-  <!-- Main scarf wrap -->
-  <rect x="10" y="17" width="11" height="1" fill="#2BA694"/>
-  <rect x="9"  y="18" width="13" height="2" fill="#50D2C2"/>
-  <rect x="9"  y="20" width="13" height="1" fill="#2BA694"/>
-  <!-- Scarf knot on the left side -->
-  <rect x="7"  y="18" width="2"  height="3" fill="#50D2C2"/>
-  <rect x="7"  y="18" width="2"  height="1" fill="#2BA694"/>
-  <rect x="7"  y="20" width="2"  height="1" fill="#2BA694"/>
-  <!-- Scarf tail dangling down-left -->
-  <rect x="5"  y="21" width="2"  height="2" fill="#50D2C2"/>
-  <rect x="5"  y="23" width="2"  height="1" fill="#2BA694"/>
-  <rect x="6"  y="24" width="1"  height="1" fill="#50D2C2"/>
+  <!-- Snout patch (lighter cream over the lower face) -->
+  <rect x="12" y="13" width="8" height="3" fill="#F8FBFF"/>
+  <!-- Nose: 3-pixel wide rounded rectangle at the snout's centre -->
+  <rect x="14" y="13" width="4" height="2" fill="#1B2A4E"/>
+  <rect x="14" y="13" width="1" height="1" fill="#FFFFFF"/>
+  <rect x="15" y="15" width="2" height="1" fill="#1B2A4E"/>
+  <!-- Smile: clear upturned curve below the nose -->
+  <rect x="13" y="16" width="1" height="1" fill="#1B2A4E"/>
+  <rect x="14" y="16" width="4" height="1" fill="#F4B6C0"/>
+  <rect x="18" y="16" width="1" height="1" fill="#1B2A4E"/>
 
   <!-- ============================================================
-       Body (sitting upright). Chest is narrow at the top, body
-       widens through the torso, haunches are widest at the base.
+       Cyan scarf around the neck. Fringed knot trails to the right.
        ============================================================ -->
-  <!-- Chest outline -->
-  <rect x="11" y="20" width="10" height="1" fill="#1B2A4E"/>
-  <!-- Body sides (taper outward as we move down) -->
-  <rect x="10" y="21" width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="21" y="21" width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="9"  y="23" width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="22" y="23" width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="8"  y="25" width="1"  height="3" fill="#1B2A4E"/>
-  <rect x="23" y="25" width="1"  height="3" fill="#1B2A4E"/>
+  <rect x="11" y="18" width="10" height="1" fill="#2BA694"/>
+  <rect x="10" y="19" width="12" height="2" fill="#50D2C2"/>
+  <rect x="11" y="21" width="10" height="1" fill="#2BA694"/>
+  <!-- Knot on the right side -->
+  <rect x="22" y="19" width="2"  height="3" fill="#50D2C2"/>
+  <rect x="22" y="19" width="2"  height="1" fill="#2BA694"/>
+  <rect x="22" y="21" width="2"  height="1" fill="#2BA694"/>
+  <!-- Trailing scarf tail (fringed) -->
+  <rect x="24" y="22" width="2"  height="2" fill="#50D2C2"/>
+  <rect x="24" y="24" width="2"  height="1" fill="#2BA694"/>
+  <rect x="25" y="25" width="1"  height="2" fill="#50D2C2"/>
+
+  <!-- ============================================================
+       Body (round, sat-bear silhouette). Narrow at chest, wider
+       at haunches, soft rounded shoulders.
+       ============================================================ -->
+  <!-- Top of body -->
+  <rect x="12" y="22" width="8"  height="1" fill="#1B2A4E"/>
+  <!-- Body sides taper outward -->
+  <rect x="11" y="23" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="20" y="23" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="10" y="24" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="21" y="24" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="9"  y="26" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="22" y="26" width="1"  height="2" fill="#1B2A4E"/>
 
   <!-- Body fill -->
-  <rect x="11" y="21" width="10" height="2" fill="#ECF6FF"/>
-  <rect x="10" y="23" width="12" height="2" fill="#ECF6FF"/>
-  <rect x="9"  y="25" width="14" height="3" fill="#ECF6FF"/>
+  <rect x="12" y="23" width="8"  height="1" fill="#ECF6FF"/>
+  <rect x="11" y="24" width="10" height="2" fill="#ECF6FF"/>
+  <rect x="10" y="26" width="12" height="2" fill="#ECF6FF"/>
 
-  <!-- Belly shading (gives the body an oval look from the side) -->
-  <rect x="15" y="23" width="7" height="4" fill="#D8E5F5"/>
+  <!-- Belly oval (soft shadow) -->
+  <rect x="13" y="24" width="6"  height="3" fill="#D8E5F5"/>
 
   <!-- ============================================================
-       Front paws (two visible side-by-side at the front-right base)
+       Front paws (two, planted side-by-side at the centre-bottom,
+       matching the reference)
        ============================================================ -->
+  <!-- Left front paw -->
+  <rect x="12" y="28" width="3" height="2" fill="#ECF6FF"/>
+  <rect x="11" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="15" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="12" y="30" width="3" height="1" fill="#1B2A4E"/>
+  <rect x="13" y="29" width="1" height="1" fill="#F4B6C0"/>
   <!-- Right front paw -->
-  <rect x="19" y="28" width="4" height="2" fill="#ECF6FF"/>
-  <rect x="18" y="28" width="1" height="3" fill="#1B2A4E"/>
-  <rect x="23" y="28" width="1" height="3" fill="#1B2A4E"/>
-  <rect x="19" y="30" width="4" height="1" fill="#1B2A4E"/>
-  <rect x="20" y="29" width="1" height="1" fill="#F4B6C0"/>
-  <rect x="21" y="29" width="1" height="1" fill="#F4B6C0"/>
+  <rect x="17" y="28" width="3" height="2" fill="#ECF6FF"/>
+  <rect x="16" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="20" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="17" y="30" width="3" height="1" fill="#1B2A4E"/>
+  <rect x="18" y="29" width="1" height="1" fill="#F4B6C0"/>
 
   <!-- ============================================================
-       Hind paw (visible at the back-left base, curling under the
-       body where the bear is sitting)
+       Hind paws (visible at the sides, peeking out from the haunches)
        ============================================================ -->
-  <rect x="9"  y="28" width="4" height="2" fill="#ECF6FF"/>
-  <rect x="8"  y="28" width="1" height="3" fill="#1B2A4E"/>
-  <rect x="13" y="28" width="1" height="3" fill="#1B2A4E"/>
-  <rect x="9"  y="30" width="4" height="1" fill="#1B2A4E"/>
-  <rect x="10" y="29" width="1" height="1" fill="#F4B6C0"/>
-  <rect x="11" y="29" width="1" height="1" fill="#F4B6C0"/>
-
-  <!-- ============================================================
-       Tail (small white nub peeking at the back-left of the haunch)
-       ============================================================ -->
-  <rect x="6"  y="25" width="2" height="2" fill="#ECF6FF"/>
-  <rect x="5"  y="25" width="1" height="2" fill="#1B2A4E"/>
-  <rect x="6"  y="27" width="2" height="1" fill="#1B2A4E"/>
+  <!-- Left hind -->
+  <rect x="8"  y="28" width="3" height="2" fill="#ECF6FF"/>
+  <rect x="7"  y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="8"  y="30" width="3" height="1" fill="#1B2A4E"/>
+  <!-- Right hind -->
+  <rect x="21" y="28" width="3" height="2" fill="#ECF6FF"/>
+  <rect x="24" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="21" y="30" width="3" height="1" fill="#1B2A4E"/>
 </svg>


### PR DESCRIPTION
User shared a line-drawing reference of a sat polar bear in 3/4 view with clear face features (two ears, two eyes, prominent nose, smile). Previous v2 was a strict side profile; this v3 redesigns to match.

## Changes

- **Head turned to face camera (3/4 view)** instead of strict side profile — both ears now visible, both eyes visible
- **Eyes are 2x2 black dots** with 1px white highlight (was a single 1x2 side-profile pupil) — readable at sprite scale
- **Nose** is now a 4x2 black rectangle centred on the snout (was just 1x1)
- **Mouth** is a clear pink smile bracketed by two navy pixels — upturned curve
- **Snout cream patch** covers the lower face for shape definition
- **Two ears**, larger and more pronounced, with pink inner detail
- **Body is rounder** — narrow at chest, widens through torso, widest at haunches
- **Two front paws planted side-by-side** at centre-bottom (matching the reference)
- **Two hind paws** visible at the sides peeking from under the haunches
- Hat sized down slightly so the face has more room
- All previous touches preserved: red wool hat + white pom-pom + knit-pattern brim dots, cyan scarf, pink toe beans

## Files

Both copies updated: `apps/desk/src/characters/pole.svg` + `apps/docs/static/img/brand/pole.svg`

## Verification

- SVG renders cleanly (verified in the in-IDE browser)
- World view shows the new Pole at left-front of the ice with all face features readable