### PR TITLE
Trading Desk: penguins move with their ice shelves + uniform 96px sprites

### DIFF
--- a/apps/desk/src/components/Actor.tsx
+++ b/apps/desk/src/components/Actor.tsx
@@ -8,10 +8,23 @@ import { useDraggable } from '../hooks/useDraggable';
 // global.css. Optional nameplate is shown on hover; optional speech
 // bubble appears for `speech-pop` duration when set.
 //
-// If dragId is supplied, the actor becomes draggable by the user --
-// click-and-drag anywhere on the sprite moves it, and the position
-// is persisted in localStorage under the supplied id (use the
-// "actor:<name>" namespace to avoid collisions with HUD ids).
+// LAYOUT MODEL
+// ┌── .actor (positioned at x%, y%, transformed -50%/-50%) ──┐
+// │   ┌── .actor-content (THIS gets the walk/swim/etc animation)
+// │   │   <img />        (the sprite)
+// │   │   children        (e.g. workstation pad under a penguin)
+// │   ├──────────────────────────────────────────────────────┤
+// │   <nameplate />     (NOT animated; stays attached to .actor)
+// │   <speech />         (NOT animated; stays attached to .actor)
+// └──────────────────────────────────────────────────────────┘
+//
+// This split is what makes a penguin's ice-shelf workstation move
+// together with the penguin: pass the workstation as `children` and
+// it lives inside .actor-content, so the walk keyframe translates
+// img + workstation as a single unit.
+//
+// If dragId is supplied, the actor becomes draggable. Drag updates
+// the OUTER .actor position; the inner .actor-content keeps animating.
 
 export interface ActorProps {
   name: CharacterName;
@@ -34,11 +47,16 @@ export interface ActorProps {
    * stable id like `actor:pole` or `actor:penguin:<agent-id>`.
    */
   dragId?: string;
+  /**
+   * Children render INSIDE .actor-content (alongside the sprite),
+   * so they participate in any walk / swim / coin-fly animation
+   * applied to the actor. Use for the penguin's workstation pad.
+   */
   children?: ReactNode;
 }
 
 export const Actor: React.FC<ActorProps> = ({
-  name, size = 64, x, y, state = '', nameplate, speech, zIndex, style, dragId, children,
+  name, size = 96, x, y, state = '', nameplate, speech, zIndex, style, dragId, children,
 }) => {
   // Always call the hook (rules of hooks) but pass an empty id if
   // not draggable -- the hook short-circuits in that case and
@@ -63,10 +81,12 @@ export const Actor: React.FC<ActorProps> = ({
         ...(isDraggable ? drag.style : null),
       }}
     >
-      <Sprite name={name} size={size} />
+      <div className="actor-content">
+        <Sprite name={name} size={size} />
+        {children}
+      </div>
       {nameplate && <div className="nameplate">{nameplate}</div>}
       {speech && <div className="speech">{speech}</div>}
-      {children}
     </div>
   );
 };

--- a/apps/desk/src/components/World.tsx
+++ b/apps/desk/src/components/World.tsx
@@ -36,6 +36,12 @@ export interface WorldProps {
   alertActive: boolean;
 }
 
+// All character sprites in the world are rendered at the same
+// canonical size so the cast feels like a coherent set. Coins and
+// transient effects keep their own sizes since they aren't
+// "characters". Adjust here once to scale every actor uniformly.
+const SPRITE_SIZE = 96;
+
 // Workstation slots distributed across the MIDDLE of the ice, in a
 // safe band that's clear of every corner HUD:
 //   - above the bottom-left decision log    (which extends to ~x=33%)
