### PR TITLE
Trading Desk: clamp drags below chrome, add reset-layout, shrink Skipper + narwhals

### DIFF
--- a/apps/desk/src/App.tsx
+++ b/apps/desk/src/App.tsx
@@ -3,6 +3,7 @@ import { APIClient, Agent, DecisionLite, demoData, nextDemoBatch } from './api/c
 import { World } from './components/World';
 import { VaultHud, AgentLegendHud, DecisionLogHud, CastHud } from './components/Hud';
 import { Sprite } from './components/Sprite';
+import { resetLayout } from './hooks/useDraggable';
 
 // App is the root view. The world fills the viewport; HUDs (Vault,
 // Agent legend, Decision log, Cast) overlay the corners. Title +
@@ -109,6 +110,32 @@ export const App: React.FC = () => {
       <AgentLegendHud agents={agents} />
       <DecisionLogHud decisions={decisions} />
       <CastHud />
+
+      {/* Reset-layout escape hatch -- if a HUD or sprite ends up in
+          an unrecoverable position (or the user just wants to
+          start over), one click clears every persisted position
+          and reloads. Pinned discreetly to the top-right edge,
+          beside the connection dot. */}
+      <button
+        type="button"
+        onClick={() => {
+          if (confirm('Reset all HUD and sprite positions to defaults?')) {
+            resetLayout();
+          }
+        }}
+        title="Reset all draggable HUD and sprite positions"
+        style={{
+          position: 'fixed', top: 20, right: 92, zIndex: 60,
+          background: 'rgba(10,27,54,0.7)', border: '1px solid var(--ice-edge)',
+          color: 'var(--ice-bright)', fontSize: 11, fontFamily: 'inherit',
+          padding: '4px 8px', borderRadius: 6, cursor: 'pointer',
+          opacity: 0.65, transition: 'opacity 120ms ease-out',
+        }}
+        onMouseEnter={e => (e.currentTarget.style.opacity = '1')}
+        onMouseLeave={e => (e.currentTarget.style.opacity = '0.65')}
+      >
+        ↺ reset layout
+      </button>
 
       {/* Footer error banner -- only when offline AND we have an error */}
       {lastError && !connected && (

--- a/apps/desk/src/components/World.tsx
+++ b/apps/desk/src/components/World.tsx
@@ -41,6 +41,13 @@ export interface WorldProps {
 // transient effects keep their own sizes since they aren't
 // "characters". Adjust here once to scale every actor uniformly.
 const SPRITE_SIZE = 96;
+// Per-character size overrides for sprites that read better
+// slightly smaller than the canonical size:
+//   - Husky trots cross-screen; full size feels too domineering.
+//   - Narwhal floats in the sky beside its agent; smaller keeps
+//     the focus on the penguin trader on the workstation.
+const HUSKY_SIZE   = 76;
+const NARWHAL_SIZE = 72;
 
 // Workstation slots distributed across the MIDDLE of the ice, in a
 // safe band that's clear of every corner HUD:
@@ -179,15 +186,17 @@ export const World: React.FC<WorldProps> = ({ agents, decisions, alertActive }) 
           </div>
         </Actor>
         {/* Permanent narwhal companion for LLM-using strategies,
-            floating in the sky above the workstation. Draggable
+            floating in the sky above the workstation. Smaller than
+            the canonical sprite size so it reads as a sidekick to
+            the penguin rather than competing with it. Draggable
             independently -- if the user drags the penguin, the
             narwhal stays where the user puts it (and vice versa). */}
         {usesLLM && (
           <Actor
             name="narwhal"
             x={slot.x}
-            y={slot.y - 24}
-            size={SPRITE_SIZE}
+            y={slot.y - 22}
+            size={NARWHAL_SIZE}
             state="perched"
             nameplate={`${a.name || a.id.slice(0, 12)}'s LLM advisor`}
             zIndex={19}
@@ -249,12 +258,14 @@ export const World: React.FC<WorldProps> = ({ agents, decisions, alertActive }) 
 
       {/* Skipper trots rightward forever via a single infinite CSS
           animation -- runs across the ice, exits right, pauses,
-          re-enters from the left. Never moves backwards. */}
+          re-enters from the left. Never moves backwards. Uses a
+          smaller-than-canonical size so he doesn't visually compete
+          with the static cast. */}
       <Actor
         name="husky"
         x={-5}
         y={70}
-        size={SPRITE_SIZE}
+        size={HUSKY_SIZE}
         state="running-across"
         nameplate="Skipper"
         zIndex={28}
@@ -266,16 +277,16 @@ export const World: React.FC<WorldProps> = ({ agents, decisions, alertActive }) 
       {/* === transient effects === */}
       {effects.map(e => {
         if (e.kind === 'narwhal') {
-          // Transient swim effect uses the same canonical size as
-          // the perched narwhal companion so they read as the same
-          // character mid-action.
+          // Transient swim effect uses the same NARWHAL_SIZE as the
+          // perched companion so they read as the same character
+          // mid-action.
           return (
             <Actor
               key={e.id}
               name="narwhal"
               x={e.x}
               y={e.y}
-              size={SPRITE_SIZE}
+              size={NARWHAL_SIZE}
               state="swim glowing"
               zIndex={30}
             />

--- a/apps/desk/src/hooks/useDraggable.ts
+++ b/apps/desk/src/hooks/useDraggable.ts
@@ -52,7 +52,12 @@ export function useDraggable(id: string): DraggableHandle {
       if (!raw) return null;
       const parsed = JSON.parse(raw);
       if (typeof parsed?.top === 'number' && typeof parsed?.left === 'number') {
-        return { top: parsed.top, left: parsed.left };
+        // Migration: if a previously-saved position is behind the
+        // chrome bar (because a pre-fix drag let it slip up), pull
+        // it back down to the chrome boundary so the user can grab
+        // its title bar to drag it again.
+        const top = Math.max(parsed.top, CHROME_HEIGHT);
+        return { top, left: parsed.left };
       }
     } catch {
       /* ignore -- localStorage might be disabled or corrupt */
@@ -97,7 +102,10 @@ export function useDraggable(id: string): DraggableHandle {
       const w = ref.current.offsetWidth;
       const h = ref.current.offsetHeight;
       const left = clamp(dragRef.current.left0 + dx, 0, window.innerWidth - w);
-      const top = clamp(dragRef.current.top0 + dy, 0, window.innerHeight - h);
+      // Top minimum is CHROME_HEIGHT so HUDs can't slip behind the
+      // top chrome bar where the user can't grab their title to drag
+      // back. Bottom is window height minus the panel's height.
+      const top = clamp(dragRef.current.top0 + dy, CHROME_HEIGHT, window.innerHeight - h);
       setPos({ top, left });
     };
 
@@ -153,4 +161,29 @@ export function useDraggable(id: string): DraggableHandle {
 
 function clamp(v: number, lo: number, hi: number) {
   return Math.max(lo, Math.min(hi, v));
+}
+
+// Min top offset for any draggable -- keeps panels and characters
+// below the fixed top chrome bar so the user can never drag a HUD
+// behind it (where its title would be unclickable). Matches the
+// chrome's height + padding in global.css.
+const CHROME_HEIGHT = 60;
+
+/**
+ * resetLayout clears every persisted drag position and reloads the
+ * page so the world snaps back to its CSS defaults. Wired to the
+ * "reset layout" button in App.tsx; useful if a user gets a HUD or
+ * sprite stuck behind something else (or just wants to start over).
+ */
+export function resetLayout(): void {
+  if (typeof window === 'undefined') return;
+  const prefix = 'permafrost-desk:';
+  // Snapshot keys first because we're mutating localStorage during iteration.
+  const toRemove: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const k = localStorage.key(i);
+    if (k && k.startsWith(prefix)) toRemove.push(k);
+  }
+  for (const k of toRemove) localStorage.removeItem(k);
+  window.location.reload();
 }


### PR DESCRIPTION
Three small UX fixes per user feedback.

## (1) HUDs can no longer be dragged behind the chrome bar

The user dragged the Camp Roster up under the top chrome bar where its title became unclickable — no way to grab it back.

**Fix in `useDraggable` hook:**
- `clamp()` now bounds `top >= CHROME_HEIGHT (60px)` during drag → no future drag can stash a HUD or sprite behind the chrome
- One-time migration on hydration: any persisted position with `top < CHROME_HEIGHT` is rescued by clamping it back to the chrome boundary on next render → existing trapped HUDs come back automatically

## (2) Reset-layout escape hatch

Pinned discreetly to the top-right edge beside the connection dot:

> ↺ reset layout

Click → confirmation prompt → clears every `permafrost-desk:*` localStorage key → reloads the page. World snaps back to its CSS-default layout. Useful if anything ever gets stuck or the user just wants to start over.

Implemented as a `resetLayout()` export from `useDraggable.ts` so the storage-key prefix stays in one place.

## (3) Skipper + Narwhal shrink

Per-character size overrides in `World.tsx`:

| Sprite | Was | Now |
|---|---|---|
| Husky (Skipper) | 96 | **76** |
| Narwhal (perched + swim) | 96 | **72** |

Main cast (Pole, Aurora, Kelp, Tusk, penguins, whale) stays at `SPRITE_SIZE = 96`. Coins keep their existing small sizes.

## Verification

- `tsc --noEmit` clean
- In-IDE browser: rescued Camp Roster shows up back on screen, reset button appears top-right, Skipper + narwhals render smaller, no console errors