### PR TITLE
Walrus sprite v3: front-facing with prominent snout + tusks

### DIFF
--- a/apps/desk/src/characters/walrus.svg
+++ b/apps/desk/src/characters/walrus.svg
@@ -1,60 +1,155 @@
 <!--
-  Kelp the walrus. Swap router  appears on swap routes between
-  chains, hauling tokens across.
+  Kelp the Walrus (v3). Front-facing 3/4 view matching the user's
+  reference: round brown body bulging wide at the bottom, big cream
+  snout dominating the lower face, two prominent white tusks pointing
+  straight down, two beady eyes with brown brow ridges above, two
+  front flippers planted at the base, sparse whisker dots.
 
-  Hand-authored pixel art, 32x32 logical grid.
-  Palette: warm brown body #8B5C3A, paler belly #C19169, cream tusks
-           #F1E5C3, dark eye #1B1F2A, navy outline #1B2A4E,
-           pink whisker #F4B6C0.
+  Drawing order matters here: body is drawn FIRST, then the tusks +
+  snout + face are layered ON TOP so they're never covered by the
+  body fill.
+
+  Hand-authored pixel art on a 32x32 grid scaled to 256x256.
+  Palette: warm brown #8B5C3A, light belly #C19169, dark brown #5A3A20,
+           highlight #A06D43, cream snout #F5E6D0, snout shadow
+           #D4B896, tusk cream #F1E5C3, tusk highlight #FFFFFF,
+           navy outline #1B2A4E, eye black #1B1F2A.
 -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Kelp the walrus, swap router">
-  <title>Kelp the walrus</title>
-  <desc>Hauls tokens between chains via the swap router.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Kelp the Walrus">
+  <title>Kelp the Walrus</title>
+  <desc>Front-facing walrus with big cream snout, two long tusks, and two front flippers. Routes swaps between chains.</desc>
 
