### PR TITLE
Pole sprite v4: clean reference design with pink cheek blushes

### DIFF
--- a/apps/desk/src/characters/pole.svg
+++ b/apps/desk/src/characters/pole.svg
@@ -1,20 +1,21 @@
 <!--
-  Pole the Polar Bear (v3). Big readable face: round head, two visible
-  ears, two clear eyes, prominent black nose, gentle smile. Sat upright
-  on haunches with two front paws planted together and two hind paws
-  visible at the sides. Wears a red wooly hat (with white pom-pom)
-  and a cyan scarf around the neck. Iterated to match the user's
-  reference line drawing.
+  Pole the Polar Bear (v4). Clean simple silhouette matching the
+  user's pixel-art reference: round white body that flows from head
+  to torso, two tiny ear nubs, two small black dot eyes, a small
+  black bean nose, PINK CHEEK BLUSHES on each side of the nose
+  (the signature feature from the reference), two small front paws
+  planted at the base. Wears a red wooly hat with a white pom-pom
+  on top, plus the cyan scarf around the neck.
   Hand-authored pixel art on a 32x32 grid scaled to 256x256.
   Palette: ice white #ECF6FF, soft shadow #D8E5F5, navy outline
-           #1B2A4E, snout cream #F8FBFF, pink mouth/toe-bean #F4B6C0,
-           hat red #DC2626, hat highlight #EF4444, hat dark #991B1B,
-           hat shadow #7F1D1D, pom-pom white #FFFFFF,
+           #1B2A4E, pink cheek/mouth #F4B6C0, ear-inner pink
+           #F4B6C0, hat red #DC2626, hat highlight #EF4444, hat
+           dark #991B1B, hat shadow #7F1D1D, pom-pom white #FFFFFF,
            scarf cyan #50D2C2 + dark #2BA694.
 -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Pole the Polar Bear">
   <title>Pole the Polar Bear</title>
-  <desc>Sat upright in 3/4 view with a round friendly face, a red wooly hat, and a cyan scarf.</desc>
+  <desc>Clean cute polar bear with pink cheek blushes, a red wooly hat, and a cyan scarf.</desc>
 
   <!-- ============================================================
        Pom-pom on top of the hat
@@ -24,148 +25,134 @@
   <rect x="15" y="2" width="2" height="1" fill="#FFFFFF"/>
 
   <!-- ============================================================
-       Red wooly hat (kept short so the face has room)
+       Red wooly hat dome (kept compact so the face has room for
+       the cheek blushes)
        ============================================================ -->
   <rect x="13" y="3"  width="6"  height="1" fill="#DC2626"/>
   <rect x="11" y="4"  width="10" height="1" fill="#DC2626"/>
   <rect x="10" y="5"  width="12" height="1" fill="#DC2626"/>
-  <!-- Highlights (knit sheen) -->
+  <!-- Knit highlight -->
   <rect x="13" y="4"  width="3"  height="1" fill="#EF4444"/>
   <rect x="12" y="5"  width="3"  height="1" fill="#EF4444"/>
-  <!-- Brim cuff -->
+  <!-- Brim cuff (darker rolled wool) -->
   <rect x="9"  y="6"  width="14" height="1" fill="#991B1B"/>
   <rect x="9"  y="7"  width="14" height="1" fill="#7F1D1D"/>
-  <!-- Knit dots on the brim -->
+  <!-- Knit pattern dots on the brim -->
   <rect x="11" y="6"  width="1" height="1" fill="#DC2626"/>
   <rect x="14" y="6"  width="1" height="1" fill="#DC2626"/>
   <rect x="17" y="6"  width="1" height="1" fill="#DC2626"/>
   <rect x="20" y="6"  width="1" height="1" fill="#DC2626"/>
 
   <!-- ============================================================
-       Ears (two, peeking out either side just below the brim).
-       Larger so they read at a glance.
+       Ears (tiny nubs peeking out either side under the brim)
        ============================================================ -->
   <!-- Left ear -->
-  <rect x="7"  y="8"  width="3" height="1" fill="#1B2A4E"/>
-  <rect x="6"  y="9"  width="4" height="2" fill="#1B2A4E"/>
-  <rect x="7"  y="9"  width="3" height="1" fill="#ECF6FF"/>
-  <rect x="7"  y="10" width="2" height="1" fill="#F4B6C0"/>
+  <rect x="8"  y="8"  width="2"  height="1" fill="#1B2A4E"/>
+  <rect x="7"  y="9"  width="3"  height="1" fill="#1B2A4E"/>
+  <rect x="8"  y="9"  width="2"  height="1" fill="#F4B6C0"/>
   <!-- Right ear -->
