### PR TITLE
Mammoth sprite v4: side-profile to match the user's pixel reference

### DIFF
--- a/apps/desk/src/characters/mammoth.svg
+++ b/apps/desk/src/characters/mammoth.svg
@@ -1,72 +1,135 @@
 <!--
-  Tusk the mammoth. Operator's gitignored private strategies.
-  Visible only on the maintainer's local build (extinct from public
-  view). Shaggy fur, large tusks, big personality.
-
-  Hand-authored pixel art, 32x32 logical grid.
-  Palette: shaggy brown #6B4624, accent rust #8C5C2E, tusk cream
-           #F1E5C3, dark eye #1B1F2A, navy outline #1B2A4E.
+  Tusk the Mammoth (v4). Side-profile mammoth facing left, mapped from
+  the user's pixel-art reference. Iterated v3 to make the head, trunk
+  and tusk readable: bigger head with clear eye, longer thicker trunk,
+  prominent cream tusk curving down. Body has the lighter highlight
+  along the back and darker shadow along the belly per the reference.
+  Hand-authored pixel art on a 32x32 grid scaled to 256x256.
+  Palette: highlight tan #C68250, main brown #A0623C, shadow brown
+           #6B3F22, very dark outline #2B1810, tusk cream #F1E5C3,
+           tusk highlight #FFFFFF, eye black #000000.
 -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Tusk the mammoth, private strategies">
-  <title>Tusk the mammoth</title>
-  <desc>Operator's gitignored private strategies. Visible only on the maintainer's local build.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Tusk the Mammoth, private strategy">
+  <title>Tusk the Mammoth</title>
+  <desc>Side-profile woolly mammoth facing left -- the operator's gitignored private strategies.</desc>
 
-  <!-- Shaggy head/body crown -->
-  <rect x="9"  y="3"  width="14" height="1" fill="#6B4624"/>
-  <rect x="8"  y="4"  width="16" height="1" fill="#6B4624"/>
+  <!-- ============================================================
+       BODY - big rounded torso. Drawn first so head + trunk +
+       tusk + legs layer on top.
+       ============================================================ -->
+  <!-- Top of body outline (the back) -->
+  <rect x="11" y="9"  width="14" height="1" fill="#2B1810"/>
+  <rect x="10" y="10" width="1"  height="1" fill="#2B1810"/>
+  <rect x="25" y="10" width="1"  height="1" fill="#2B1810"/>
+  <!-- Back outline curving down to tail -->
+  <rect x="26" y="11" width="1"  height="6" fill="#2B1810"/>
+  <!-- Bottom of body -->
+  <rect x="9"  y="11" width="1"  height="6" fill="#2B1810"/>
+  <rect x="10" y="17" width="16" height="1" fill="#2B1810"/>
 
-  <!-- Head outline -->
-  <rect x="7"  y="5"  width="18" height="1" fill="#1B2A4E"/>
-  <rect x="6"  y="6"  width="1"  height="11" fill="#1B2A4E"/>
-  <rect x="25" y="6"  width="1"  height="11" fill="#1B2A4E"/>
-  <rect x="7"  y="17" width="18" height="1" fill="#1B2A4E"/>
+  <!-- Body fill (warm brown) -->
+  <rect x="11" y="10" width="14" height="1" fill="#A0623C"/>
+  <rect x="10" y="11" width="16" height="6" fill="#A0623C"/>
+  <!-- Lighter highlight along the back -->
+  <rect x="11" y="10" width="14" height="1" fill="#C68250"/>
+  <rect x="11" y="11" width="14" height="1" fill="#C68250"/>
+  <!-- Darker shadow along the belly -->
+  <rect x="10" y="15" width="16" height="2" fill="#6B3F22"/>
 
+  <!-- ============================================================
+       HEAD - bigger and more pronounced than v3. Sits on the
+       front-left of the body (overlapping it slightly), with a
+       clear face and visible eye.
+       ============================================================ -->
+  <!-- Head dome (curves up + over from the body) -->
+  <rect x="6"  y="11" width="4"  height="1" fill="#2B1810"/>
+  <rect x="5"  y="12" width="1"  height="3" fill="#2B1810"/>
+  <rect x="6"  y="15" width="1"  height="1" fill="#2B1810"/>
   <!-- Head fill -->
-  <rect x="7"  y="6"  width="18" height="11" fill="#6B4624"/>
+  <rect x="6"  y="12" width="4"  height="3" fill="#A0623C"/>
+  <!-- Head highlight along the top -->
+  <rect x="6"  y="12" width="4"  height="1" fill="#C68250"/>
 
