### PR TITLE
Docs + README styled to match the Trading Desk UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,184 +1,184 @@
 <div align="center">
 
+<img src="apps/desk/src/characters/pole.svg" width="128" height="128" alt="Pole the Polar Bear" style="image-rendering: pixelated;" />
+
 # Permafrost
 
-**An open-source DeFi market-making and hedge-fund protocol where AI agents deploy capital into a range of trading strategies. Capital and gains are locked into the permafrost.**
+**Your AI trading desk, locked in the ice.**
+
+A Go framework for self-custodied algorithmic trading with optional LLM augmentation. Hummingbot-style strategies. Real killswitch. Hand-authored arctic-themed operator UI.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Go Version](https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go)](https://go.dev/)
-[![Status](https://img.shields.io/badge/status-MVP-orange)]()
-[![Built with TimescaleDB](https://img.shields.io/badge/database-TimescaleDB-FDB515)](https://www.timescale.com/)
+[![Go](https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go)](https://go.dev/)
+[![Release](https://img.shields.io/github/v/release/teslashibe/permafrost?color=50D2C2)](https://github.com/teslashibe/permafrost/releases)
+[![Docs](https://img.shields.io/badge/docs-live-50D2C2)](https://teslashibe.github.io/permafrost/)
 [![Hyperliquid](https://img.shields.io/badge/perp-Hyperliquid-50D2C2)](https://hyperliquid.xyz/)
 [![Solana](https://img.shields.io/badge/spot-Solana-9945FF?logo=solana)](https://solana.com/)
 
-📚 **[Read the docs →](https://teslashibe.github.io/permafrost/)**
+📚 **[Read the docs](https://teslashibe.github.io/permafrost/)** &middot; 🐧 **[Run the demo](https://teslashibe.github.io/permafrost/getting-started/make-demo)** &middot; 🐳 **[The Cast](https://teslashibe.github.io/permafrost/brand/cast)**
 
 </div>
 
 ---
 
-## Overview
+## What this is
 
-Permafrost is a self-custodied, locally-runnable trading framework. It is an open agent runtime around the Strategy SAPI: write a deterministic Go strategy, register it, and the framework handles exchange adapters, swap routing, reconciliation, PnL accounting, risk gates, the killswitch, decision provenance, and LLM augmentation.
+Permafrost is a self-custodied, locally-runnable trading framework built around a stable Strategy SAPI. You write deterministic Go strategies, optionally augment them with an LLM, and the framework handles exchange adapters, swap routing, reconciliation, PnL accounting, risk gates, the killswitch, and decision provenance.
 
-Strategies are first-class extensions, not patches: each one lives as its own subdirectory under `strategies/`, calls `strategy.Register` in `init()`, and is enabled by adding one blank-import line to `cmd/permafrostd/strategies.go`. See the [strategy authors guide](https://teslashibe.github.io/permafrost/strategies/sapi) for the full extension flow.
+Strategies are first-class extensions, not patches. Each one lives as its own subdirectory under `strategies/`, calls `strategy.Register` in `init()`, and is enabled by adding one blank-import line to each binary's `strategies.go`. See the [strategy authors guide](https://teslashibe.github.io/permafrost/strategies/sapi).
 
-The framework ships with `noop` as the reference implementation. Real strategies — basis trades, market makers, anything you can express as Go — are yours to build, share, or keep private.
-
-> **Status:** MVP, single-operator, local-first. v2 will introduce hosted vaults with on-chain accounting.
+The OSS build ships three reference strategies (`noop`, `dca_buy`, `market_maker_basic`). Real strategies — basis trades, market makers, anything you can express as Go — are yours to build, share, or [keep private](https://teslashibe.github.io/permafrost/strategies/private-strategies).
 
 ---
 
-## Why Permafrost
+## The expedition
 
-- **Self-custodied spot leg.** The long side of every trade is held in your own wallet. No CEX can freeze, rehypothecate, or lose your tokens.
-- **AI agents, deterministic execution.** Strategies are deterministic Go code. The LLM augments — vetoing risky entries based on news, tuning thresholds — but never invents orders.
-- **Open framework, your strategies.** Drop a folder in `strategies/`, register, build. Keep your code public, private, or somewhere in between. The framework doesn't care.
-- **Built for transparency.** Every decision the agent makes — including the exact prompt and model response — is persisted in TimescaleDB and joinable to the resulting orders.
+Permafrost uses a polar-camp metaphor for every moving part of the framework. Every character is a hand-authored pixel-art SVG sprite that animates on the [Trading Desk UI](https://teslashibe.github.io/permafrost/operations/trading-desk-ui).
+
+<table>
+<tr>
+<td align="center" width="11%"><img src="apps/desk/src/characters/pole.svg"    width="56" height="56" /><br/><b>Pole</b><br/><sub>Camp Director</sub></td>
+<td align="center" width="11%"><img src="apps/desk/src/characters/penguin.svg" width="56" height="56" /><br/><b>Penguin</b><br/><sub>Strategy agent</sub></td>
+<td align="center" width="11%"><img src="apps/desk/src/characters/narwhal.svg" width="56" height="56" /><br/><b>Narwhal</b><br/><sub>LLM consult</sub></td>
+<td align="center" width="11%"><img src="apps/desk/src/characters/owl.svg"     width="56" height="56" /><br/><b>Aurora</b><br/><sub>Risk monitor</sub></td>
+<td align="center" width="11%"><img src="apps/desk/src/characters/husky.svg"   width="56" height="56" /><br/><b>Skipper</b><br/><sub>Reconciler</sub></td>
+<td align="center" width="11%"><img src="apps/desk/src/characters/walrus.svg"  width="56" height="56" /><br/><b>Kelp</b><br/><sub>Swap router</sub></td>
+<td align="center" width="11%"><img src="apps/desk/src/characters/whale.svg"   width="56" height="56" /><br/><b>Frostbite</b><br/><sub>Killswitch</sub></td>
+<td align="center" width="11%"><img src="apps/desk/src/characters/mammoth.svg" width="56" height="56" /><br/><b>Tusk</b><br/><sub>Private strategy</sub></td>
+</tr>
+</table>
+
+---
+
+## Quick start
+
+> Requires Docker and Go 1.25+.
+
+```bash
+git clone https://github.com/teslashibe/permafrost.git
+cd permafrost
+make demo
+```
+
+That's it. `make demo` builds the binaries, brings up Postgres + `permafrostd` in Docker, runs the [`init` wizard](https://teslashibe.github.io/permafrost/getting-started/init-and-doctor), recruits a paper-mode `noop` agent named **Pip**, and tails decisions in your terminal. Tear down with `make demo-clean`.
+
+For the manual walk-through (one command at a time), see [local install](https://teslashibe.github.io/permafrost/getting-started/local-install).
+
+### Trading Desk UI
+
+```bash
+cd apps/desk
+npm install
+npm run dev          # http://127.0.0.1:5173
+```
+
+The arctic-themed operator dashboard. Drag the HUDs, drag the characters, watch decisions land in real time. Falls back to demo data when the daemon isn't running. See [Trading Desk UI docs](https://teslashibe.github.io/permafrost/operations/trading-desk-ui).
+
+---
+
+## What you get out of the box
+
+| Area | Capabilities |
+|---|---|
+| **Framework** | Generic Strategy SAPI · Hummingbot-style `strategies/` tree · `pkg/strategy`, `pkg/types`, `pkg/inference` |
+| **Perp venues** | Hyperliquid (EIP-712 action signing, OpenOrders, idempotent place/cancel) |
+| **Spot venues** | Solana via Jupiter (Jito bundles) · EVM via 1inch v6 (Ethereum, Base, Avalanche, BSC) |
+| **Custody** | Self-custodied keystore; private key bytes never leave `internal/wallet` |
+| **Risk** | Pre-trade limits, circuit breakers (drawdown, daily loss, funding flip) |
+| **Killswitch** | Real: cancels open orders, flattens shorts, opt-in spot liquidation to USDC via SwapVenue |
+| **AI** | OpenAI-compatible LLM-veto (OpenAI, OpenRouter, Groq, vLLM, Ollama) · decision provenance to the prompt |
+| **Strategies** | `noop`, `dca_buy`, `market_maker_basic` · `permafrost strategy-new` scaffolds your own |
+| **Tooling** | `permafrost init`, `doctor`, `agent`, `vault`, `wallet`, `serve`, `backtest` |
+| **Distribution** | Multi-arch Docker on GHCR (amd64 + arm64) · `cli` compose service · `make demo` one-shot |
+| **UI** | React + Vite arctic-themed Trading Desk with hand-authored pixel-art sprites |
 
 ---
 
 ## Architecture
 
-```
-                ┌─────────────────────────────────────────────┐
-                │                  permafrostd                │
-                │  ┌──────────┐   ┌────────────┐  ┌────────┐  │
-   CLI ◄───────►│  │  Fiber   │   │  Scheduler │  │ Agent  │  │
-                │  │   API    │   │            │  │ Runtime│  │
-                │  └──────────┘   └────────────┘  └────┬───┘  │
-                │                                       │      │
-                │  ┌──────────────────────────────┐    │      │
-                │  │  Strategy (your code)        │◄───┘      │
-                │  └──────┬─────────┬─────────┬───┘           │
-                │         │         │         │                │
-                │         ▼         ▼         ▼                │
-                │   ┌────────┐ ┌────────┐ ┌────────┐          │
-                │   │  Risk  │ │Inference│ │Wallet  │          │
-                │   └────────┘ └────────┘ └────────┘          │
-                │         │         │         │                │
-                └─────────┼─────────┼─────────┼────────────────┘
-                          │         │         │
-                          ▼         ▼         ▼
-                  ┌───────────┐  ┌─────┐  ┌─────────────┐
-                  │TimescaleDB│  │ LLM │  │Local        │
-                  └───────────┘  └─────┘  │keystore     │
-                                          └─────────────┘
-                          │
-                          ▼
-              ┌────────────────────────┐
-              │  Venues                 │
-              │  • Hyperliquid (perp)   │
-              │  • Jupiter (Solana spot)│
-              └────────────────────────┘
+```mermaid
+flowchart LR
+    CLI[permafrost CLI] -->|REST| API
+    Desk[Trading Desk UI] -->|REST| API
+    subgraph permafrostd
+      API[Fiber API]
+      SCHED[Scheduler]
+      AGENT[Agent Runtime]
+      STRAT[Strategy &lpar;your code&rpar;]
+      RISK[Risk + Killswitch]
+      INF[Inference]
+      WAL[Wallet]
+      RECON[Reconcile + PnL]
+      API --> AGENT
+      SCHED --> AGENT
+      AGENT --> STRAT
+      AGENT --> RISK
+      AGENT --> INF
+      AGENT --> WAL
+      AGENT --> RECON
+    end
+    AGENT -->|writes| TS[(TimescaleDB)]
+    AGENT -->|orders| HL[Hyperliquid]
+    AGENT -->|swaps| JUP[Jupiter / 1inch]
+    INF -->|HTTPS| LLM[OpenAI-compatible LLM]
+    WAL --> KS[Encrypted local keystore]
 ```
 
-For the full architectural specification, the agent runtime, the strategy SAPI, and operations guidance, see the [docs site](https://teslashibe.github.io/permafrost/).
+Full architecture page: [docs/introduction/architecture](https://teslashibe.github.io/permafrost/introduction/architecture).
 
 ---
 
-## Tech Stack
+## Going live
 
-| Layer | Choice |
-|---|---|
-| Language | Go 1.25+ |
-| HTTP API | [Fiber](https://gofiber.io/) |
-| Database | [TimescaleDB](https://www.timescale.com/) (Postgres + hypertables) |
-| Migrations | [`goose`](https://github.com/pressly/goose) |
-| Query layer | [`sqlc`](https://sqlc.dev/) over [`pgx`](https://github.com/jackc/pgx) |
-| CLI | [`cobra`](https://github.com/spf13/cobra) |
-| Config | [`viper`](https://github.com/spf13/viper) (yaml + env) |
-| Logging | [`log/slog`](https://pkg.go.dev/log/slog) (stdlib) |
-| Perp venue | [Hyperliquid](https://hyperliquid.xyz/) |
-| Spot venues | [Solana](https://solana.com/) via [Jupiter](https://jup.ag/); EVM (Ethereum, Base, Avalanche, BSC) via [1inch](https://1inch.io/) v6 |
-| MEV protection | [Jito](https://www.jito.wtf/) bundles (Solana) |
-| Inference | OpenAI-compatible (works with OpenAI, OpenRouter, Groq, Together, vLLM, Ollama, etc.) |
-| Deploy | Docker + docker-compose |
-
----
-
-## Quick Start
-
-> Requires Docker and Go 1.25+.
-
-**TL;DR:** `git clone … && cd permafrost && make demo` — one command from clone to seeing decisions land. Tears down via `make demo-clean`.
-
-What `make demo` does, step by step, if you'd rather drive each one yourself:
+Paper mode is the default — real market data, no real orders. To trade real money:
 
 ```bash
-git clone https://github.com/teslashibe/permafrost.git
-cd permafrost
-
-# Build the CLI + daemon binaries.
-make build
-export PATH=$PWD/bin:$PATH
-
-# Bring up Postgres + permafrostd in Docker.
-make up
-
-# The keystore is unlocked from this env var. Any reasonably strong string is fine
-# for the noop quickstart (noop never signs anything). Save it somewhere safe.
-export PERMAFROST_KEYSTORE_PASSPHRASE=$(uuidgen 2>/dev/null || openssl rand -hex 16)
-
-# Create and start a paper-mode noop agent.
-permafrost agent create --strategy noop --perp hyperliquid --alloc 1000
-# → "created agent id=ag-... ..."
-permafrost agent start ag-...
-permafrost agent decisions ag-...
-```
-
-`agent start` marks the agent runnable so the daemon (started by `make up`) picks it up. For one-shot foreground iteration in a single shell without the daemon, use `permafrost agent run ag-...` instead — that runs the tick loop in the foreground and exits on SIGINT.
-
-The OSS build ships with `noop` registered; that's enough to confirm your install, database, and venue connections are working. To run a real strategy, see the [strategy authors guide](https://teslashibe.github.io/permafrost/strategies/sapi) — adding one is a folder + a registration call + one import line per binary.
-
-Default mode is `paper` — no real orders are placed until the agent is explicitly promoted to `live` (which requires `--confirm-live`).
-
-### Going live
-
-For real-money operation you'll also need:
-
-```bash
-# Import a Solana keypair (for the spot leg of any basis-style strategy).
-# Accepts a Phantom-style JSON array file, a base58 secret, or hex 32/64 bytes.
+# Import your spot signer (Solana keypair, Phantom-style JSON / base58 / hex)
 permafrost wallet import --chain solana --from ~/.config/solana/id.json
 
-# Import a Hyperliquid signer key (for placing real perp orders).
-# Save the hex private key (with or without 0x prefix) to a file first,
-# then point --from at it.
-echo "0xYOUR_HYPERLIQUID_PRIVATE_KEY" > /tmp/hl-key
+# Import your Hyperliquid perp signer (hex private key in a file)
+echo "0xYOUR_PRIVATE_KEY" > /tmp/hl-key
 permafrost wallet import --chain hyperliquid --from /tmp/hl-key
-shred -u /tmp/hl-key   # (or `rm` on macOS) — don't leave it on disk
+shred -u /tmp/hl-key
 
-# Initialize vault accounting (off-chain in v1).
 permafrost vault init
-
-# Flip the agent to live mode. This is just a state change on the agent
-# record; the --confirm-live gate fires when you actually start the agent.
-permafrost agent set-mode ag-... live
-
-# Start the agent in the foreground with the explicit live acknowledgement.
-# This is the recommended way to bring a live agent online for the first time
-# so you can watch the first few decisions.
-permafrost agent run ag-... --confirm-live
-
-# After you trust it, switch to daemon-supervised:
-permafrost agent start ag-...    # marks status=running
-permafrost serve                  # supervisor picks it up
+permafrost agent set-mode <id> live
+permafrost agent run     <id> --confirm-live   # explicit foreground gate
 ```
 
-> ⚠ **Live-mode gating note (v1):** `--confirm-live` is currently only enforced by `agent run` (foreground). The daemon supervisor does not re-prompt — once an agent is `mode=live, status=running`, `permafrost serve` will start it. Tracked by [#38](https://github.com/teslashibe/permafrost/issues/38) for hardening.
+**EVM RPCs:** pick fresh ones from [chainlist.org](https://chainlist.org/) and drop them into `config.yaml`. Public defaults rate-limit aggressively in production.
 
-**EVM RPCs**: pick fresh ones from [chainlist.org](https://chainlist.org/) and drop them into `config.yaml` under `evm.chains.<name>.rpc_url`. Public defaults work for testing but rate-limit aggressively in production.
+> ⚠ **Live-mode gating note:** `--confirm-live` is currently only enforced by `agent run`. The daemon supervisor doesn't re-prompt. Tracked by [#38](https://github.com/teslashibe/permafrost/issues/38).
+
+---
+
+## Safety
+
+A leveraged AI agent will absolutely try to nuke a vault if you let it. Permafrost ships with non-negotiable guardrails:
+
+- **Spot-first execution** — DEX swap must confirm before the perp short is sent
+- **Idempotent intents** — every order and swap carries a deterministic client ID
+- **Decision provenance** — every order links back to the exact prompt + model response
+- **Paper mode by default** — real orders require explicit `--confirm-live`
+- **Per-agent circuit breakers** — drawdown, daily loss, funding flip
+- **Real killswitch** — cancels open orders, flattens shorts via reduce-only market orders, opt-in spot liquidation to USDC via the configured `SwapVenue`. Documented at [killswitch tuning](https://teslashibe.github.io/permafrost/operations/killswitch-tuning).
+- **Mainnet gating** — Hyperliquid live mode behind explicit per-agent flags
+
+When something does go wrong, **Frostbite the Whale** surfaces — that's the killswitch character on the dashboard.
 
 ---
 
 ## CLI
 
 ```
+permafrost init                      # interactive setup wizard
+permafrost doctor                    # preflight check (Go / Docker / DB / RPCs / strategies)
+permafrost strategy-new <name>       # scaffold a new strategy
+
 permafrost wallet     show | generate | import | path
 permafrost vault      init | deposit | withdraw | lockup | status | record-nav | nav
 permafrost agent      create | list | status | decisions | set-mode | set-network | start | stop | tick | run
-permafrost strategy   list | backtest
+permafrost strategy   list | backtest <name>
 permafrost inference  test | list
 permafrost swap       quote
 permafrost risk       show
@@ -186,56 +186,72 @@ permafrost pnl        summary | positions | history
 permafrost reconcile
 permafrost db         migrate
 permafrost serve
+permafrost version
 ```
 
-See the [CLI reference](https://teslashibe.github.io/permafrost/reference/cli) for flags and semantics.
+Full reference: [`/reference/cli`](https://teslashibe.github.io/permafrost/reference/cli).
+
+---
+
+## Tech stack
+
+| Layer | Choice |
+|---|---|
+| Language | Go 1.25+ |
+| HTTP API | [Fiber](https://gofiber.io/) |
+| Database | [TimescaleDB](https://www.timescale.com/) |
+| Migrations | [`goose`](https://github.com/pressly/goose) |
+| Query layer | [`sqlc`](https://sqlc.dev/) over [`pgx`](https://github.com/jackc/pgx) |
+| CLI | [`cobra`](https://github.com/spf13/cobra) |
+| Config | [`viper`](https://github.com/spf13/viper) |
+| Logging | [`log/slog`](https://pkg.go.dev/log/slog) |
+| Perp | [Hyperliquid](https://hyperliquid.xyz/) |
+| Spot | [Jupiter](https://jup.ag/) (Solana) · [1inch v6](https://1inch.io/) (EVM) |
+| MEV | [Jito](https://www.jito.wtf/) bundles |
+| Inference | OpenAI-compatible (OpenAI, OpenRouter, Groq, vLLM, Ollama, …) |
+| UI | React 18 + Vite 5, no framework, hand-authored SVG sprites |
+| Deploy | Docker + docker-compose · Multi-arch GHCR image |
 
 ---
 
 ## Roadmap
 
-What's shipped in `main` today:
+v0.1.0 (this release) closes the [Trading Desk epic](https://github.com/teslashibe/permafrost/issues/30):
 
-| Milestone | Description | Status |
+| | Milestone | Status |
 |---|---|---|
-| M0 | Skeleton (config, logging, compose, migrations, health endpoint) | ✅ |
+| M0 | Skeleton (config, logging, compose, migrations) | ✅ |
 | M1 | Core interfaces (`Strategy`, `Venue`, `SwapVenue`, `Provider`, `Signer`, `Risk`) | ✅ |
 | M2 | Hyperliquid adapter | ✅ |
-| M3 | Inference (OpenAI-compatible client + mock) | ✅ |
+| M3 | OpenAI-compatible inference | ✅ |
 | M4 | Wallet & keystore | ✅ |
 | M5 | Solana SwapVenue (Jupiter + Jito) | ✅ |
 | M6 | Asset registry | ✅ |
 | M7 | Vault & accounting | ✅ |
 | M8 | Agent runtime | ✅ |
-| M9 | Risk + circuit breakers + kill switch | ✅ (kill switch order-cancel + spot-liquidation are partial — see [#38](https://github.com/teslashibe/permafrost/issues/38)) |
+| M9 | Risk + circuit breakers + real killswitch | ✅ |
 | M10 | Backtest harness | ✅ |
+| M11 | EVM SwapVenue (1inch v6, multi-chain) | ✅ |
+| M12 | Operator tooling (`init`, `doctor`, `make demo`, `strategy-new`) | ✅ |
+| M13 | Multi-arch Docker image (GHCR) | ✅ |
+| M14 | Reference strategies (`dca_buy`, `market_maker_basic`) | ✅ |
+| M15 | Trading Desk UI + sprite cast | ✅ |
+| M16 | Brand narrative + cast docs | ✅ |
 
-What's next: the [Trading Desk epic (#30)](https://github.com/teslashibe/permafrost/issues/30) — onboarding polish, web dashboard, hosted demo, brand narrative.
-
----
-
-## Safety
-
-A leveraged AI agent will absolutely try to nuke a vault if you let it. Permafrost ships with these guardrails:
-
-- **Spot-first execution** — DEX swap must confirm before the perp short is sent.
-- **Idempotent intents** — every order and swap carries a deterministic client ID.
-- **Decision provenance** — every order links back to the exact prompt + model response.
-- **Paper mode by default** — no real orders until explicitly promoted to `live` with `--confirm-live`.
-- **Per-agent circuit breakers** — NAV drawdown and daily loss are wired and configurable via the agent's `risk` config block; additional breakers (funding flip, RPC errors) tracked on the [Trading Desk epic](https://github.com/teslashibe/permafrost/issues/30).
-- **Kill switch** — `permafrost agent stop --all` halts every agent and (when the daemon is running) flattens open perp positions via reduce-only market orders. **Open-order cancellation and spot-leg liquidation are partial in v1** — tracked by [#38](https://github.com/teslashibe/permafrost/issues/38). Until that lands, cancel resting orders manually via the exchange UI if needed.
-- **Mainnet gating** — Hyperliquid live mode behind explicit `--confirm-live` per agent.
-
-For full killswitch behaviour, configurable knobs, and current limits, see the [killswitch tuning page](https://teslashibe.github.io/permafrost/operations/killswitch-tuning).
+Up next: hosted vault accounting on-chain, additional venues, more reference strategies.
 
 ---
 
 ## Contributing
 
-This is an open-source project and contributions are welcome. Please read the [strategy authors guide](https://teslashibe.github.io/permafrost/strategies/sapi) (for new strategies) and the [architecture docs](https://teslashibe.github.io/permafrost/introduction/architecture) before opening a PR.
+Contributions welcome. Read the [strategy authors guide](https://teslashibe.github.io/permafrost/strategies/sapi) (for new strategies) and [architecture](https://teslashibe.github.io/permafrost/introduction/architecture) before opening a PR.
 
 ---
 
 ## License
 
 [MIT](LICENSE)
+
+<div align="center">
+<sub>The expedition is on the ice. 🐻🐧🦄🦉🐕🦣🐳🪙</sub>
+</div>

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -61,8 +61,9 @@ const config: Config = {
     navbar: {
       title: 'Permafrost',
       logo: {
-        alt: 'Permafrost',
-        src: 'img/logo.svg',
+        alt: 'Pole the Polar Bear',
+        src: 'img/brand/pole.svg',
+        srcDark: 'img/brand/pole.svg',
       },
       items: [
         {
@@ -70,6 +71,11 @@ const config: Config = {
           sidebarId: 'docsSidebar',
           position: 'left',
           label: 'Docs',
+        },
+        {
+          to: '/brand/cast',
+          position: 'left',
+          label: 'The Cast',
         },
         {
           href: 'https://pkg.go.dev/github.com/teslashibe/permafrost',

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -1,27 +1,64 @@
-/**
- * Permafrost docs theme.
- * Cool blues + cyan accents matching the project's badge palette.
+/* Permafrost docs theme.
+ *
+ * Mirrors the Trading Desk UI palette so the docs site reads as
+ * the same product:
+ *   --aurora-c (cyan)   -- primary accent / CTAs
+ *   --aurora-p (purple) -- LLM/inference accent
+ *   --aurora-g (green)  -- healthy / shipped accent
+ *   --ice-deep / mid    -- night sky base for dark surfaces
+ *
+ * Light mode keeps Docusaurus's defaults but maps the primary to
+ * a slightly desaturated cyan so the brand carries through.
  */
 
 :root {
-  --ifm-color-primary: #00525c;
-  --ifm-color-primary-dark: #004a52;
-  --ifm-color-primary-darker: #00464d;
-  --ifm-color-primary-darkest: #003940;
-  --ifm-color-primary-light: #006674;
-  --ifm-color-primary-lighter: #006d7c;
-  --ifm-color-primary-lightest: #008092;
+  --ifm-color-primary:        #1F8E80;
+  --ifm-color-primary-dark:   #1B7F73;
+  --ifm-color-primary-darker: #18746A;
+  --ifm-color-primary-darkest: #135E55;
+  --ifm-color-primary-light:  #239D8E;
+  --ifm-color-primary-lighter: #25A695;
+  --ifm-color-primary-lightest: #2BC2AE;
   --ifm-code-font-size: 92%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.08);
 }
 
 [data-theme='dark'] {
-  --ifm-color-primary: #50d2c2;
-  --ifm-color-primary-dark: #34cab9;
-  --ifm-color-primary-darker: #28c6b3;
-  --ifm-color-primary-darkest: #20a394;
-  --ifm-color-primary-light: #6cd9cb;
-  --ifm-color-primary-lighter: #79ddd1;
-  --ifm-color-primary-lightest: #a3e8e0;
+  --ifm-color-primary:        #50D2C2;
+  --ifm-color-primary-dark:   #34CAB9;
+  --ifm-color-primary-darker: #28C6B3;
+  --ifm-color-primary-darkest: #20A394;
+  --ifm-color-primary-light:  #6CD9CB;
+  --ifm-color-primary-lighter: #79DDD1;
+  --ifm-color-primary-lightest: #A3E8E0;
+
+  /* Match the Trading Desk world's deep arctic background */
+  --ifm-background-color: #0A1B36;
+  --ifm-background-surface-color: #122A52;
+  --ifm-navbar-background-color: rgba(10, 27, 54, 0.92);
+  --ifm-footer-background-color: #050E22;
   --docusaurus-highlighted-code-line-bg: rgba(255, 255, 255, 0.08);
+}
+
+/* Pixelated rendering for the navbar logo (Pole) so the sprite
+ * stays crisp at small sizes instead of being browser-smoothed. */
+.navbar__logo img {
+  image-rendering: pixelated;
+}
+.navbar__logo {
+  width: 32px;
+  height: 32px;
+}
+
+/* Backdrop blur on the sticky navbar so the aurora bands behind
+ * the hero show through pleasantly. */
+[data-theme='dark'] .navbar {
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid #1F4380;
+}
+
+/* Pixelated sprites everywhere else they appear in markdown
+ * content (cast page, brand page, etc). */
+img[src*="/img/brand/"] {
+  image-rendering: pixelated;
 }

--- a/apps/docs/src/pages/index.module.css
+++ b/apps/docs/src/pages/index.module.css
@@ -1,46 +1,399 @@
-.heroBanner {
-  padding: 5rem 0;
-  text-align: center;
+/* Docs landing page styled to match the Trading Desk UI:
+ * deep arctic sky, drifting aurora bands, ice horizon, sprite hero,
+ * cast showcase. Mirrors apps/desk/src/styles/global.css palette
+ * + animation language so the docs site reads as the same product. */
+
+:root {
+  --ice-deep:   #0A1B36;
+  --ice-mid:    #122A52;
+  --ice-edge:   #1F4380;
+  --ice-bright: #ECF6FF;
+  --ice-pale:   #C8DCF7;
+  --aurora-c:   #50D2C2;
+  --aurora-p:   #B5A6E0;
+  --aurora-g:   #66E5A8;
+}
+
+/* ============================================================
+ * HERO -- night-sky background with aurora + stars + horizon,
+ * Pole sprite as the avatar, "Camp Director" tagline.
+ * ============================================================ */
+
+.hero {
   position: relative;
   overflow: hidden;
-  background: linear-gradient(135deg, #0a1929 0%, #00525c 100%);
-  color: #fff;
+  padding: 6rem 1rem 8rem 1rem;
+  color: var(--ice-bright);
+  /* Layered background mirrors the Trading Desk world */
+  background:
+    radial-gradient(1px 1px at 20% 12%,  rgba(255,255,255,0.7) 50%, transparent),
+    radial-gradient(1px 1px at 65% 8%,   rgba(255,255,255,0.6) 50%, transparent),
+    radial-gradient(1px 1px at 80% 20%,  rgba(255,255,255,0.7) 50%, transparent),
+    radial-gradient(1px 1px at 35% 18%,  rgba(255,255,255,0.5) 50%, transparent),
+    radial-gradient(2px 2px at 45% 14%,  rgba(255,255,255,0.85) 50%, transparent),
+    radial-gradient(2px 2px at 75% 30%,  rgba(255,255,255,0.7)  50%, transparent),
+    radial-gradient(ellipse 1400px 280px at 50% -120px,
+      rgba(80,210,194,0.32) 0%, transparent 65%),
+    radial-gradient(ellipse 1000px 220px at 30% -100px,
+      rgba(181,166,224,0.28) 0%, transparent 70%),
+    radial-gradient(ellipse 800px 200px at 70% -80px,
+      rgba(102,229,168,0.20) 0%, transparent 70%),
+    linear-gradient(180deg, #050E22 0%, var(--ice-deep) 50%, #0F2A4D 100%);
 }
 
-.heroBanner :global(.hero__subtitle) {
-  font-size: 1.25rem;
+/* Aurora drift -- second layer animating horizontally */
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: 0 -200px;
+  background:
+    radial-gradient(ellipse 700px 120px at 20% 18%, rgba(102,229,168,0.18) 0%, transparent 60%),
+    radial-gradient(ellipse 700px 120px at 60% 12%, rgba(181,166,224,0.16) 0%, transparent 60%),
+    radial-gradient(ellipse 700px 140px at 90% 22%, rgba(80,210,194,0.18)  0%, transparent 60%);
+  animation: aurora-drift 60s linear infinite;
+  pointer-events: none;
+}
+@keyframes aurora-drift {
+  0%   { transform: translateX(0); }
+  100% { transform: translateX(-200px); }
+}
+
+/* Ice horizon at the bottom of the hero */
+.hero::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 35%;
+  background:
+    linear-gradient(180deg, rgba(255,255,255,0.05) 0%, transparent 6%),
+    radial-gradient(ellipse 100% 100% at 50% 0%,
+      var(--ice-pale) 0%, var(--ice-bright) 30%, #9EBADD 80%, #6A8AB8 100%);
+  border-top: 1px solid rgba(255,255,255,0.15);
+  pointer-events: none;
+}
+
+.heroContent {
+  position: relative;
+  z-index: 2;
+  max-width: 1100px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.heroBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  background: rgba(10, 27, 54, 0.7);
+  border: 1px solid var(--ice-edge);
+  border-radius: 999px;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ice-bright);
+  backdrop-filter: blur(4px);
+  margin-bottom: 1.5rem;
+}
+.heroBadge .dot {
+  display: inline-block;
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--aurora-c);
+  box-shadow: 0 0 8px var(--aurora-c);
+  animation: pulse 2s ease-in-out infinite;
+}
+@keyframes pulse {
+  0%, 100% { box-shadow: 0 0 4px var(--aurora-c); }
+  50%      { box-shadow: 0 0 14px var(--aurora-c); }
+}
+
+.heroTitle {
+  font-size: clamp(2.4rem, 6vw, 4.5rem);
+  line-height: 1.05;
+  font-weight: 700;
+  margin: 0 0 1rem 0;
+  letter-spacing: -0.02em;
+  color: var(--ice-bright);
+}
+.heroTitle .gradient {
+  background: linear-gradient(120deg, var(--aurora-c) 0%, var(--aurora-p) 60%, var(--aurora-g) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+
+.heroSubtitle {
+  font-size: clamp(1rem, 2vw, 1.25rem);
   max-width: 720px;
-  margin: 0 auto 1.5rem;
-  opacity: 0.9;
+  margin: 0 auto 2rem auto;
+  opacity: 0.85;
+  line-height: 1.55;
 }
 
-@media screen and (max-width: 996px) {
-  .heroBanner {
-    padding: 3rem 1rem;
-  }
-}
-
-.buttons {
+.heroButtons {
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 3rem;
+}
+.btnPrimary {
+  background: var(--aurora-c) !important;
+  border-color: var(--aurora-c) !important;
+  color: var(--ice-deep) !important;
+  font-weight: 600;
+}
+.btnPrimary:hover {
+  background: var(--aurora-g) !important;
+  border-color: var(--aurora-g) !important;
+}
+.btnSecondary {
+  background: rgba(10, 27, 54, 0.5) !important;
+  border: 1px solid var(--ice-edge) !important;
+  color: var(--ice-bright) !important;
+}
+.btnSecondary:hover {
+  background: rgba(31, 67, 128, 0.6) !important;
 }
 
-.props {
-  padding: 4rem 0;
+/* Pole + label, centered on the ice */
+.heroPole {
+  position: relative;
+  z-index: 3;
+  margin-top: 1.5rem;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+.heroPole img {
+  width: 128px;
+  height: 128px;
+  image-rendering: pixelated;
+  filter: drop-shadow(0 6px 10px rgba(0, 0, 0, 0.4));
+  animation: idle-bob 3s ease-in-out infinite;
+}
+@keyframes idle-bob {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-4px); }
+}
+.heroPoleLabel {
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  opacity: 0.7;
+  color: var(--ice-deep);
+  background: rgba(255, 255, 255, 0.85);
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-weight: 600;
 }
 
-.prop {
-  padding: 1.5rem 0;
-}
+/* ============================================================
+ * "Quick start" code block -- terminal-style card
+ * ============================================================ */
 
-.prop h3 {
+.quickStart {
+  padding: 4rem 1rem;
+  background: var(--ice-deep);
+  color: var(--ice-bright);
+}
+.quickStartInner {
+  max-width: 880px;
+  margin: 0 auto;
+}
+.quickStartLabel {
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.6;
   margin-bottom: 0.5rem;
 }
+.quickStartHeading {
+  font-size: clamp(1.5rem, 3vw, 2.25rem);
+  margin: 0 0 1.5rem 0;
+}
+.terminal {
+  background: #050E22;
+  border: 1px solid var(--ice-edge);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4);
+}
+.terminalChrome {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  background: var(--ice-mid);
+  border-bottom: 1px solid var(--ice-edge);
+}
+.terminalChrome .cdot {
+  width: 10px; height: 10px; border-radius: 50%;
+}
+.terminalChrome .cdot:nth-child(1) { background: #FF5F56; }
+.terminalChrome .cdot:nth-child(2) { background: #FFBD2E; }
+.terminalChrome .cdot:nth-child(3) { background: #27C93F; }
+.terminalChrome .cTitle {
+  margin-left: auto;
+  font-size: 11px;
+  opacity: 0.6;
+}
+.terminalBody {
+  padding: 16px 20px;
+  font-family: 'IBM Plex Mono', 'JetBrains Mono', 'Menlo', monospace;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--ice-bright);
+  white-space: pre;
+  overflow-x: auto;
+}
+.terminalBody .prompt { color: var(--aurora-c); }
+.terminalBody .comment { color: rgba(236, 246, 255, 0.45); }
+.terminalBody .heart { color: var(--aurora-p); }
 
+/* ============================================================
+ * Feature cards (the "props" section)
+ * ============================================================ */
+
+.props {
+  padding: 5rem 1rem;
+  background: linear-gradient(180deg, var(--ice-deep) 0%, #112341 100%);
+}
+.propsInner {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+.propsHeading {
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  text-align: center;
+  margin: 0 0 0.5rem 0;
+  color: var(--ice-bright);
+}
+.propsSubheading {
+  text-align: center;
+  opacity: 0.7;
+  margin: 0 0 3rem 0;
+  color: var(--ice-bright);
+}
+.propsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+.prop {
+  background: rgba(10, 27, 54, 0.6);
+  border: 1px solid var(--ice-edge);
+  border-radius: 10px;
+  padding: 1.25rem;
+  transition: transform 200ms ease-out, border-color 200ms ease-out;
+}
+.prop:hover {
+  transform: translateY(-2px);
+  border-color: var(--aurora-c);
+}
+.prop .propIcon {
+  width: 48px;
+  height: 48px;
+  image-rendering: pixelated;
+  margin-bottom: 0.75rem;
+  filter: drop-shadow(0 3px 5px rgba(0, 0, 0, 0.35));
+}
+.prop h3 {
+  font-size: 15px;
+  margin: 0 0 0.5rem 0;
+  color: var(--ice-bright);
+}
+.prop p {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.55;
+  color: rgba(236, 246, 255, 0.78);
+}
 .prop code {
-  background: var(--ifm-color-emphasis-200);
+  background: rgba(80, 210, 194, 0.12);
+  color: var(--aurora-c);
   padding: 0.1rem 0.35rem;
   border-radius: 4px;
   font-size: 0.92em;
+  border: 1px solid rgba(80, 210, 194, 0.25);
+}
+
+/* ============================================================
+ * The Expedition -- cast showcase
+ * ============================================================ */
+
+.cast {
+  padding: 5rem 1rem;
+  background: var(--ice-deep);
+  color: var(--ice-bright);
+}
+.castInner {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+.castGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+.castCard {
+  background: rgba(18, 42, 82, 0.4);
+  border: 1px solid var(--ice-edge);
+  border-radius: 10px;
+  padding: 1rem;
+  text-align: center;
+  transition: transform 200ms ease-out, border-color 200ms ease-out, background 200ms ease-out;
+}
+.castCard:hover {
+  transform: translateY(-3px);
+  border-color: var(--aurora-c);
+  background: rgba(18, 42, 82, 0.7);
+}
+.castCard img {
+  width: 72px;
+  height: 72px;
+  image-rendering: pixelated;
+  filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.4));
+  animation: idle-bob 3s ease-in-out infinite;
+}
+.castCard:nth-child(2n) img { animation-delay: -1s; }
+.castCard:nth-child(3n) img { animation-delay: -2s; }
+.castName {
+  margin-top: 0.5rem;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ice-bright);
+}
+.castRole {
+  font-size: 10px;
+  opacity: 0.6;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-top: 2px;
+}
+
+/* ============================================================
+ * "Going further" CTA strip
+ * ============================================================ */
+
+.cta {
+  padding: 4rem 1rem;
+  background: linear-gradient(180deg, var(--ice-deep) 0%, #0A1B36 100%);
+  text-align: center;
+  color: var(--ice-bright);
+}
+.cta h2 {
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  margin: 0 0 1rem 0;
+}
+.cta p {
+  max-width: 640px;
+  margin: 0 auto 1.5rem auto;
+  opacity: 0.8;
 }

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -1,50 +1,52 @@
 import type {ReactNode} from 'react';
-import clsx from 'clsx';
 import Link from '@docusaurus/Link';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import Layout from '@theme/Layout';
-import Heading from '@theme/Heading';
 
 import styles from './index.module.css';
 
-function HomepageHeader() {
-  const {siteConfig} = useDocusaurusContext();
-  return (
-    <header className={clsx('hero', styles.heroBanner)}>
-      <div className="container">
-        <Heading as="h1" className="hero__title">
-          {siteConfig.title}
-        </Heading>
-        <p className="hero__subtitle">{siteConfig.tagline}</p>
-        <div className={styles.buttons}>
-          <Link
-            className="button button--primary button--lg"
-            to="/introduction/what-is-permafrost">
-            Read the docs
-          </Link>
-          <Link
-            className="button button--secondary button--lg"
-            style={{marginLeft: '0.75rem'}}
-            href="https://github.com/teslashibe/permafrost">
-            View on GitHub
-          </Link>
-        </div>
-      </div>
-    </header>
-  );
+// Docs landing page styled to match the Trading Desk UI:
+// arctic night sky with aurora + stars + ice horizon, Pole the
+// Polar Bear avatar in the hero, terminal-style quickstart card,
+// feature-prop cards anchored to sprites, and the cast showcase.
+
+interface CastEntry {
+  sprite: string;       // filename under /img/brand/
+  name: string;
+  role: string;
+  href: string;         // docs page describing this character/concept
 }
 
-const PROPS = [
+const CAST: CastEntry[] = [
+  { sprite: 'pole.svg',    name: 'Pole the Polar Bear', role: 'Camp Director', href: '/brand/cast' },
+  { sprite: 'penguin.svg', name: 'Penguin trader',      role: 'Strategy agent', href: '/concepts/agent-runtime' },
+  { sprite: 'narwhal.svg', name: 'Narwhal advisor',     role: 'LLM consult',     href: '/concepts/inference' },
+  { sprite: 'owl.svg',     name: 'Aurora the owl',      role: 'Risk monitor',    href: '/concepts/risk-and-killswitch' },
+  { sprite: 'husky.svg',   name: 'Skipper',             role: 'Reconciler',      href: '/concepts/reconcile-and-pnl' },
+  { sprite: 'walrus.svg',  name: 'Kelp the walrus',     role: 'Swap router',     href: '/concepts/primitives' },
+  { sprite: 'whale.svg',   name: 'Frostbite',           role: 'Killswitch',      href: '/operations/killswitch-tuning' },
+  { sprite: 'mammoth.svg', name: 'Tusk',                role: 'Private strategy', href: '/strategies/private-strategies' },
+];
+
+interface PropEntry {
+  sprite: string;
+  title: string;
+  body: ReactNode;
+}
+
+const PROPS: PropEntry[] = [
   {
+    sprite: 'penguin.svg',
     title: 'Open framework, your strategies',
     body: (
       <>
         Drop a folder under <code>strategies/</code>, register in <code>init()</code>,
-        add one blank-import line to enable it. Same shape as Hummingbot, in Go.
+        add one blank import to enable it. Same shape as Hummingbot, in Go.
       </>
     ),
   },
   {
+    sprite: 'pole.svg',
     title: 'Self-custodied by design',
     body: (
       <>
@@ -54,39 +56,201 @@ const PROPS = [
     ),
   },
   {
+    sprite: 'narwhal.svg',
     title: 'AI augments, never invents',
     body: (
       <>
         Strategies are deterministic Go. The LLM can veto entries, score candidates,
-        and tune thresholds — but never produces orders directly.
+        and tune thresholds &mdash; but never produces orders directly.
       </>
     ),
   },
   {
+    sprite: 'owl.svg',
     title: 'Auditable to the prompt',
     body: (
       <>
-        Every decision is persisted with the exact prompt, model response, and resulting
-        on-chain action. Joinable in TimescaleDB.
+        Every decision is persisted with the exact prompt, model response, and
+        resulting on-chain action. Joinable in TimescaleDB.
+      </>
+    ),
+  },
+  {
+    sprite: 'whale.svg',
+    title: 'Real killswitch',
+    body: (
+      <>
+        <code>agent stop --all</code> cancels every open order, flattens shorts via
+        reduce-only market orders, and (opt-in) liquidates spot legs back to USDC.
+      </>
+    ),
+  },
+  {
+    sprite: 'husky.svg',
+    title: 'Reconciliation built in',
+    body: (
+      <>
+        Framework state matches venue truth after every tick. Drift is detected and
+        surfaces in the decision log; the killswitch can engage on persistent drift.
       </>
     ),
   },
 ];
 
-function Props(): ReactNode {
+function HeroBanner() {
+  const poleUrl = useBaseUrl('/img/brand/pole.svg');
+  return (
+    <header className={styles.hero}>
+      <div className={styles.heroContent}>
+        <div className={styles.heroBadge}>
+          <span className={styles.dot} />
+          v0.1.0 &middot; the camp is open
+        </div>
+        <h1 className={styles.heroTitle}>
+          Permafrost &mdash; <span className={styles.gradient}>your AI trading desk</span>,<br />
+          locked in the ice.
+        </h1>
+        <p className={styles.heroSubtitle}>
+          A Go framework for self-custodied algorithmic trading. Write deterministic
+          strategies, optionally augment them with an LLM, and run them locally on
+          a real arctic-themed operator dashboard.
+        </p>
+        <div className={styles.heroButtons}>
+          <Link
+            className={`button button--lg ${styles.btnPrimary}`}
+            to="/getting-started/make-demo">
+            Run the demo &rarr;
+          </Link>
+          <Link
+            className={`button button--lg ${styles.btnSecondary}`}
+            to="/introduction/what-is-permafrost">
+            Read the docs
+          </Link>
+          <Link
+            className={`button button--lg ${styles.btnSecondary}`}
+            href="https://github.com/teslashibe/permafrost">
+            {'GitHub \u2197'}
+          </Link>
+        </div>
+        <div className={styles.heroPole}>
+          <img src={poleUrl} alt="Pole the Polar Bear, Camp Director" />
+          <div className={styles.heroPoleLabel}>Camp Director</div>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function QuickStart() {
+  return (
+    <section className={styles.quickStart}>
+      <div className={styles.quickStartInner}>
+        <div className={styles.quickStartLabel}>quick start</div>
+        <h2 className={styles.quickStartHeading}>One command, from clone to decisions</h2>
+        <div className={styles.terminal}>
+          <div className={styles.terminalChrome}>
+            <span className={styles.cdot} />
+            <span className={styles.cdot} />
+            <span className={styles.cdot} />
+            <span className={styles.cTitle}>~/permafrost</span>
+          </div>
+          <div className={styles.terminalBody}>
+            <span className={styles.comment}># Clone, build, run. Idempotent: re-run any time.</span>{'\n'}
+            <span className={styles.prompt}>$</span> git clone https://github.com/teslashibe/permafrost.git{'\n'}
+            <span className={styles.prompt}>$</span> cd permafrost{'\n'}
+            <span className={styles.prompt}>$</span> make demo{'\n'}
+            {'\n'}
+            <span className={styles.comment}># Brings up Postgres + permafrostd in Docker, runs the init wizard,</span>{'\n'}
+            <span className={styles.comment}># spins up a paper-mode noop agent, and tails its decisions.</span>{'\n'}
+            {'\n'}
+            <span className={styles.heart}>&#10084;</span> &nbsp;Pip is on the ice.{'\n'}
+            <span className={styles.comment}>[tick 1] confidence=0.00 swaps=0 orders=0 notes="noop"</span>{'\n'}
+            <span className={styles.comment}>[tick 2] confidence=0.00 swaps=0 orders=0 notes="noop"</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Props() {
   return (
     <section className={styles.props}>
-      <div className="container">
-        <div className="row">
+      <div className={styles.propsInner}>
+        <h2 className={styles.propsHeading}>What you get out of the box</h2>
+        <p className={styles.propsSubheading}>
+          Six things the framework gives you on day one. Bring your own strategy.
+        </p>
+        <div className={styles.propsGrid}>
           {PROPS.map((p) => (
-            <div key={p.title} className="col col--6">
-              <div className={styles.prop}>
-                <Heading as="h3">{p.title}</Heading>
-                <p>{p.body}</p>
-              </div>
-            </div>
+            <PropCard key={p.title} prop={p} />
           ))}
         </div>
+      </div>
+    </section>
+  );
+}
+
+function PropCard({prop}: {prop: PropEntry}) {
+  const url = useBaseUrl('/img/brand/' + prop.sprite);
+  return (
+    <div className={styles.prop}>
+      <img src={url} alt="" className={styles.propIcon} aria-hidden />
+      <h3>{prop.title}</h3>
+      <p>{prop.body}</p>
+    </div>
+  );
+}
+
+function Cast() {
+  return (
+    <section className={styles.cast}>
+      <div className={styles.castInner}>
+        <h2 className={styles.propsHeading}>The Expedition</h2>
+        <p className={styles.propsSubheading}>
+          Permafrost uses a polar-camp metaphor for every moving part of the
+          framework. Click any character to see what they do.
+        </p>
+        <div className={styles.castGrid}>
+          {CAST.map((c) => (
+            <CastCard key={c.name} entry={c} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CastCard({entry}: {entry: CastEntry}) {
+  const url = useBaseUrl('/img/brand/' + entry.sprite);
+  return (
+    <Link to={entry.href} className={styles.castCard}>
+      <img src={url} alt={entry.name} />
+      <div className={styles.castName}>{entry.name}</div>
+      <div className={styles.castRole}>{entry.role}</div>
+    </Link>
+  );
+}
+
+function CTA() {
+  return (
+    <section className={styles.cta}>
+      <h2>Ready to ship a strategy?</h2>
+      <p>
+        Five minutes from clone to a working scaffold. Write the logic; the framework
+        handles the rest.
+      </p>
+      <div className={styles.heroButtons}>
+        <Link
+          className={`button button--lg ${styles.btnPrimary}`}
+          to="/strategies/sapi">
+          Write a strategy &rarr;
+        </Link>
+        <Link
+          className={`button button--lg ${styles.btnSecondary}`}
+          to="/strategies/scaffolding">
+          permafrost strategy-new
+        </Link>
       </div>
     </section>
   );
@@ -95,12 +259,13 @@ function Props(): ReactNode {
 export default function Home(): ReactNode {
   return (
     <Layout
-      title="Permafrost"
-      description="Open-source DeFi trading framework where AI agents deploy capital into your strategies.">
-      <HomepageHeader />
-      <main>
-        <Props />
-      </main>
+      title="Permafrost &mdash; your AI trading desk, locked in the ice"
+      description="Open-source Go framework for self-custodied algorithmic trading with optional LLM augmentation. Hummingbot-style strategies, real killswitch, arctic-themed operator UI.">
+      <HeroBanner />
+      <QuickStart />
+      <Props />
+      <Cast />
+      <CTA />
     </Layout>
   );
 }


### PR DESCRIPTION
Restyles the Docusaurus landing page and the repo README so they read as the same product as the Trading Desk dashboard. Same arctic palette, same sprite cast, same camp-director narrative.

## Done in a worktree

This work was done on a sibling worktree (`../permafrost-docs-styling`) so it stayed isolated from the main checkout while iterating.

## Docs landing page (`apps/docs/src/pages/index.tsx`)

- **New hero section** with the Trading Desk's exact background — layered radial-gradient starfield + aurora bands + aurora-drift keyframe + ice-horizon pseudo-element. Pulsing v0.1.0 badge, gradient title (cyan → purple → green), CTA buttons in the same colour ramp.
- **Pole the Polar Bear sprite** stands on the ice horizon at the bottom of the hero with an idle-bob animation and a "CAMP DIRECTOR" nameplate. Mirrors the chrome-bar avatar in the actual dashboard.
- **Quick-start section**: macOS-style terminal card with the demo transcript (clone, cd, make demo, "Pip is on the ice").
- **Six-prop feature grid**, each with a sprite icon. Anchors features to characters: penguin → strategy framework, pole → self-custody, narwhal → AI augments, owl → auditable, whale → killswitch, husky → reconciliation.
- **The Expedition cast showcase** — 8 sprite cards, each linking to the relevant docs concept page. Hover lift + cyan border.
- **CTA strip** at the bottom pointing at the SAPI guide and `permafrost strategy-new`.

## Custom CSS (`custom.css`)

- Maps Docusaurus's primary colour to **aurora-cyan (#50D2C2)** in dark mode so links/CTAs/sidebar accents match the desk.
- Dark mode background switched to **ice-deep** so navigating from the styled landing into the docs feels continuous.
- `image-rendering: pixelated` for navbar logo + any `/img/brand/*` sprite in markdown content.
- Backdrop blur on the dark navbar.

## `docusaurus.config.ts`

- Navbar logo: placeholder → **Pole the Polar Bear** sprite.
- New **"The Cast"** navbar item linking to `/brand/cast`.

## README

- Centered Pole sprite hero + new tagline: **"Your AI trading desk, locked in the ice."**
- Badges row updated: v0.1.0 release badge, live docs badge.
- **8-character cast table** near the top, sprites inline.
- Restructured sections: What this is / The expedition / Quick start / Trading Desk UI / What you get out of the box / Architecture (mermaid) / Going live / Safety / CLI / Tech stack / Roadmap / Contributing.
- Roadmap updated to reflect v0.1.0 milestones (M11–M16 added: EVM SwapVenue, operator tooling, Docker, reference strategies, Trading Desk UI, brand narrative).

## Verification

- `npm run build` clean — Docusaurus has `onBrokenLinks: 'throw'` so a single broken link would have failed the build
- In-IDE browser preview against the built site: hero renders correctly with the aurora background + Pole + ice horizon + cast grid + terminal card all working
- Tested on dark mode (which is the default per `respectPrefersColorScheme`)

## Test plan

- [x] Docusaurus build clean
- [x] Visual smoke test in the browser
- [ ] Reviewer can `cd apps/docs && npm install && npm run start` to see live