-  <rect x="22" y="8"  width="3" height="1" fill="#1B2A4E"/>
-  <rect x="22" y="9"  width="4" height="2" fill="#1B2A4E"/>
-  <rect x="22" y="9"  width="3" height="1" fill="#ECF6FF"/>
-  <rect x="23" y="10" width="2" height="1" fill="#F4B6C0"/>
+  <rect x="22" y="8"  width="2"  height="1" fill="#1B2A4E"/>
+  <rect x="22" y="9"  width="3"  height="1" fill="#1B2A4E"/>
+  <rect x="22" y="9"  width="2"  height="1" fill="#F4B6C0"/>
 
   <!-- ============================================================
-       Head (big and round). Outline first, then white fill.
+       Head (white, rounded). The cheek blushes are the focal point
+       so the head fill is wider than the hat to give them room.
        ============================================================ -->
-  <!-- Head outline (rounded square) -->
+  <!-- Head outline -->
   <rect x="10" y="8"  width="12" height="1" fill="#1B2A4E"/>
   <rect x="9"  y="9"  width="1"  height="2" fill="#1B2A4E"/>
   <rect x="22" y="9"  width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="8"  y="11" width="1"  height="4" fill="#1B2A4E"/>
-  <rect x="23" y="11" width="1"  height="4" fill="#1B2A4E"/>
-  <rect x="9"  y="15" width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="22" y="15" width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="10" y="16" width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="21" y="16" width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="11" y="17" width="10" height="1" fill="#1B2A4E"/>
+  <rect x="9"  y="11" width="1"  height="3" fill="#1B2A4E"/>
+  <rect x="22" y="11" width="1"  height="3" fill="#1B2A4E"/>
+  <rect x="10" y="14" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="21" y="14" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="11" y="15" width="10" height="1" fill="#1B2A4E"/>
 
   <!-- Head fill (white) -->
-  <rect x="10" y="9"  width="12" height="2" fill="#ECF6FF"/>
-  <rect x="9"  y="11" width="14" height="4" fill="#ECF6FF"/>
-  <rect x="10" y="15" width="12" height="1" fill="#ECF6FF"/>
-  <rect x="11" y="16" width="10" height="1" fill="#ECF6FF"/>
+  <rect x="10" y="9"  width="12" height="5" fill="#ECF6FF"/>
+  <rect x="11" y="14" width="10" height="1" fill="#ECF6FF"/>
 
-  <!-- Forehead shading just under the hat -->
-  <rect x="9"  y="9"  width="14" height="1" fill="#D8E5F5"/>
+  <!-- Forehead shading just under the hat brim -->
+  <rect x="10" y="9"  width="12" height="1" fill="#D8E5F5"/>
 
   <!-- ============================================================
-       Eyes (two, 2x2 black with a 1px white highlight - big enough
-       to read clearly at sprite scale)
+       FACE - the signature features from the reference:
+       two tiny eyes, a black bean nose, and PINK CHEEK BLUSHES
+       flanking the nose.
        ============================================================ -->