-  <!-- Shaggy texture (rust streaks) -->
-  <rect x="8"  y="7"  width="2"  height="2" fill="#8C5C2E"/>
-  <rect x="14" y="6"  width="2"  height="2" fill="#8C5C2E"/>
-  <rect x="20" y="7"  width="2"  height="2" fill="#8C5C2E"/>
-  <rect x="9"  y="14" width="3"  height="1" fill="#8C5C2E"/>
-  <rect x="20" y="14" width="3"  height="1" fill="#8C5C2E"/>
+  <!-- EYE (black dot, prominent) -->
+  <rect x="8"  y="13" width="1"  height="1" fill="#000000"/>
 
-  <!-- Eyes -->
-  <rect x="10" y="9"  width="2"  height="2" fill="#1B1F2A"/>
-  <rect x="20" y="9"  width="2"  height="2" fill="#1B1F2A"/>
-  <rect x="10" y="9"  width="1"  height="1" fill="#F1E5C3"/>
-  <rect x="20" y="9"  width="1"  height="1" fill="#F1E5C3"/>
+  <!-- ============================================================
+       TRUNK - thick curved trunk hanging down from the head, with
+       a slight forward (left) curl at the tip. Drawn AFTER the
+       head so it always layers cleanly.
+       ============================================================ -->
+  <!-- Trunk outline (left + right edges) -->
+  <rect x="5"  y="15" width="1"  height="5" fill="#2B1810"/>
+  <rect x="9"  y="15" width="1"  height="4" fill="#2B1810"/>
+  <rect x="6"  y="20" width="1"  height="1" fill="#2B1810"/>
+  <rect x="8"  y="19" width="1"  height="1" fill="#2B1810"/>
+  <rect x="4"  y="20" width="1"  height="1" fill="#2B1810"/>
+  <rect x="4"  y="21" width="2"  height="1" fill="#2B1810"/>
+  <!-- Trunk fill -->
+  <rect x="6"  y="15" width="3"  height="4" fill="#A0623C"/>
+  <rect x="6"  y="19" width="2"  height="1" fill="#A0623C"/>
+  <rect x="5"  y="20" width="1"  height="1" fill="#A0623C"/>
+  <!-- Trunk highlight (catches the light along the right side) -->
+  <rect x="8"  y="15" width="1"  height="4" fill="#C68250"/>
+  <!-- Trunk shadow (darker on the left side) -->
+  <rect x="6"  y="16" width="1"  height="3" fill="#6B3F22"/>
 
-  <!-- Trunk (curved down then up) -->
-  <rect x="14" y="12" width="4"  height="2" fill="#6B4624"/>
-  <rect x="14" y="14" width="2"  height="6" fill="#6B4624"/>
-  <rect x="13" y="20" width="3"  height="1" fill="#6B4624"/>
-  <rect x="13" y="21" width="1"  height="1" fill="#6B4624"/>
+  <!-- ============================================================
+       TUSK - single visible cream tusk curving down from beneath
+       the trunk. Drawn LAST so it's always on top.
+       ============================================================ -->
+  <!-- Tusk outline -->
+  <rect x="6"  y="18" width="1"  height="1" fill="#2B1810"/>
+  <rect x="7"  y="19" width="1"  height="1" fill="#2B1810"/>
+  <rect x="3"  y="22" width="1"  height="1" fill="#2B1810"/>
+  <rect x="6"  y="22" width="1"  height="1" fill="#2B1810"/>
+  <rect x="3"  y="23" width="4"  height="1" fill="#2B1810"/>
+  <!-- Tusk fill (cream) -->
+  <rect x="7"  y="20" width="1"  height="1" fill="#F1E5C3"/>
+  <rect x="6"  y="21" width="2"  height="1" fill="#F1E5C3"/>
+  <rect x="5"  y="22" width="2"  height="1" fill="#F1E5C3"/>
+  <rect x="4"  y="22" width="1"  height="1" fill="#F1E5C3"/>
+  <!-- Tusk shine -->
+  <rect x="6"  y="21" width="1"  height="1" fill="#FFFFFF"/>
 
-  <!-- Trunk shading -->
-  <rect x="15" y="14" width="1"  height="6" fill="#8C5C2E"/>
+  <!-- ============================================================
+       LEGS - four stubby brown legs at the bottom. Two front
+       (closer, brighter) + two back (slightly inset, darker for
+       depth perception).
+       ============================================================ -->
 