+  <!-- ============================================================
+       BODY (drawn first so the snout + tusks layer on top later).
+       Tear-drop pinniped silhouette: narrow at the top, bulging
+       wide at the base where the walrus is sat.
+       ============================================================ -->
+  <!-- Body outline (curving outward from shoulders to base) -->
+  <rect x="9"  y="13" width="2"  height="1" fill="#1B2A4E"/>
+  <rect x="21" y="13" width="2"  height="1" fill="#1B2A4E"/>
+  <rect x="8"  y="14" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="23" y="14" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="7"  y="16" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="24" y="16" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="6"  y="18" width="1"  height="3" fill="#1B2A4E"/>
+  <rect x="25" y="18" width="1"  height="3" fill="#1B2A4E"/>
+  <rect x="5"  y="21" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="26" y="21" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="6"  y="27" width="20" height="1" fill="#1B2A4E"/>
+
+  <!-- Body fill (brown) -->
+  <rect x="9"  y="14" width="14" height="2" fill="#8B5C3A"/>
+  <rect x="8"  y="16" width="16" height="2" fill="#8B5C3A"/>
+  <rect x="7"  y="18" width="18" height="3" fill="#8B5C3A"/>
+  <rect x="6"  y="21" width="20" height="6" fill="#8B5C3A"/>
+
+  <!-- Belly (lighter brown, large oval at front-centre) -->
+  <rect x="11" y="17" width="10" height="1" fill="#C19169"/>
+  <rect x="10" y="18" width="12" height="3" fill="#C19169"/>
+  <rect x="9"  y="21" width="14" height="6" fill="#C19169"/>
+
+  <!-- Subtle belly fold lines -->
+  <rect x="8"  y="23" width="1"  height="1" fill="#5A3A20"/>
+  <rect x="23" y="23" width="1"  height="1" fill="#5A3A20"/>
+
+  <!-- ============================================================
+       FRONT FLIPPERS (two, planted at the base under the body).
+       Drawn before the head so the body's lower edge sits on top.
+       ============================================================ -->
+  <!-- Left flipper -->
+  <rect x="3"  y="25" width="6"  height="1" fill="#1B2A4E"/>
+  <rect x="2"  y="26" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="3"  y="28" width="7"  height="1" fill="#1B2A4E"/>
+  <rect x="9"  y="27" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="3"  y="26" width="6"  height="2" fill="#8B5C3A"/>
+  <!-- Toe lines -->
+  <rect x="4"  y="27" width="1"  height="1" fill="#5A3A20"/>
+  <rect x="6"  y="27" width="1"  height="1" fill="#5A3A20"/>
+  <rect x="8"  y="27" width="1"  height="1" fill="#5A3A20"/>
+
+  <!-- Right flipper -->
+  <rect x="23" y="25" width="6"  height="1" fill="#1B2A4E"/>
+  <rect x="29" y="26" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="22" y="28" width="7"  height="1" fill="#1B2A4E"/>
+  <rect x="22" y="27" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="23" y="26" width="6"  height="2" fill="#8B5C3A"/>
+  <!-- Toe lines -->
+  <rect x="24" y="27" width="1"  height="1" fill="#5A3A20"/>
+  <rect x="26" y="27" width="1"  height="1" fill="#5A3A20"/>
+  <rect x="28" y="27" width="1"  height="1" fill="#5A3A20"/>
+
+  <!-- ============================================================
+       HEAD (drawn AFTER body so it's on top).
+       Round brown head sitting on top of the body. Wider than my
+       previous attempt - 14 columns wide so the snout has room.
+       ============================================================ -->
   <!-- Head outline -->
-  <rect x="6"  y="6"  width="14" height="1" fill="#1B2A4E"/>
-  <rect x="5"  y="7"  width="1"  height="9" fill="#1B2A4E"/>
-  <rect x="20" y="7"  width="1"  height="9" fill="#1B2A4E"/>
-  <rect x="6"  y="16" width="14" height="1" fill="#1B2A4E"/>
-
+  <rect x="11" y="2"  width="10" height="1" fill="#1B2A4E"/>
+  <rect x="10" y="3"  width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="21" y="3"  width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="9"  y="5"  width="1"  height="3" fill="#1B2A4E"/>
+  <rect x="22" y="5"  width="1"  height="3" fill="#1B2A4E"/>
   <!-- Head fill -->
-  <rect x="6"  y="7"  width="14" height="9" fill="#8B5C3A"/>
+  <rect x="11" y="3"  width="10" height="2" fill="#8B5C3A"/>
+  <rect x="10" y="5"  width="12" height="3" fill="#8B5C3A"/>
 
+  <!-- Top-of-head highlight -->
+  <rect x="14" y="4"  width="3"  height="1" fill="#A06D43"/>
+
+  <!-- ============================================================
+       EYES (two black dots with white highlight) + brow ridges
+       ============================================================ -->
+  <!-- Brow ridges (slightly darker brown above each eye) -->
+  <rect x="11" y="5"  width="3"  height="1" fill="#5A3A20"/>
+  <rect x="18" y="5"  width="3"  height="1" fill="#5A3A20"/>
   <!-- Eyes -->
-  <rect x="9"  y="10" width="1"  height="1" fill="#1B1F2A"/>
-  <rect x="13" y="10" width="1"  height="1" fill="#1B1F2A"/>
+  <rect x="11" y="6"  width="2"  height="2" fill="#1B1F2A"/>
+  <rect x="19" y="6"  width="2"  height="2" fill="#1B1F2A"/>
+  <rect x="11" y="6"  width="1"  height="1" fill="#FFFFFF"/>
+  <rect x="19" y="6"  width="1"  height="1" fill="#FFFFFF"/>
 
-  <!-- Snout (paler) -->
-  <rect x="8"  y="12" width="8"  height="3" fill="#C19169"/>
+  <!-- ============================================================
+       SNOUT / MUZZLE - big cream patch, dominates the lower face.
+       Drawn over the body, so it spills slightly down past the head.
+       ============================================================ -->
+  <!-- Snout outline -->
+  <rect x="11" y="8"  width="10" height="1" fill="#1B2A4E"/>
+  <rect x="10" y="9"  width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="21" y="9"  width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="11" y="15" width="10" height="1" fill="#1B2A4E"/>
+  <!-- Snout fill (cream) -->
+  <rect x="11" y="9"  width="10" height="6" fill="#F5E6D0"/>
+  <!-- Centre divider down the snout -->
+  <rect x="15" y="10" width="2"  height="4" fill="#D4B896"/>
+  <!-- Nostrils (two dark dots) -->
+  <rect x="13" y="11" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="18" y="11" width="1"  height="1" fill="#1B2A4E"/>
+  <!-- Whisker spots (sparse darker dots) -->
+  <rect x="11" y="13" width="1"  height="1" fill="#5A3A20"/>
+  <rect x="13" y="14" width="1"  height="1" fill="#5A3A20"/>
+  <rect x="20" y="13" width="1"  height="1" fill="#5A3A20"/>
+  <rect x="18" y="14" width="1"  height="1" fill="#5A3A20"/>
+  <!-- Mouth (small dark line at the bottom of the snout) -->
+  <rect x="14" y="14" width="4"  height="1" fill="#1B2A4E"/>
 
-  <!-- Whiskers -->
-  <rect x="7"  y="13" width="1"  height="1" fill="#F4B6C0"/>
-  <rect x="6"  y="14" width="1"  height="1" fill="#F4B6C0"/>
-  <rect x="16" y="13" width="1"  height="1" fill="#F4B6C0"/>
-  <rect x="17" y="14" width="1"  height="1" fill="#F4B6C0"/>
+  <!-- ============================================================
+       TUSKS - two long white tusks pointing straight down from
+       beneath the snout. Drawn LAST so they always sit on top of
+       the body.
+       ============================================================ -->
+  <!-- Left tusk -->
+  <rect x="13" y="16" width="2"  height="6" fill="#F1E5C3"/>
+  <rect x="12" y="16" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="15" y="16" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="13" y="22" width="2"  height="1" fill="#1B2A4E"/>
+  <!-- Tusk shine -->
+  <rect x="13" y="16" width="1"  height="2" fill="#FFFFFF"/>
 
-  <!-- Tusks -->
-  <rect x="9"  y="15" width="2"  height="3" fill="#F1E5C3"/>
-  <rect x="13" y="15" width="2"  height="3" fill="#F1E5C3"/>
-  <rect x="9"  y="18" width="2"  height="1" fill="#1B2A4E"/>
-  <rect x="13" y="18" width="2"  height="1" fill="#1B2A4E"/>
-
-  <!-- Body (round, pinniped  wider than head) -->
-  <rect x="4"  y="17" width="22" height="1" fill="#1B2A4E"/>
-  <rect x="3"  y="18" width="1"  height="7" fill="#1B2A4E"/>
-  <rect x="26" y="18" width="1"  height="7" fill="#1B2A4E"/>
-  <rect x="4"  y="18" width="22" height="7" fill="#8B5C3A"/>
-  <rect x="4"  y="25" width="22" height="1" fill="#1B2A4E"/>
-
-  <!-- Belly -->
-  <rect x="7"  y="20" width="16" height="4" fill="#C19169"/>
-
-  <!-- Flippers (front pair) -->
-  <rect x="3"  y="22" width="1"  height="3" fill="#8B5C3A"/>
-  <rect x="2"  y="23" width="1"  height="2" fill="#8B5C3A"/>
-  <rect x="26" y="22" width="1"  height="3" fill="#8B5C3A"/>
-  <rect x="27" y="23" width="1"  height="2" fill="#8B5C3A"/>
-
-  <!-- Tail (small) -->
-  <rect x="14" y="26" width="4"  height="1" fill="#8B5C3A"/>
+  <!-- Right tusk -->
+  <rect x="17" y="16" width="2"  height="6" fill="#F1E5C3"/>
+  <rect x="16" y="16" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="19" y="16" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="17" y="22" width="2"  height="1" fill="#1B2A4E"/>
+  <!-- Tusk shine -->
+  <rect x="17" y="16" width="1"  height="2" fill="#FFFFFF"/>
 </svg>

--- a/apps/docs/static/img/brand/walrus.svg
+++ b/apps/docs/static/img/brand/walrus.svg
@@ -1,60 +1,155 @@
 <!--
-  Kelp the walrus. Swap router  appears on swap routes between
-  chains, hauling tokens across.
+  Kelp the Walrus (v3). Front-facing 3/4 view matching the user's
+  reference: round brown body bulging wide at the bottom, big cream
+  snout dominating the lower face, two prominent white tusks pointing
+  straight down, two beady eyes with brown brow ridges above, two
+  front flippers planted at the base, sparse whisker dots.
 
-  Hand-authored pixel art, 32x32 logical grid.
-  Palette: warm brown body #8B5C3A, paler belly #C19169, cream tusks
-           #F1E5C3, dark eye #1B1F2A, navy outline #1B2A4E,
-           pink whisker #F4B6C0.
+  Drawing order matters here: body is drawn FIRST, then the tusks +
+  snout + face are layered ON TOP so they're never covered by the
+  body fill.
+
+  Hand-authored pixel art on a 32x32 grid scaled to 256x256.
+  Palette: warm brown #8B5C3A, light belly #C19169, dark brown #5A3A20,
+           highlight #A06D43, cream snout #F5E6D0, snout shadow
+           #D4B896, tusk cream #F1E5C3, tusk highlight #FFFFFF,
+           navy outline #1B2A4E, eye black #1B1F2A.
 -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Kelp the walrus, swap router">
-  <title>Kelp the walrus</title>
-  <desc>Hauls tokens between chains via the swap router.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Kelp the Walrus">
+  <title>Kelp the Walrus</title>
+  <desc>Front-facing walrus with big cream snout, two long tusks, and two front flippers. Routes swaps between chains.</desc>
 
+  <!-- ============================================================
+       BODY (drawn first so the snout + tusks layer on top later).
+       Tear-drop pinniped silhouette: narrow at the top, bulging
+       wide at the base where the walrus is sat.
+       ============================================================ -->
+  <!-- Body outline (curving outward from shoulders to base) -->
+  <rect x="9"  y="13" width="2"  height="1" fill="#1B2A4E"/>
+  <rect x="21" y="13" width="2"  height="1" fill="#1B2A4E"/>
+  <rect x="8"  y="14" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="23" y="14" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="7"  y="16" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="24" y="16" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="6"  y="18" width="1"  height="3" fill="#1B2A4E"/>
+  <rect x="25" y="18" width="1"  height="3" fill="#1B2A4E"/>
+  <rect x="5"  y="21" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="26" y="21" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="6"  y="27" width="20" height="1" fill="#1B2A4E"/>
+
+  <!-- Body fill (brown) -->
+  <rect x="9"  y="14" width="14" height="2" fill="#8B5C3A"/>
+  <rect x="8"  y="16" width="16" height="2" fill="#8B5C3A"/>
+  <rect x="7"  y="18" width="18" height="3" fill="#8B5C3A"/>
+  <rect x="6"  y="21" width="20" height="6" fill="#8B5C3A"/>
+
+  <!-- Belly (lighter brown, large oval at front-centre) -->
+  <rect x="11" y="17" width="10" height="1" fill="#C19169"/>
+  <rect x="10" y="18" width="12" height="3" fill="#C19169"/>
+  <rect x="9"  y="21" width="14" height="6" fill="#C19169"/>
+
+  <!-- Subtle belly fold lines -->
+  <rect x="8"  y="23" width="1"  height="1" fill="#5A3A20"/>
+  <rect x="23" y="23" width="1"  height="1" fill="#5A3A20"/>
+
+  <!-- ============================================================
+       FRONT FLIPPERS (two, planted at the base under the body).
+       Drawn before the head so the body's lower edge sits on top.
+       ============================================================ -->
+  <!-- Left flipper -->
+  <rect x="3"  y="25" width="6"  height="1" fill="#1B2A4E"/>
+  <rect x="2"  y="26" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="3"  y="28" width="7"  height="1" fill="#1B2A4E"/>
+  <rect x="9"  y="27" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="3"  y="26" width="6"  height="2" fill="#8B5C3A"/>
+  <!-- Toe lines -->
+  <rect x="4"  y="27" width="1"  height="1" fill="#5A3A20"/>
+  <rect x="6"  y="27" width="1"  height="1" fill="#5A3A20"/>
+  <rect x="8"  y="27" width="1"  height="1" fill="#5A3A20"/>
+
+  <!-- Right flipper -->
+  <rect x="23" y="25" width="6"  height="1" fill="#1B2A4E"/>
+  <rect x="29" y="26" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="22" y="28" width="7"  height="1" fill="#1B2A4E"/>
+  <rect x="22" y="27" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="23" y="26" width="6"  height="2" fill="#8B5C3A"/>
+  <!-- Toe lines -->
+  <rect x="24" y="27" width="1"  height="1" fill="#5A3A20"/>
+  <rect x="26" y="27" width="1"  height="1" fill="#5A3A20"/>
+  <rect x="28" y="27" width="1"  height="1" fill="#5A3A20"/>
+
+  <!-- ============================================================
+       HEAD (drawn AFTER body so it's on top).
+       Round brown head sitting on top of the body. Wider than my
+       previous attempt - 14 columns wide so the snout has room.
+       ============================================================ -->
   <!-- Head outline -->
-  <rect x="6"  y="6"  width="14" height="1" fill="#1B2A4E"/>
-  <rect x="5"  y="7"  width="1"  height="9" fill="#1B2A4E"/>
-  <rect x="20" y="7"  width="1"  height="9" fill="#1B2A4E"/>
-  <rect x="6"  y="16" width="14" height="1" fill="#1B2A4E"/>
-
+  <rect x="11" y="2"  width="10" height="1" fill="#1B2A4E"/>
+  <rect x="10" y="3"  width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="21" y="3"  width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="9"  y="5"  width="1"  height="3" fill="#1B2A4E"/>
+  <rect x="22" y="5"  width="1"  height="3" fill="#1B2A4E"/>
   <!-- Head fill -->
-  <rect x="6"  y="7"  width="14" height="9" fill="#8B5C3A"/>
+  <rect x="11" y="3"  width="10" height="2" fill="#8B5C3A"/>
+  <rect x="10" y="5"  width="12" height="3" fill="#8B5C3A"/>
 
+  <!-- Top-of-head highlight -->
+  <rect x="14" y="4"  width="3"  height="1" fill="#A06D43"/>
+
+  <!-- ============================================================
+       EYES (two black dots with white highlight) + brow ridges
+       ============================================================ -->
+  <!-- Brow ridges (slightly darker brown above each eye) -->
+  <rect x="11" y="5"  width="3"  height="1" fill="#5A3A20"/>
+  <rect x="18" y="5"  width="3"  height="1" fill="#5A3A20"/>
   <!-- Eyes -->
-  <rect x="9"  y="10" width="1"  height="1" fill="#1B1F2A"/>
-  <rect x="13" y="10" width="1"  height="1" fill="#1B1F2A"/>
+  <rect x="11" y="6"  width="2"  height="2" fill="#1B1F2A"/>
+  <rect x="19" y="6"  width="2"  height="2" fill="#1B1F2A"/>
+  <rect x="11" y="6"  width="1"  height="1" fill="#FFFFFF"/>
+  <rect x="19" y="6"  width="1"  height="1" fill="#FFFFFF"/>
 
-  <!-- Snout (paler) -->
-  <rect x="8"  y="12" width="8"  height="3" fill="#C19169"/>
+  <!-- ============================================================
+       SNOUT / MUZZLE - big cream patch, dominates the lower face.
+       Drawn over the body, so it spills slightly down past the head.
+       ============================================================ -->
+  <!-- Snout outline -->
+  <rect x="11" y="8"  width="10" height="1" fill="#1B2A4E"/>
+  <rect x="10" y="9"  width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="21" y="9"  width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="11" y="15" width="10" height="1" fill="#1B2A4E"/>
+  <!-- Snout fill (cream) -->
+  <rect x="11" y="9"  width="10" height="6" fill="#F5E6D0"/>
+  <!-- Centre divider down the snout -->
+  <rect x="15" y="10" width="2"  height="4" fill="#D4B896"/>
+  <!-- Nostrils (two dark dots) -->
+  <rect x="13" y="11" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="18" y="11" width="1"  height="1" fill="#1B2A4E"/>
+  <!-- Whisker spots (sparse darker dots) -->
+  <rect x="11" y="13" width="1"  height="1" fill="#5A3A20"/>
+  <rect x="13" y="14" width="1"  height="1" fill="#5A3A20"/>
+  <rect x="20" y="13" width="1"  height="1" fill="#5A3A20"/>
+  <rect x="18" y="14" width="1"  height="1" fill="#5A3A20"/>
+  <!-- Mouth (small dark line at the bottom of the snout) -->
+  <rect x="14" y="14" width="4"  height="1" fill="#1B2A4E"/>
 
-  <!-- Whiskers -->
-  <rect x="7"  y="13" width="1"  height="1" fill="#F4B6C0"/>
-  <rect x="6"  y="14" width="1"  height="1" fill="#F4B6C0"/>
-  <rect x="16" y="13" width="1"  height="1" fill="#F4B6C0"/>
-  <rect x="17" y="14" width="1"  height="1" fill="#F4B6C0"/>
+  <!-- ============================================================
+       TUSKS - two long white tusks pointing straight down from
+       beneath the snout. Drawn LAST so they always sit on top of
+       the body.
+       ============================================================ -->
+  <!-- Left tusk -->
+  <rect x="13" y="16" width="2"  height="6" fill="#F1E5C3"/>
+  <rect x="12" y="16" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="15" y="16" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="13" y="22" width="2"  height="1" fill="#1B2A4E"/>
+  <!-- Tusk shine -->
+  <rect x="13" y="16" width="1"  height="2" fill="#FFFFFF"/>
 
-  <!-- Tusks -->
-  <rect x="9"  y="15" width="2"  height="3" fill="#F1E5C3"/>
-  <rect x="13" y="15" width="2"  height="3" fill="#F1E5C3"/>
-  <rect x="9"  y="18" width="2"  height="1" fill="#1B2A4E"/>
-  <rect x="13" y="18" width="2"  height="1" fill="#1B2A4E"/>
-
-  <!-- Body (round, pinniped  wider than head) -->
-  <rect x="4"  y="17" width="22" height="1" fill="#1B2A4E"/>
-  <rect x="3"  y="18" width="1"  height="7" fill="#1B2A4E"/>
-  <rect x="26" y="18" width="1"  height="7" fill="#1B2A4E"/>
-  <rect x="4"  y="18" width="22" height="7" fill="#8B5C3A"/>
-  <rect x="4"  y="25" width="22" height="1" fill="#1B2A4E"/>
-
-  <!-- Belly -->
-  <rect x="7"  y="20" width="16" height="4" fill="#C19169"/>
-
-  <!-- Flippers (front pair) -->
-  <rect x="3"  y="22" width="1"  height="3" fill="#8B5C3A"/>
-  <rect x="2"  y="23" width="1"  height="2" fill="#8B5C3A"/>
-  <rect x="26" y="22" width="1"  height="3" fill="#8B5C3A"/>
-  <rect x="27" y="23" width="1"  height="2" fill="#8B5C3A"/>
-
-  <!-- Tail (small) -->
-  <rect x="14" y="26" width="4"  height="1" fill="#8B5C3A"/>
+  <!-- Right tusk -->
+  <rect x="17" y="16" width="2"  height="6" fill="#F1E5C3"/>
+  <rect x="16" y="16" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="19" y="16" width="1"  height="6" fill="#1B2A4E"/>
+  <rect x="17" y="22" width="2"  height="1" fill="#1B2A4E"/>
+  <!-- Tusk shine -->
+  <rect x="17" y="16" width="1"  height="2" fill="#FFFFFF"/>
 </svg>


### PR DESCRIPTION
User shared a reference drawing of a sat walrus (front-facing 3/4 view, big cream snout, two long white tusks, brown round body, two front flippers). Previous v2 was a side profile; this v3 redesigns Kelp to match.

## Changes

- **Front-facing 3/4 view** (was strict side profile) — both eyes visible, snout faces camera
- **Big cream snout** (10x6, the dominant face feature) with centre divider, two nostril dots, and four sparse whisker dots
- **Two long white tusks** (5-6 pixels tall) pointing straight down from beneath the snout, with white shine at the top
- **Two beady eyes** (2x2 black + 1px white highlight) flanking the snout, with darker brown brow ridges above
- **Brown round body** with a tear-drop silhouette: narrow at shoulders, bulging wide at the base, with lighter brown belly oval and subtle dark fold lines
- **Two front flippers** planted at the base with toe-line shading
- **Drawing order fixed** — body drawn FIRST, then face + snout + tusks layered on top (previous version had body covering the tusks)

## Files

- `apps/desk/src/characters/walrus.svg` (Trading Desk world)
- `apps/docs/static/img/brand/walrus.svg` (cast docs page)

## Verification

- SVG renders cleanly in the in-IDE browser
- World view shows the new Kelp with both tusks clearly visible