-  <rect x="12" y="11" width="2" height="2" fill="#1B2A4E"/>
-  <rect x="18" y="11" width="2" height="2" fill="#1B2A4E"/>
-  <rect x="12" y="11" width="1" height="1" fill="#FFFFFF"/>
-  <rect x="18" y="11" width="1" height="1" fill="#FFFFFF"/>
+
+  <!-- Eyes (small 1x2 navy dots, close together for "cute") -->
+  <rect x="13" y="11" width="1" height="2" fill="#1B2A4E"/>
+  <rect x="18" y="11" width="1" height="2" fill="#1B2A4E"/>
+
+  <!-- Nose (small black bean centred between the eyes) -->
+  <rect x="15" y="12" width="2" height="2" fill="#1B2A4E"/>
+  <rect x="15" y="12" width="1" height="1" fill="#FFFFFF"/>
+
+  <!-- PINK CHEEK BLUSHES (the reference's defining feature) -
+       2x1 patches on each side of the nose -->
+  <rect x="11" y="13" width="2" height="1" fill="#F4B6C0"/>
+  <rect x="19" y="13" width="2" height="1" fill="#F4B6C0"/>
+
+  <!-- Mouth (tiny smile under the nose) -->
+  <rect x="14" y="14" width="1" height="1" fill="#1B2A4E"/>
+  <rect x="15" y="14" width="2" height="1" fill="#F4B6C0"/>
+  <rect x="17" y="14" width="1" height="1" fill="#1B2A4E"/>
 
   <!-- ============================================================
-       Snout cream patch + prominent black nose + smile
+       Cyan scarf around the neck. Compact so the body silhouette
+       below stays clean.
        ============================================================ -->
-  <!-- Snout patch (lighter cream over the lower face) -->
-  <rect x="12" y="13" width="8" height="3" fill="#F8FBFF"/>
-  <!-- Nose: 3-pixel wide rounded rectangle at the snout's centre -->
-  <rect x="14" y="13" width="4" height="2" fill="#1B2A4E"/>
-  <rect x="14" y="13" width="1" height="1" fill="#FFFFFF"/>
-  <rect x="15" y="15" width="2" height="1" fill="#1B2A4E"/>
-  <!-- Smile: clear upturned curve below the nose -->
-  <rect x="13" y="16" width="1" height="1" fill="#1B2A4E"/>
-  <rect x="14" y="16" width="4" height="1" fill="#F4B6C0"/>
-  <rect x="18" y="16" width="1" height="1" fill="#1B2A4E"/>
+  <rect x="12" y="16" width="8"  height="1" fill="#2BA694"/>
+  <rect x="11" y="17" width="10" height="2" fill="#50D2C2"/>
+  <rect x="12" y="19" width="8"  height="1" fill="#2BA694"/>
+  <!-- Knot on the right -->
+  <rect x="21" y="17" width="2"  height="3" fill="#50D2C2"/>
+  <rect x="21" y="17" width="2"  height="1" fill="#2BA694"/>
+  <rect x="21" y="19" width="2"  height="1" fill="#2BA694"/>
+  <!-- Trailing scarf tail -->
+  <rect x="23" y="20" width="2"  height="2" fill="#50D2C2"/>
+  <rect x="23" y="22" width="2"  height="1" fill="#2BA694"/>
+  <rect x="24" y="23" width="1"  height="2" fill="#50D2C2"/>
 
   <!-- ============================================================
-       Cyan scarf around the neck. Fringed knot trails to the right.
+       BODY - mochi-shaped: starts narrow at the chest, widens
+       smoothly at the haunches. Matches the reference's clean
+       continuous silhouette.
        ============================================================ -->
-  <rect x="11" y="18" width="10" height="1" fill="#2BA694"/>
-  <rect x="10" y="19" width="12" height="2" fill="#50D2C2"/>
-  <rect x="11" y="21" width="10" height="1" fill="#2BA694"/>
-  <!-- Knot on the right side -->
-  <rect x="22" y="19" width="2"  height="3" fill="#50D2C2"/>
-  <rect x="22" y="19" width="2"  height="1" fill="#2BA694"/>
-  <rect x="22" y="21" width="2"  height="1" fill="#2BA694"/>
-  <!-- Trailing scarf tail (fringed) -->
-  <rect x="24" y="22" width="2"  height="2" fill="#50D2C2"/>
-  <rect x="24" y="24" width="2"  height="1" fill="#2BA694"/>
-  <rect x="25" y="25" width="1"  height="2" fill="#50D2C2"/>
+  <!-- Body outline -->
+  <rect x="11" y="20" width="10" height="1" fill="#1B2A4E"/>
+  <rect x="10" y="21" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="21" y="21" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="9"  y="23" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="22" y="23" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="8"  y="25" width="1"  height="3" fill="#1B2A4E"/>
+  <rect x="23" y="25" width="1"  height="3" fill="#1B2A4E"/>
+
+  <!-- Body fill (white) -->
+  <rect x="11" y="21" width="10" height="2" fill="#ECF6FF"/>
+  <rect x="10" y="23" width="12" height="2" fill="#ECF6FF"/>
+  <rect x="9"  y="25" width="14" height="3" fill="#ECF6FF"/>
+
+  <!-- Subtle belly oval (soft shadow for roundness) -->
+  <rect x="13" y="23" width="6"  height="4" fill="#D8E5F5"/>
 
   <!-- ============================================================
-       Body (round, sat-bear silhouette). Narrow at chest, wider
-       at haunches, soft rounded shoulders.
-       ============================================================ -->
-  <!-- Top of body -->
-  <rect x="12" y="22" width="8"  height="1" fill="#1B2A4E"/>
-  <!-- Body sides taper outward -->
-  <rect x="11" y="23" width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="20" y="23" width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="10" y="24" width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="21" y="24" width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="9"  y="26" width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="22" y="26" width="1"  height="2" fill="#1B2A4E"/>
-
-  <!-- Body fill -->
-  <rect x="12" y="23" width="8"  height="1" fill="#ECF6FF"/>
-  <rect x="11" y="24" width="10" height="2" fill="#ECF6FF"/>
-  <rect x="10" y="26" width="12" height="2" fill="#ECF6FF"/>
-
-  <!-- Belly oval (soft shadow) -->
-  <rect x="13" y="24" width="6"  height="3" fill="#D8E5F5"/>
-
-  <!-- ============================================================
-       Front paws (two, planted side-by-side at the centre-bottom,
+       FRONT PAWS (two white nubs planted at the bottom-corners,
        matching the reference)
        ============================================================ -->
-  <!-- Left front paw -->
-  <rect x="12" y="28" width="3" height="2" fill="#ECF6FF"/>
-  <rect x="11" y="28" width="1" height="3" fill="#1B2A4E"/>
-  <rect x="15" y="28" width="1" height="3" fill="#1B2A4E"/>
-  <rect x="12" y="30" width="3" height="1" fill="#1B2A4E"/>
-  <rect x="13" y="29" width="1" height="1" fill="#F4B6C0"/>
-  <!-- Right front paw -->
-  <rect x="17" y="28" width="3" height="2" fill="#ECF6FF"/>
-  <rect x="16" y="28" width="1" height="3" fill="#1B2A4E"/>
-  <rect x="20" y="28" width="1" height="3" fill="#1B2A4E"/>
-  <rect x="17" y="30" width="3" height="1" fill="#1B2A4E"/>
-  <rect x="18" y="29" width="1" height="1" fill="#F4B6C0"/>
+  <!-- Left paw -->
+  <rect x="9"  y="28" width="4" height="2" fill="#ECF6FF"/>
+  <rect x="8"  y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="13" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="9"  y="30" width="4" height="1" fill="#1B2A4E"/>
+  <rect x="10" y="29" width="1" height="1" fill="#F4B6C0"/>
 
-  <!-- ============================================================
-       Hind paws (visible at the sides, peeking out from the haunches)
-       ============================================================ -->
-  <!-- Left hind -->
-  <rect x="8"  y="28" width="3" height="2" fill="#ECF6FF"/>
-  <rect x="7"  y="28" width="1" height="3" fill="#1B2A4E"/>
-  <rect x="8"  y="30" width="3" height="1" fill="#1B2A4E"/>
-  <!-- Right hind -->
-  <rect x="21" y="28" width="3" height="2" fill="#ECF6FF"/>
-  <rect x="24" y="28" width="1" height="3" fill="#1B2A4E"/>
-  <rect x="21" y="30" width="3" height="1" fill="#1B2A4E"/>
+  <!-- Right paw -->
+  <rect x="19" y="28" width="4" height="2" fill="#ECF6FF"/>
+  <rect x="18" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="23" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="19" y="30" width="4" height="1" fill="#1B2A4E"/>
+  <rect x="20" y="29" width="1" height="1" fill="#F4B6C0"/>
 </svg>

--- a/apps/docs/static/img/brand/pole.svg
+++ b/apps/docs/static/img/brand/pole.svg
@@ -1,20 +1,21 @@
 <!--
-  Pole the Polar Bear (v3). Big readable face: round head, two visible
-  ears, two clear eyes, prominent black nose, gentle smile. Sat upright
-  on haunches with two front paws planted together and two hind paws
-  visible at the sides. Wears a red wooly hat (with white pom-pom)
-  and a cyan scarf around the neck. Iterated to match the user's
-  reference line drawing.
+  Pole the Polar Bear (v4). Clean simple silhouette matching the
+  user's pixel-art reference: round white body that flows from head
+  to torso, two tiny ear nubs, two small black dot eyes, a small
+  black bean nose, PINK CHEEK BLUSHES on each side of the nose
+  (the signature feature from the reference), two small front paws
+  planted at the base. Wears a red wooly hat with a white pom-pom
+  on top, plus the cyan scarf around the neck.
   Hand-authored pixel art on a 32x32 grid scaled to 256x256.
   Palette: ice white #ECF6FF, soft shadow #D8E5F5, navy outline
-           #1B2A4E, snout cream #F8FBFF, pink mouth/toe-bean #F4B6C0,
-           hat red #DC2626, hat highlight #EF4444, hat dark #991B1B,
-           hat shadow #7F1D1D, pom-pom white #FFFFFF,
+           #1B2A4E, pink cheek/mouth #F4B6C0, ear-inner pink
+           #F4B6C0, hat red #DC2626, hat highlight #EF4444, hat
+           dark #991B1B, hat shadow #7F1D1D, pom-pom white #FFFFFF,
            scarf cyan #50D2C2 + dark #2BA694.
 -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Pole the Polar Bear">
   <title>Pole the Polar Bear</title>
-  <desc>Sat upright in 3/4 view with a round friendly face, a red wooly hat, and a cyan scarf.</desc>
+  <desc>Clean cute polar bear with pink cheek blushes, a red wooly hat, and a cyan scarf.</desc>
 
   <!-- ============================================================
        Pom-pom on top of the hat
@@ -24,148 +25,134 @@
   <rect x="15" y="2" width="2" height="1" fill="#FFFFFF"/>
 
   <!-- ============================================================
-       Red wooly hat (kept short so the face has room)
+       Red wooly hat dome (kept compact so the face has room for
+       the cheek blushes)
        ============================================================ -->
   <rect x="13" y="3"  width="6"  height="1" fill="#DC2626"/>
   <rect x="11" y="4"  width="10" height="1" fill="#DC2626"/>
   <rect x="10" y="5"  width="12" height="1" fill="#DC2626"/>
-  <!-- Highlights (knit sheen) -->
+  <!-- Knit highlight -->
   <rect x="13" y="4"  width="3"  height="1" fill="#EF4444"/>
   <rect x="12" y="5"  width="3"  height="1" fill="#EF4444"/>
-  <!-- Brim cuff -->
+  <!-- Brim cuff (darker rolled wool) -->
   <rect x="9"  y="6"  width="14" height="1" fill="#991B1B"/>
   <rect x="9"  y="7"  width="14" height="1" fill="#7F1D1D"/>
-  <!-- Knit dots on the brim -->
+  <!-- Knit pattern dots on the brim -->
   <rect x="11" y="6"  width="1" height="1" fill="#DC2626"/>
   <rect x="14" y="6"  width="1" height="1" fill="#DC2626"/>
   <rect x="17" y="6"  width="1" height="1" fill="#DC2626"/>
   <rect x="20" y="6"  width="1" height="1" fill="#DC2626"/>
 
   <!-- ============================================================
-       Ears (two, peeking out either side just below the brim).
-       Larger so they read at a glance.
+       Ears (tiny nubs peeking out either side under the brim)
        ============================================================ -->
   <!-- Left ear -->
-  <rect x="7"  y="8"  width="3" height="1" fill="#1B2A4E"/>
-  <rect x="6"  y="9"  width="4" height="2" fill="#1B2A4E"/>
-  <rect x="7"  y="9"  width="3" height="1" fill="#ECF6FF"/>
-  <rect x="7"  y="10" width="2" height="1" fill="#F4B6C0"/>
+  <rect x="8"  y="8"  width="2"  height="1" fill="#1B2A4E"/>
+  <rect x="7"  y="9"  width="3"  height="1" fill="#1B2A4E"/>
+  <rect x="8"  y="9"  width="2"  height="1" fill="#F4B6C0"/>
   <!-- Right ear -->
-  <rect x="22" y="8"  width="3" height="1" fill="#1B2A4E"/>
-  <rect x="22" y="9"  width="4" height="2" fill="#1B2A4E"/>
-  <rect x="22" y="9"  width="3" height="1" fill="#ECF6FF"/>
-  <rect x="23" y="10" width="2" height="1" fill="#F4B6C0"/>
+  <rect x="22" y="8"  width="2"  height="1" fill="#1B2A4E"/>
+  <rect x="22" y="9"  width="3"  height="1" fill="#1B2A4E"/>
+  <rect x="22" y="9"  width="2"  height="1" fill="#F4B6C0"/>
 
   <!-- ============================================================
-       Head (big and round). Outline first, then white fill.
+       Head (white, rounded). The cheek blushes are the focal point
+       so the head fill is wider than the hat to give them room.
        ============================================================ -->
-  <!-- Head outline (rounded square) -->
+  <!-- Head outline -->
   <rect x="10" y="8"  width="12" height="1" fill="#1B2A4E"/>
   <rect x="9"  y="9"  width="1"  height="2" fill="#1B2A4E"/>
   <rect x="22" y="9"  width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="8"  y="11" width="1"  height="4" fill="#1B2A4E"/>
-  <rect x="23" y="11" width="1"  height="4" fill="#1B2A4E"/>
-  <rect x="9"  y="15" width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="22" y="15" width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="10" y="16" width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="21" y="16" width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="11" y="17" width="10" height="1" fill="#1B2A4E"/>
+  <rect x="9"  y="11" width="1"  height="3" fill="#1B2A4E"/>
+  <rect x="22" y="11" width="1"  height="3" fill="#1B2A4E"/>
+  <rect x="10" y="14" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="21" y="14" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="11" y="15" width="10" height="1" fill="#1B2A4E"/>
 
   <!-- Head fill (white) -->
-  <rect x="10" y="9"  width="12" height="2" fill="#ECF6FF"/>
-  <rect x="9"  y="11" width="14" height="4" fill="#ECF6FF"/>
-  <rect x="10" y="15" width="12" height="1" fill="#ECF6FF"/>
-  <rect x="11" y="16" width="10" height="1" fill="#ECF6FF"/>
+  <rect x="10" y="9"  width="12" height="5" fill="#ECF6FF"/>
+  <rect x="11" y="14" width="10" height="1" fill="#ECF6FF"/>
 
-  <!-- Forehead shading just under the hat -->
-  <rect x="9"  y="9"  width="14" height="1" fill="#D8E5F5"/>
+  <!-- Forehead shading just under the hat brim -->
+  <rect x="10" y="9"  width="12" height="1" fill="#D8E5F5"/>
 
   <!-- ============================================================
-       Eyes (two, 2x2 black with a 1px white highlight - big enough
-       to read clearly at sprite scale)
+       FACE - the signature features from the reference:
+       two tiny eyes, a black bean nose, and PINK CHEEK BLUSHES
+       flanking the nose.
        ============================================================ -->
-  <rect x="12" y="11" width="2" height="2" fill="#1B2A4E"/>
-  <rect x="18" y="11" width="2" height="2" fill="#1B2A4E"/>
-  <rect x="12" y="11" width="1" height="1" fill="#FFFFFF"/>
-  <rect x="18" y="11" width="1" height="1" fill="#FFFFFF"/>
+
+  <!-- Eyes (small 1x2 navy dots, close together for "cute") -->
+  <rect x="13" y="11" width="1" height="2" fill="#1B2A4E"/>
+  <rect x="18" y="11" width="1" height="2" fill="#1B2A4E"/>
+
+  <!-- Nose (small black bean centred between the eyes) -->
+  <rect x="15" y="12" width="2" height="2" fill="#1B2A4E"/>
+  <rect x="15" y="12" width="1" height="1" fill="#FFFFFF"/>
+
+  <!-- PINK CHEEK BLUSHES (the reference's defining feature) -
+       2x1 patches on each side of the nose -->
+  <rect x="11" y="13" width="2" height="1" fill="#F4B6C0"/>
+  <rect x="19" y="13" width="2" height="1" fill="#F4B6C0"/>
+
+  <!-- Mouth (tiny smile under the nose) -->
+  <rect x="14" y="14" width="1" height="1" fill="#1B2A4E"/>
+  <rect x="15" y="14" width="2" height="1" fill="#F4B6C0"/>
+  <rect x="17" y="14" width="1" height="1" fill="#1B2A4E"/>
 
   <!-- ============================================================
-       Snout cream patch + prominent black nose + smile
+       Cyan scarf around the neck. Compact so the body silhouette
+       below stays clean.
        ============================================================ -->
-  <!-- Snout patch (lighter cream over the lower face) -->
-  <rect x="12" y="13" width="8" height="3" fill="#F8FBFF"/>
-  <!-- Nose: 3-pixel wide rounded rectangle at the snout's centre -->
-  <rect x="14" y="13" width="4" height="2" fill="#1B2A4E"/>
-  <rect x="14" y="13" width="1" height="1" fill="#FFFFFF"/>
-  <rect x="15" y="15" width="2" height="1" fill="#1B2A4E"/>
-  <!-- Smile: clear upturned curve below the nose -->
-  <rect x="13" y="16" width="1" height="1" fill="#1B2A4E"/>
-  <rect x="14" y="16" width="4" height="1" fill="#F4B6C0"/>
-  <rect x="18" y="16" width="1" height="1" fill="#1B2A4E"/>
+  <rect x="12" y="16" width="8"  height="1" fill="#2BA694"/>
+  <rect x="11" y="17" width="10" height="2" fill="#50D2C2"/>
+  <rect x="12" y="19" width="8"  height="1" fill="#2BA694"/>
+  <!-- Knot on the right -->
+  <rect x="21" y="17" width="2"  height="3" fill="#50D2C2"/>
+  <rect x="21" y="17" width="2"  height="1" fill="#2BA694"/>
+  <rect x="21" y="19" width="2"  height="1" fill="#2BA694"/>
+  <!-- Trailing scarf tail -->
+  <rect x="23" y="20" width="2"  height="2" fill="#50D2C2"/>
+  <rect x="23" y="22" width="2"  height="1" fill="#2BA694"/>
+  <rect x="24" y="23" width="1"  height="2" fill="#50D2C2"/>
 
   <!-- ============================================================
-       Cyan scarf around the neck. Fringed knot trails to the right.
+       BODY - mochi-shaped: starts narrow at the chest, widens
+       smoothly at the haunches. Matches the reference's clean
+       continuous silhouette.
        ============================================================ -->
-  <rect x="11" y="18" width="10" height="1" fill="#2BA694"/>
-  <rect x="10" y="19" width="12" height="2" fill="#50D2C2"/>
-  <rect x="11" y="21" width="10" height="1" fill="#2BA694"/>
-  <!-- Knot on the right side -->
-  <rect x="22" y="19" width="2"  height="3" fill="#50D2C2"/>
-  <rect x="22" y="19" width="2"  height="1" fill="#2BA694"/>
-  <rect x="22" y="21" width="2"  height="1" fill="#2BA694"/>
-  <!-- Trailing scarf tail (fringed) -->
-  <rect x="24" y="22" width="2"  height="2" fill="#50D2C2"/>
-  <rect x="24" y="24" width="2"  height="1" fill="#2BA694"/>
-  <rect x="25" y="25" width="1"  height="2" fill="#50D2C2"/>
+  <!-- Body outline -->
+  <rect x="11" y="20" width="10" height="1" fill="#1B2A4E"/>
+  <rect x="10" y="21" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="21" y="21" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="9"  y="23" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="22" y="23" width="1"  height="2" fill="#1B2A4E"/>
+  <rect x="8"  y="25" width="1"  height="3" fill="#1B2A4E"/>
+  <rect x="23" y="25" width="1"  height="3" fill="#1B2A4E"/>
+
+  <!-- Body fill (white) -->
+  <rect x="11" y="21" width="10" height="2" fill="#ECF6FF"/>
+  <rect x="10" y="23" width="12" height="2" fill="#ECF6FF"/>
+  <rect x="9"  y="25" width="14" height="3" fill="#ECF6FF"/>
+
+  <!-- Subtle belly oval (soft shadow for roundness) -->
+  <rect x="13" y="23" width="6"  height="4" fill="#D8E5F5"/>
 
   <!-- ============================================================
-       Body (round, sat-bear silhouette). Narrow at chest, wider
-       at haunches, soft rounded shoulders.
-       ============================================================ -->
-  <!-- Top of body -->
-  <rect x="12" y="22" width="8"  height="1" fill="#1B2A4E"/>
-  <!-- Body sides taper outward -->
-  <rect x="11" y="23" width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="20" y="23" width="1"  height="1" fill="#1B2A4E"/>
-  <rect x="10" y="24" width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="21" y="24" width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="9"  y="26" width="1"  height="2" fill="#1B2A4E"/>
-  <rect x="22" y="26" width="1"  height="2" fill="#1B2A4E"/>
-
-  <!-- Body fill -->
-  <rect x="12" y="23" width="8"  height="1" fill="#ECF6FF"/>
-  <rect x="11" y="24" width="10" height="2" fill="#ECF6FF"/>
-  <rect x="10" y="26" width="12" height="2" fill="#ECF6FF"/>
-
-  <!-- Belly oval (soft shadow) -->
-  <rect x="13" y="24" width="6"  height="3" fill="#D8E5F5"/>
-
-  <!-- ============================================================
-       Front paws (two, planted side-by-side at the centre-bottom,
+       FRONT PAWS (two white nubs planted at the bottom-corners,
        matching the reference)
        ============================================================ -->
-  <!-- Left front paw -->
-  <rect x="12" y="28" width="3" height="2" fill="#ECF6FF"/>
-  <rect x="11" y="28" width="1" height="3" fill="#1B2A4E"/>
-  <rect x="15" y="28" width="1" height="3" fill="#1B2A4E"/>
-  <rect x="12" y="30" width="3" height="1" fill="#1B2A4E"/>
-  <rect x="13" y="29" width="1" height="1" fill="#F4B6C0"/>
-  <!-- Right front paw -->
-  <rect x="17" y="28" width="3" height="2" fill="#ECF6FF"/>
-  <rect x="16" y="28" width="1" height="3" fill="#1B2A4E"/>
-  <rect x="20" y="28" width="1" height="3" fill="#1B2A4E"/>
-  <rect x="17" y="30" width="3" height="1" fill="#1B2A4E"/>
-  <rect x="18" y="29" width="1" height="1" fill="#F4B6C0"/>
+  <!-- Left paw -->
+  <rect x="9"  y="28" width="4" height="2" fill="#ECF6FF"/>
+  <rect x="8"  y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="13" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="9"  y="30" width="4" height="1" fill="#1B2A4E"/>
+  <rect x="10" y="29" width="1" height="1" fill="#F4B6C0"/>
 
-  <!-- ============================================================
-       Hind paws (visible at the sides, peeking out from the haunches)
-       ============================================================ -->
-  <!-- Left hind -->
-  <rect x="8"  y="28" width="3" height="2" fill="#ECF6FF"/>
-  <rect x="7"  y="28" width="1" height="3" fill="#1B2A4E"/>
-  <rect x="8"  y="30" width="3" height="1" fill="#1B2A4E"/>
-  <!-- Right hind -->
-  <rect x="21" y="28" width="3" height="2" fill="#ECF6FF"/>
-  <rect x="24" y="28" width="1" height="3" fill="#1B2A4E"/>
-  <rect x="21" y="30" width="3" height="1" fill="#1B2A4E"/>
+  <!-- Right paw -->
+  <rect x="19" y="28" width="4" height="2" fill="#ECF6FF"/>
+  <rect x="18" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="23" y="28" width="1" height="3" fill="#1B2A4E"/>
+  <rect x="19" y="30" width="4" height="1" fill="#1B2A4E"/>
+  <rect x="20" y="29" width="1" height="1" fill="#F4B6C0"/>
 </svg>


### PR DESCRIPTION
User shared a clean pixel-art reference of a sat polar bear with **pink cheek blushes** as the defining feature, plus a simple mochi-shaped silhouette, tiny eye dots, and a small nose. v3 had the right pose but the face read busy at sprite scale. This v4 pares the face down to match the reference's clean cuteness.

## Changes

- **PINK CHEEK BLUSHES** (NEW) — 2x1 pink patches on each side of the nose. The reference's signature feature; transforms the face from "polar bear with hat" into "cute pixel polar bear".
- **Eyes shrunk** from 2x2 to 1x2 navy dots — the reference uses tiny dots, not big circles
- **Nose simplified** back to a 2x2 black bean (was 4x2 wide bar)
- **Body silhouette is mochi-shaped** — continuous flow from head to torso, slight neck-pinch from scarf, smooth taper outward to haunches. Matches the reference's simple round shape
- **Snout cream patch removed** — reference has pure white face with just the dark features and pink blushes
- **Hat sized down slightly** so the face has room for the cheek blushes
- **Two paws** planted at bottom-corners (was four — reference shows just two front paws)

## Preserved

- Red wool hat + white pom-pom + knit-pattern brim dots
- Cyan scarf with knot + fringed tail
- Pink toe beans

## Files

- `apps/desk/src/characters/pole.svg` (Trading Desk world)
- `apps/docs/static/img/brand/pole.svg` (cast docs page)

## Verification

- SVG renders cleanly in the in-IDE browser
- World view shows Pole at left-front of the ice with the pink cheek blushes clearly visible