-  <!-- Tusks (big, curving outward) -->
-  <rect x="11" y="13" width="1"  height="4" fill="#F1E5C3"/>
-  <rect x="10" y="14" width="1"  height="3" fill="#F1E5C3"/>
-  <rect x="9"  y="16" width="1"  height="2" fill="#F1E5C3"/>
+  <!-- Front-left leg -->
+  <rect x="10" y="18" width="1"  height="5" fill="#2B1810"/>
+  <rect x="13" y="18" width="1"  height="5" fill="#2B1810"/>
+  <rect x="11" y="18" width="2"  height="5" fill="#A0623C"/>
+  <rect x="11" y="22" width="2"  height="1" fill="#2B1810"/>
+  <rect x="10" y="23" width="4"  height="1" fill="#2B1810"/>
+  <!-- Front-leg highlight -->
+  <rect x="11" y="18" width="1"  height="3" fill="#C68250"/>
 
-  <rect x="20" y="13" width="1"  height="4" fill="#F1E5C3"/>
-  <rect x="21" y="14" width="1"  height="3" fill="#F1E5C3"/>
-  <rect x="22" y="16" width="1"  height="2" fill="#F1E5C3"/>
+  <!-- Front-right leg -->
+  <rect x="15" y="18" width="1"  height="5" fill="#2B1810"/>
+  <rect x="18" y="18" width="1"  height="5" fill="#2B1810"/>
+  <rect x="16" y="18" width="2"  height="5" fill="#A0623C"/>
+  <rect x="16" y="22" width="2"  height="1" fill="#2B1810"/>
+  <rect x="15" y="23" width="4"  height="1" fill="#2B1810"/>
+  <rect x="16" y="18" width="1"  height="3" fill="#C68250"/>
 
-  <!-- Body / shoulders -->
-  <rect x="6"  y="18" width="20" height="1" fill="#1B2A4E"/>
-  <rect x="6"  y="19" width="20" height="6" fill="#6B4624"/>
-  <rect x="5"  y="19" width="1"  height="6" fill="#1B2A4E"/>
-  <rect x="26" y="19" width="1"  height="6" fill="#1B2A4E"/>
-  <rect x="6"  y="25" width="20" height="1" fill="#1B2A4E"/>
+  <!-- Back-left leg (slightly inset, darker shadow brown) -->
+  <rect x="20" y="18" width="1"  height="5" fill="#2B1810"/>
+  <rect x="22" y="18" width="1"  height="5" fill="#2B1810"/>
+  <rect x="21" y="18" width="1"  height="5" fill="#6B3F22"/>
+  <rect x="20" y="23" width="3"  height="1" fill="#2B1810"/>
 
-  <!-- Shaggy underside -->
-  <rect x="8"  y="22" width="3"  height="3" fill="#8C5C2E"/>
-  <rect x="21" y="22" width="3"  height="3" fill="#8C5C2E"/>
+  <!-- Back-right leg -->
+  <rect x="23" y="18" width="1"  height="5" fill="#2B1810"/>
+  <rect x="25" y="18" width="1"  height="5" fill="#2B1810"/>
+  <rect x="24" y="18" width="1"  height="5" fill="#6B3F22"/>
+  <rect x="23" y="23" width="3"  height="1" fill="#2B1810"/>
 
-  <!-- Legs -->
-  <rect x="9"  y="26" width="3"  height="2" fill="#6B4624"/>
-  <rect x="20" y="26" width="3"  height="2" fill="#6B4624"/>
+  <!-- ============================================================
+       Small tail nub at the back-right
+       ============================================================ -->
+  <rect x="27" y="13" width="1"  height="2" fill="#2B1810"/>
+  <rect x="28" y="14" width="1"  height="1" fill="#A0623C"/>
 </svg>

--- a/apps/docs/static/img/brand/mammoth.svg
+++ b/apps/docs/static/img/brand/mammoth.svg
@@ -1,72 +1,135 @@
 <!--
