### PR TITLE
Trading Desk: center title in nav and inline the reset-layout button

### DIFF
--- a/apps/desk/src/App.tsx
+++ b/apps/desk/src/App.tsx
@@ -79,9 +79,13 @@ export const App: React.FC = () => {
 
   return (
     <>
-      {/* Top chrome -- title + connection dot */}
+      {/* Top chrome -- title + connection dot. Three-column grid with
+          symmetric 1fr left/right tracks so the title cell is centered
+          relative to the viewport. Reset-layout button lives inline in
+          the right section so every nav element shares the same
+          horizontal baseline. */}
       <header className="chrome">
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <div className="left">
           <Sprite name="pole" size={48} />
           <div style={{ fontSize: 11, opacity: 0.7, letterSpacing: 0.5, textTransform: 'uppercase' }}>
             Camp Director
@@ -95,6 +99,18 @@ export const App: React.FC = () => {
           </div>
         </div>
         <div className="right">
+          <button
+            type="button"
+            className="reset-btn"
+            onClick={() => {
+              if (confirm('Reset all HUD and sprite positions to defaults?')) {
+                resetLayout();
+              }
+            }}
+            title="Reset all draggable HUD and sprite positions"
+          >
+            ↺ reset layout
+          </button>
           <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, opacity: 0.85 }}>
             <span className={`conn-dot ${connected ? 'live' : ''}`} />
             {connected ? 'connected' : 'demo'}
@@ -110,32 +126,6 @@ export const App: React.FC = () => {
       <AgentLegendHud agents={agents} />
       <DecisionLogHud decisions={decisions} />
       <CastHud />
-
-      {/* Reset-layout escape hatch -- if a HUD or sprite ends up in
-          an unrecoverable position (or the user just wants to
-          start over), one click clears every persisted position
-          and reloads. Pinned discreetly to the top-right edge,
-          beside the connection dot. */}
-      <button
-        type="button"
-        onClick={() => {
-          if (confirm('Reset all HUD and sprite positions to defaults?')) {
-            resetLayout();
-          }
-        }}
-        title="Reset all draggable HUD and sprite positions"
-        style={{
-          position: 'fixed', top: 20, right: 92, zIndex: 60,
-          background: 'rgba(10,27,54,0.7)', border: '1px solid var(--ice-edge)',
-          color: 'var(--ice-bright)', fontSize: 11, fontFamily: 'inherit',
-          padding: '4px 8px', borderRadius: 6, cursor: 'pointer',
-          opacity: 0.65, transition: 'opacity 120ms ease-out',
-        }}
-        onMouseEnter={e => (e.currentTarget.style.opacity = '1')}
-        onMouseLeave={e => (e.currentTarget.style.opacity = '0.65')}
-      >
-        ↺ reset layout
-      </button>
 
       {/* Footer error banner -- only when offline AND we have an error */}
       {lastError && !connected && (

--- a/apps/desk/src/styles/global.css
+++ b/apps/desk/src/styles/global.css
@@ -208,7 +208,10 @@ img { -webkit-user-drag: none; user-select: none; }
   top: 0; left: 0; right: 0;
   z-index: 50;
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  /* Symmetric 1fr columns on either side of an auto-sized title cell
+   * so the title is centered relative to the VIEWPORT, not relative
+   * to the leftover space after left/right take their auto widths. */
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
   padding: 12px 24px;
   gap: 16px;
@@ -219,7 +222,22 @@ img { -webkit-user-drag: none; user-select: none; }
 .chrome .title { text-align: center; }
 .chrome .title h1 { margin: 0; font-size: 18px; }
 .chrome .title .subtitle { font-size: 11px; opacity: 0.7; }
-.chrome .right { display: flex; align-items: center; gap: 12px; }
+.chrome .left  { display: flex; align-items: center; gap: 10px; justify-self: start; }
+.chrome .right { display: flex; align-items: center; gap: 12px; justify-self: end; }
+
+.chrome .reset-btn {
+  background: rgba(10,27,54,0.7);
+  border: 1px solid var(--ice-edge);
+  color: var(--ice-bright);
+  font-size: 11px;
+  font-family: inherit;
+  padding: 4px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  opacity: 0.65;
+  transition: opacity 120ms ease-out;
+}
+.chrome .reset-btn:hover { opacity: 1; }
 
 .conn-dot {
   width: 8px; height: 8px; border-radius: 50%;


### PR DESCRIPTION
## Summary
- Switch the chrome's `grid-template-columns` from `auto 1fr auto` to `1fr auto 1fr` so "Permafrost - Trading Desk" is centered relative to the viewport rather than the leftover space after the (wider) left section claims its auto width.
- Move the floating `position: fixed` ↺ reset-layout button into the chrome's `.right` cell so it shares the same horizontal baseline as the connection dot, the title, and Pole on the left. Inline styles promoted to a `.reset-btn` class.
- Add `.chrome .left` / `.chrome .right` with `justify-self: start|end` so each side hugs its viewport edge inside the new symmetric grid.

## Test plan
- [ ] `cd apps/desk && pnpm dev`, open the desk, confirm "Permafrost - Trading Desk" sits dead-centre in the nav at narrow and wide viewport widths.
- [ ] Confirm Pole + "CAMP DIRECTOR Pole the Polar Bear" still sit flush-left, and the reset button + connection dot sit flush-right on the same baseline.
- [ ] Click ↺ reset layout, accept the confirm, and verify HUD/sprite positions reset as before.