@@ -152,27 +158,26 @@ export const World: React.FC<WorldProps> = ({ agents, decisions, alertActive }) 
     const state = isHalted ? 'halted' : (isWalking ? 'walking' : 'idle');
     return (
       <React.Fragment key={a.id}>
-        {/* Workstation pad under the penguin's feet */}
-        <div
-          className="workstation"
-          style={{ left: `${slot.x}%`, top: `calc(${slot.y}% + 38px)` }}
-        >
-          <div className="top" />
-          {/* small "alive" beacon when the agent is running */}
-          {!isHalted && <div className="glow" />}
-        </div>
-
         <Actor
           name="penguin"
           x={slot.x}
           y={slot.y}
-          size={84}
+          size={SPRITE_SIZE}
           state={state}
           nameplate={`${a.name || a.id.slice(0, 12)} - ${a.strategy}`}
           speech={speeches[a.id]}
           zIndex={20}
           dragId={`actor:penguin:${a.id}`}
-        />
+        >
+          {/* Workstation pad rendered INSIDE the actor so it
+              participates in every animation -- when the penguin
+              walks (decision tick) or bobs (idle), the ice shelf
+              moves with him. Also moves together when dragged. */}
+          <div className="workstation">
+            <div className="top" />
+            {!isHalted && <div className="glow" />}
+          </div>
+        </Actor>
         {/* Permanent narwhal companion for LLM-using strategies,
             floating in the sky above the workstation. Draggable
             independently -- if the user drags the penguin, the
@@ -182,7 +187,7 @@ export const World: React.FC<WorldProps> = ({ agents, decisions, alertActive }) 
             name="narwhal"
             x={slot.x}
             y={slot.y - 24}
-            size={56}
+            size={SPRITE_SIZE}
             state="perched"
             nameplate={`${a.name || a.id.slice(0, 12)}'s LLM advisor`}
             zIndex={19}
@@ -208,20 +213,21 @@ export const World: React.FC<WorldProps> = ({ agents, decisions, alertActive }) 
         name="pole"
         x={12}
         y={58}
-        size={150}
+        size={SPRITE_SIZE}
         state="idle"
         nameplate="Pole the Polar Bear"
         zIndex={25}
         dragId="actor:pole"
       />
 
-      {/* Aurora the snowy owl floats high above the right side of
-          the ice. Draggable. */}
+      {/* Aurora the snowy owl floats above the right side of the
+          ice. y=52 keeps her clear of the Camp Roster HUD which
+          spans the top-right corner down to ~y=34. Draggable. */}
       <Actor
         name="owl"
-        x={87}
-        y={42}
-        size={88}
+        x={84}
+        y={52}
+        size={SPRITE_SIZE}
         state={`perched ${alertActive ? 'alert' : ''}`}
         nameplate={alertActive ? 'Aurora is ALERT' : 'Aurora is watching'}
         zIndex={26}
@@ -234,7 +240,7 @@ export const World: React.FC<WorldProps> = ({ agents, decisions, alertActive }) 
         name="walrus"
         x={23}
         y={66}
-        size={104}
+        size={SPRITE_SIZE}
         state="idle"
         nameplate="Kelp - swap router"
         zIndex={22}
@@ -248,7 +254,7 @@ export const World: React.FC<WorldProps> = ({ agents, decisions, alertActive }) 
         name="husky"
         x={-5}
         y={70}
-        size={108}
+        size={SPRITE_SIZE}
         state="running-across"
         nameplate="Skipper"
         zIndex={28}
@@ -260,19 +266,25 @@ export const World: React.FC<WorldProps> = ({ agents, decisions, alertActive }) 
       {/* === transient effects === */}
       {effects.map(e => {
         if (e.kind === 'narwhal') {
+          // Transient swim effect uses the same canonical size as
+          // the perched narwhal companion so they read as the same
+          // character mid-action.
           return (
             <Actor
               key={e.id}
               name="narwhal"
               x={e.x}
               y={e.y}
-              size={48}
+              size={SPRITE_SIZE}
               state="swim glowing"
               zIndex={30}
             />
           );
         }
         if (e.kind === 'coin') {
+          // Coins keep a small size -- they're a UI flourish (the
+          // PnL icon flying to the vault), not a "character" on the
+          // ice. Same size as the vault HUD's coin-stack icons.
           return (
             <Actor
               key={e.id}
@@ -300,7 +312,7 @@ export const World: React.FC<WorldProps> = ({ agents, decisions, alertActive }) 
           name="mammoth"
           x={78}
           y={51}
-          size={80}
+          size={SPRITE_SIZE}
           state="idle"
           nameplate="Tusk - private"
           zIndex={15}
@@ -309,13 +321,14 @@ export const World: React.FC<WorldProps> = ({ agents, decisions, alertActive }) 
       )}
 
       {/* Frostbite the Whale surfaces from the bottom-front of the
-          ice when an agent halts. Big, ominous, hard to miss. */}
+          ice when an agent halts. Same canonical size as the rest
+          of the cast for visual consistency. */}
       {alertActive && (
         <Actor
           name="whale"
           x={50}
           y={102}
-          size={160}
+          size={SPRITE_SIZE}
           state=""
           nameplate="Frostbite has surfaced"
           zIndex={40}

--- a/apps/desk/src/styles/global.css
+++ b/apps/desk/src/styles/global.css
@@ -248,6 +248,12 @@ img { -webkit-user-drag: none; user-select: none; }
   /* Subtle drop shadow so characters lift off the ice */
   filter: drop-shadow(0 4px 6px rgba(0,0,0,0.35));
 }
+.actor-content {
+  position: relative;
+  /* This wrapper holds the sprite + any per-actor children (e.g.
+   * the penguin's workstation pad). Animations apply HERE so all
+   * children move together. */
+}
 .actor img {
   display: block;
   image-rendering: pixelated;
@@ -263,25 +269,36 @@ img { -webkit-user-drag: none; user-select: none; }
 .actor.draggable:hover { filter: drop-shadow(0 6px 10px rgba(80,210,194,0.45)); }
 
 /* Workstation -- small ice block under each penguin agent so they
- * look like they're standing at a trading desk rather than floating. */
+ * look like they're standing at a trading desk rather than floating.
+ *
+ * Lives INSIDE the penguin's .actor-content so it inherits every
+ * animation (idle-bob, walking-translate). The whole "penguin on
+ * his ice shelf" moves as one unit -- penguin can't drift off
+ * his own ice patch.
+ *
+ * Positioned absolutely under the sprite (top: 100%) so it doesn't
+ * shift the actor's bounding box -- nameplate placement stays
+ * centered on the penguin's head. */
 .workstation {
   position: absolute;
-  width: 90px; height: 28px;
+  left: 50%;
+  top: 100%;
+  transform: translate(-50%, -55%);
+  width: 100px; height: 18px;
   pointer-events: none;
-  transform: translate(-50%, -10%);
-  z-index: 18;
+  z-index: -1;
 }
 .workstation .top {
-  position: absolute; inset: 0 4px auto 4px; top: 6px;
+  position: absolute; inset: 0 4px auto 4px; top: 4px;
   height: 8px;
   background: linear-gradient(180deg, #ECF6FF 0%, #C8DCF7 100%);
-  border-radius: 2px;
-  box-shadow: 0 2px 0 #7B9FCB;
+  border-radius: 4px;
+  box-shadow: 0 2px 0 #7B9FCB, 0 4px 8px rgba(0,0,0,0.18);
 }
 .workstation .glow {
   position: absolute; left: 50%; top: 0;
-  transform: translate(-50%, -120%);
-  width: 12px; height: 4px;
+  transform: translate(-50%, -160%);
+  width: 14px; height: 4px;
   background: var(--aurora-c);
   border-radius: 2px;
   filter: blur(2px);
@@ -346,17 +363,22 @@ img { -webkit-user-drag: none; user-select: none; }
   0%, 100% { transform: translateY(0); }
   50%      { transform: translateY(-3px); }
 }
-.actor.idle img { animation: idle-bob 3s ease-in-out infinite; }
+/* All idle/walk/halted animations target .actor-content so any
+ * children inside it (e.g. a penguin's workstation pad) animate
+ * together with the sprite. The only exception is .actor.halted's
+ * static drop -- it sets a fixed transform with no keyframe. */
+.actor.idle .actor-content { animation: idle-bob 3s ease-in-out infinite; }
 /* Stagger the bob so several penguins don't move in sync */
-.actor.idle:nth-child(2n) img { animation-delay: -1s; }
-.actor.idle:nth-child(3n) img { animation-delay: -2s; }
+.actor.idle:nth-child(2n) .actor-content { animation-delay: -1s; }
+.actor.idle:nth-child(3n) .actor-content { animation-delay: -2s; }
 
-/* Halted -- agent slumps, drops by 4px and stays */
-.actor.halted img { animation: idle-bob 6s ease-in-out infinite; opacity: 0.7; transform: translateY(2px); }
+/* Halted -- agent slumps slightly and bobs more slowly, opacity dims */
+.actor.halted .actor-content { animation: idle-bob 6s ease-in-out infinite; opacity: 0.7; transform: translateY(2px); }
 
 /* Walking penguin -- waddles back and forth across a small range.
- * Used when an agent has just made a decision (the penguin took an
- * action, so it briefly wanders before sitting back down). */
+ * Used when an agent has just made a decision. The whole content
+ * (sprite + workstation ice-shelf) translates together so the
+ * penguin and his ice patch move as one unit. */
 @keyframes walk {
   0%   { transform: translateX(0)    scaleX(1); }
   20%  { transform: translateX(20px) scaleX(1); }
@@ -365,7 +387,7 @@ img { -webkit-user-drag: none; user-select: none; }
   61%  { transform: translateX(-15px) scaleX(1); }
   100% { transform: translateX(0)    scaleX(1); }
 }
-.actor.walking img { animation: walk 4s ease-in-out infinite, idle-bob 0.4s ease-in-out infinite; }
+.actor.walking .actor-content { animation: walk 4s ease-in-out infinite, idle-bob 0.4s ease-in-out infinite; }
 
 /* Husky trot -- Skipper trots rightward across the world FOREVER.
  *
@@ -389,8 +411,8 @@ img { -webkit-user-drag: none; user-select: none; }
   50%   { transform: translate(calc(100vw - 50% + 240px), -50%); }
   100%  { transform: translate(calc(100vw - 50% + 240px), -50%); }
 }
-.actor.running-across img { animation: idle-bob 0.4s linear infinite; }
-.actor.running-across     { animation: husky-trot 16s linear infinite; }
+.actor.running-across .actor-content { animation: idle-bob 0.4s linear infinite; }
+.actor.running-across                { animation: husky-trot 16s linear infinite; }
 
 /* Narwhal swim -- comes up from under the ice (off-screen) when an
  * LLM consult fires, swims across to its assigned penguin, then
@@ -402,15 +424,15 @@ img { -webkit-user-drag: none; user-select: none; }
   80%  { opacity: 1; }
   100% { transform: translate(calc(-50% + 150px), calc(-50% + 60px)) rotate(8deg); opacity: 0; }
 }
-.actor.swim img { animation: idle-bob 1.2s ease-in-out infinite; }
-.actor.swim     { animation: narwhal-swim 5s ease-in-out forwards; }
+.actor.swim .actor-content { animation: idle-bob 1.2s ease-in-out infinite; }
+.actor.swim                { animation: narwhal-swim 5s ease-in-out forwards; }
 
 /* Owl head bob -- subtle, much smaller than penguin idle */
 @keyframes owl-bob {
   0%, 100% { transform: rotate(-2deg); }
   50%      { transform: rotate(2deg); }
 }
-.actor.perched img { animation: owl-bob 5s ease-in-out infinite; }
+.actor.perched .actor-content { animation: owl-bob 5s ease-in-out infinite; }
 
 /* Coin floating up to the vault. Preserves the centering offset. */
 @keyframes coin-float {


### PR DESCRIPTION
Two related polish changes per user feedback.

## (1) Penguins now move with their ice shelves

Previously the workstation pad was a **sibling** of the penguin Actor, positioned via the slot's x/y. When the penguin walked (decision tick) or was dragged, the ice shelf stayed put — the penguin visually drifted off his own ice patch.

**Fix:** refactor Actor to wrap (sprite + children) in a new `.actor-content` div. All animations (idle / walking / running-across / swim / perched) now apply to `.actor-content` rather than to `img` directly. The penguin's workstation pad is rendered as a **child** of the Actor, lives inside `.actor-content`, so it inherits every animation.

- Penguin walks → ice shelf walks with him
- User drags penguin → ice shelf comes along

Workstation positioned absolutely under the sprite (`top: 100%`) so it doesn't expand the actor's bounding box (nameplate placement still centers on the penguin's head).

## (2) All character sprites normalised to 96px

Single `SPRITE_SIZE` constant in `World.tsx`, used by every character (Pole, owl, walrus, husky, penguins, narwhals, mammoth, whale). Previously sizes ranged from 56 (perched narwhal) to 160 (Frostbite alert) — the cast didn't read as a coherent set.

**Exception:** coin sprites stay at their existing small sizes (20 in the vault HUD, 28 in coin-fly). Coins are a UI flourish, not a character on the ice; documented inline.

**Side effects:**
- Pole shrunk from 150 to 96 — still presence-y but no longer dwarfs the cast
- Frostbite-on-alert shrunk from 160 to 96 — still dramatic emergence, visually consistent

## Bonus

Aurora the owl moved (y=42 → y=52, x=87 → x=84) so she's clear of the Camp Roster HUD which spans the top-right corner.

## Verification

- `tsc --noEmit` clean
- In-IDE browser: every sprite the same size, every penguin on their own ice shelf, Aurora fully visible