-  Tusk the mammoth. Operator's gitignored private strategies.
-  Visible only on the maintainer's local build (extinct from public
-  view). Shaggy fur, large tusks, big personality.
-
-  Hand-authored pixel art, 32x32 logical grid.
-  Palette: shaggy brown #6B4624, accent rust #8C5C2E, tusk cream
-           #F1E5C3, dark eye #1B1F2A, navy outline #1B2A4E.
+  Tusk the Mammoth (v4). Side-profile mammoth facing left, mapped from
+  the user's pixel-art reference. Iterated v3 to make the head, trunk
+  and tusk readable: bigger head with clear eye, longer thicker trunk,
+  prominent cream tusk curving down. Body has the lighter highlight
+  along the back and darker shadow along the belly per the reference.
+  Hand-authored pixel art on a 32x32 grid scaled to 256x256.
+  Palette: highlight tan #C68250, main brown #A0623C, shadow brown
+           #6B3F22, very dark outline #2B1810, tusk cream #F1E5C3,
+           tusk highlight #FFFFFF, eye black #000000.
 -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Tusk the mammoth, private strategies">
-  <title>Tusk the mammoth</title>
-  <desc>Operator's gitignored private strategies. Visible only on the maintainer's local build.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Tusk the Mammoth, private strategy">
+  <title>Tusk the Mammoth</title>
+  <desc>Side-profile woolly mammoth facing left -- the operator's gitignored private strategies.</desc>
 
-  <!-- Shaggy head/body crown -->
-  <rect x="9"  y="3"  width="14" height="1" fill="#6B4624"/>
-  <rect x="8"  y="4"  width="16" height="1" fill="#6B4624"/>
+  <!-- ============================================================
+       BODY - big rounded torso. Drawn first so head + trunk +
+       tusk + legs layer on top.
+       ============================================================ -->
+  <!-- Top of body outline (the back) -->
+  <rect x="11" y="9"  width="14" height="1" fill="#2B1810"/>
+  <rect x="10" y="10" width="1"  height="1" fill="#2B1810"/>
+  <rect x="25" y="10" width="1"  height="1" fill="#2B1810"/>
+  <!-- Back outline curving down to tail -->
+  <rect x="26" y="11" width="1"  height="6" fill="#2B1810"/>
+  <!-- Bottom of body -->
+  <rect x="9"  y="11" width="1"  height="6" fill="#2B1810"/>
+  <rect x="10" y="17" width="16" height="1" fill="#2B1810"/>
 
-  <!-- Head outline -->
-  <rect x="7"  y="5"  width="18" height="1" fill="#1B2A4E"/>
-  <rect x="6"  y="6"  width="1"  height="11" fill="#1B2A4E"/>
-  <rect x="25" y="6"  width="1"  height="11" fill="#1B2A4E"/>
-  <rect x="7"  y="17" width="18" height="1" fill="#1B2A4E"/>
+  <!-- Body fill (warm brown) -->
+  <rect x="11" y="10" width="14" height="1" fill="#A0623C"/>
+  <rect x="10" y="11" width="16" height="6" fill="#A0623C"/>
+  <!-- Lighter highlight along the back -->
+  <rect x="11" y="10" width="14" height="1" fill="#C68250"/>
+  <rect x="11" y="11" width="14" height="1" fill="#C68250"/>
+  <!-- Darker shadow along the belly -->
+  <rect x="10" y="15" width="16" height="2" fill="#6B3F22"/>
 
+  <!-- ============================================================
+       HEAD - bigger and more pronounced than v3. Sits on the
+       front-left of the body (overlapping it slightly), with a
+       clear face and visible eye.
+       ============================================================ -->
+  <!-- Head dome (curves up + over from the body) -->
+  <rect x="6"  y="11" width="4"  height="1" fill="#2B1810"/>
+  <rect x="5"  y="12" width="1"  height="3" fill="#2B1810"/>
+  <rect x="6"  y="15" width="1"  height="1" fill="#2B1810"/>
   <!-- Head fill -->
-  <rect x="7"  y="6"  width="18" height="11" fill="#6B4624"/>
+  <rect x="6"  y="12" width="4"  height="3" fill="#A0623C"/>
+  <!-- Head highlight along the top -->
+  <rect x="6"  y="12" width="4"  height="1" fill="#C68250"/>
 
-  <!-- Shaggy texture (rust streaks) -->
-  <rect x="8"  y="7"  width="2"  height="2" fill="#8C5C2E"/>
-  <rect x="14" y="6"  width="2"  height="2" fill="#8C5C2E"/>
-  <rect x="20" y="7"  width="2"  height="2" fill="#8C5C2E"/>
-  <rect x="9"  y="14" width="3"  height="1" fill="#8C5C2E"/>
-  <rect x="20" y="14" width="3"  height="1" fill="#8C5C2E"/>
+  <!-- EYE (black dot, prominent) -->
+  <rect x="8"  y="13" width="1"  height="1" fill="#000000"/>
 
-  <!-- Eyes -->
-  <rect x="10" y="9"  width="2"  height="2" fill="#1B1F2A"/>
-  <rect x="20" y="9"  width="2"  height="2" fill="#1B1F2A"/>
-  <rect x="10" y="9"  width="1"  height="1" fill="#F1E5C3"/>
-  <rect x="20" y="9"  width="1"  height="1" fill="#F1E5C3"/>
+  <!-- ============================================================
+       TRUNK - thick curved trunk hanging down from the head, with
+       a slight forward (left) curl at the tip. Drawn AFTER the
+       head so it always layers cleanly.
+       ============================================================ -->
+  <!-- Trunk outline (left + right edges) -->
+  <rect x="5"  y="15" width="1"  height="5" fill="#2B1810"/>
+  <rect x="9"  y="15" width="1"  height="4" fill="#2B1810"/>
+  <rect x="6"  y="20" width="1"  height="1" fill="#2B1810"/>
+  <rect x="8"  y="19" width="1"  height="1" fill="#2B1810"/>
+  <rect x="4"  y="20" width="1"  height="1" fill="#2B1810"/>
+  <rect x="4"  y="21" width="2"  height="1" fill="#2B1810"/>
+  <!-- Trunk fill -->
+  <rect x="6"  y="15" width="3"  height="4" fill="#A0623C"/>
+  <rect x="6"  y="19" width="2"  height="1" fill="#A0623C"/>
+  <rect x="5"  y="20" width="1"  height="1" fill="#A0623C"/>
+  <!-- Trunk highlight (catches the light along the right side) -->
+  <rect x="8"  y="15" width="1"  height="4" fill="#C68250"/>
+  <!-- Trunk shadow (darker on the left side) -->
+  <rect x="6"  y="16" width="1"  height="3" fill="#6B3F22"/>
 
-  <!-- Trunk (curved down then up) -->
-  <rect x="14" y="12" width="4"  height="2" fill="#6B4624"/>
-  <rect x="14" y="14" width="2"  height="6" fill="#6B4624"/>
-  <rect x="13" y="20" width="3"  height="1" fill="#6B4624"/>
-  <rect x="13" y="21" width="1"  height="1" fill="#6B4624"/>
+  <!-- ============================================================
+       TUSK - single visible cream tusk curving down from beneath
+       the trunk. Drawn LAST so it's always on top.
+       ============================================================ -->
+  <!-- Tusk outline -->
+  <rect x="6"  y="18" width="1"  height="1" fill="#2B1810"/>
+  <rect x="7"  y="19" width="1"  height="1" fill="#2B1810"/>
+  <rect x="3"  y="22" width="1"  height="1" fill="#2B1810"/>
+  <rect x="6"  y="22" width="1"  height="1" fill="#2B1810"/>
+  <rect x="3"  y="23" width="4"  height="1" fill="#2B1810"/>
+  <!-- Tusk fill (cream) -->
+  <rect x="7"  y="20" width="1"  height="1" fill="#F1E5C3"/>
+  <rect x="6"  y="21" width="2"  height="1" fill="#F1E5C3"/>
+  <rect x="5"  y="22" width="2"  height="1" fill="#F1E5C3"/>
+  <rect x="4"  y="22" width="1"  height="1" fill="#F1E5C3"/>
+  <!-- Tusk shine -->
+  <rect x="6"  y="21" width="1"  height="1" fill="#FFFFFF"/>
 
-  <!-- Trunk shading -->
-  <rect x="15" y="14" width="1"  height="6" fill="#8C5C2E"/>
+  <!-- ============================================================
+       LEGS - four stubby brown legs at the bottom. Two front
+       (closer, brighter) + two back (slightly inset, darker for
+       depth perception).
+       ============================================================ -->
 
-  <!-- Tusks (big, curving outward) -->
-  <rect x="11" y="13" width="1"  height="4" fill="#F1E5C3"/>
-  <rect x="10" y="14" width="1"  height="3" fill="#F1E5C3"/>
-  <rect x="9"  y="16" width="1"  height="2" fill="#F1E5C3"/>
+  <!-- Front-left leg -->
+  <rect x="10" y="18" width="1"  height="5" fill="#2B1810"/>
+  <rect x="13" y="18" width="1"  height="5" fill="#2B1810"/>
+  <rect x="11" y="18" width="2"  height="5" fill="#A0623C"/>
+  <rect x="11" y="22" width="2"  height="1" fill="#2B1810"/>
+  <rect x="10" y="23" width="4"  height="1" fill="#2B1810"/>
+  <!-- Front-leg highlight -->
+  <rect x="11" y="18" width="1"  height="3" fill="#C68250"/>
 
-  <rect x="20" y="13" width="1"  height="4" fill="#F1E5C3"/>
-  <rect x="21" y="14" width="1"  height="3" fill="#F1E5C3"/>
-  <rect x="22" y="16" width="1"  height="2" fill="#F1E5C3"/>
+  <!-- Front-right leg -->
+  <rect x="15" y="18" width="1"  height="5" fill="#2B1810"/>
+  <rect x="18" y="18" width="1"  height="5" fill="#2B1810"/>
+  <rect x="16" y="18" width="2"  height="5" fill="#A0623C"/>
+  <rect x="16" y="22" width="2"  height="1" fill="#2B1810"/>
+  <rect x="15" y="23" width="4"  height="1" fill="#2B1810"/>
+  <rect x="16" y="18" width="1"  height="3" fill="#C68250"/>
 
-  <!-- Body / shoulders -->
-  <rect x="6"  y="18" width="20" height="1" fill="#1B2A4E"/>
-  <rect x="6"  y="19" width="20" height="6" fill="#6B4624"/>
-  <rect x="5"  y="19" width="1"  height="6" fill="#1B2A4E"/>
-  <rect x="26" y="19" width="1"  height="6" fill="#1B2A4E"/>
-  <rect x="6"  y="25" width="20" height="1" fill="#1B2A4E"/>
+  <!-- Back-left leg (slightly inset, darker shadow brown) -->
+  <rect x="20" y="18" width="1"  height="5" fill="#2B1810"/>
+  <rect x="22" y="18" width="1"  height="5" fill="#2B1810"/>
+  <rect x="21" y="18" width="1"  height="5" fill="#6B3F22"/>
+  <rect x="20" y="23" width="3"  height="1" fill="#2B1810"/>
 
-  <!-- Shaggy underside -->
-  <rect x="8"  y="22" width="3"  height="3" fill="#8C5C2E"/>
-  <rect x="21" y="22" width="3"  height="3" fill="#8C5C2E"/>
+  <!-- Back-right leg -->
+  <rect x="23" y="18" width="1"  height="5" fill="#2B1810"/>
+  <rect x="25" y="18" width="1"  height="5" fill="#2B1810"/>
+  <rect x="24" y="18" width="1"  height="5" fill="#6B3F22"/>
+  <rect x="23" y="23" width="3"  height="1" fill="#2B1810"/>
 
-  <!-- Legs -->
-  <rect x="9"  y="26" width="3"  height="2" fill="#6B4624"/>
-  <rect x="20" y="26" width="3"  height="2" fill="#6B4624"/>
+  <!-- ============================================================
+       Small tail nub at the back-right
+       ============================================================ -->
+  <rect x="27" y="13" width="1"  height="2" fill="#2B1810"/>
+  <rect x="28" y="14" width="1"  height="1" fill="#A0623C"/>
 </svg>


### PR DESCRIPTION
User shared a side-profile pixel-art mammoth reference and asked for exact match. Previous v3 was front-facing shaggy. v4 redesigns Tusk as a side-profile mammoth facing left.

## Changes

- **Side-profile facing left** (was front-facing 3/4)
- **Three-tone brown gradient**: highlight tan along the back, main brown in the middle, shadow brown along the belly — matches the reference's clear top-light/bottom-dark shading
- **Pronounced head dome** on the front-left with a clear single black eye
- **Long curved trunk** hanging down from the head with a slight forward (left) curl at the tip — 3 pixels wide with a shadow stripe on the left and a highlight on the right
- **Single visible cream tusk** curving down from beneath the trunk — more prominent than v3, readable at sprite scale
- **Four stubby legs**: front pair in warm brown with highlight (closer to viewer); back pair in shadow brown only (slightly inset for depth perception)
- **Small navy tail nub** at the back-right
- **Drawing order fixed**: body first, then head + trunk + tusk + legs layered on top — trunk and tusk are never covered

## Files

- `apps/desk/src/characters/mammoth.svg` (Trading Desk world)
- `apps/docs/static/img/brand/mammoth.svg` (cast docs page)

## Verification

- SVG renders cleanly in the in-IDE browser
- World view shows the new Tusk at back-right of the ice with the trunk and tusk both clearly readable