### PR TITLE
Polish: revert narwhal to v0.1.0, drop hero gradient, no em-dashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Permafrost is a self-custodied, locally-runnable trading framework built around 
 
 Strategies are first-class extensions, not patches. Each one lives as its own subdirectory under `strategies/`, calls `strategy.Register` in `init()`, and is enabled by adding one blank-import line to each binary's `strategies.go`. See the [strategy authors guide](https://teslashibe.github.io/permafrost/strategies/sapi).
 
-The OSS build ships three reference strategies (`noop`, `dca_buy`, `market_maker_basic`). Real strategies — basis trades, market makers, anything you can express as Go — are yours to build, share, or [keep private](https://teslashibe.github.io/permafrost/strategies/private-strategies).
+The OSS build ships three reference strategies (`noop`, `dca_buy`, `market_maker_basic`). Real strategies -- basis trades, market makers, anything you can express as Go -- are yours to build, share, or [keep private](https://teslashibe.github.io/permafrost/strategies/private-strategies).
 
 ---
 
@@ -130,7 +130,7 @@ Full architecture page: [docs/introduction/architecture](https://teslashibe.gith
 
 ## Going live
 
-Paper mode is the default — real market data, no real orders. To trade real money:
+Paper mode is the default -- real market data, no real orders. To trade real money:
 
 ```bash
 # Import your spot signer (Solana keypair, Phantom-style JSON / base58 / hex)
@@ -156,15 +156,15 @@ permafrost agent run     <id> --confirm-live   # explicit foreground gate
 
 A leveraged AI agent will absolutely try to nuke a vault if you let it. Permafrost ships with non-negotiable guardrails:
 
-- **Spot-first execution** — DEX swap must confirm before the perp short is sent
-- **Idempotent intents** — every order and swap carries a deterministic client ID
-- **Decision provenance** — every order links back to the exact prompt + model response
-- **Paper mode by default** — real orders require explicit `--confirm-live`
-- **Per-agent circuit breakers** — drawdown, daily loss, funding flip
-- **Real killswitch** — cancels open orders, flattens shorts via reduce-only market orders, opt-in spot liquidation to USDC via the configured `SwapVenue`. Documented at [killswitch tuning](https://teslashibe.github.io/permafrost/operations/killswitch-tuning).
-- **Mainnet gating** — Hyperliquid live mode behind explicit per-agent flags
+- **Spot-first execution** -- DEX swap must confirm before the perp short is sent
+- **Idempotent intents** -- every order and swap carries a deterministic client ID
+- **Decision provenance** -- every order links back to the exact prompt + model response
+- **Paper mode by default** -- real orders require explicit `--confirm-live`
+- **Per-agent circuit breakers** -- drawdown, daily loss, funding flip
+- **Real killswitch** -- cancels open orders, flattens shorts via reduce-only market orders, opt-in spot liquidation to USDC via the configured `SwapVenue`. Documented at [killswitch tuning](https://teslashibe.github.io/permafrost/operations/killswitch-tuning).
+- **Mainnet gating** -- Hyperliquid live mode behind explicit per-agent flags
 
-When something does go wrong, **Frostbite the Whale** surfaces — that's the killswitch character on the dashboard.
+When something does go wrong, **Frostbite the Whale** surfaces -- that's the killswitch character on the dashboard.
 
 ---
 

--- a/apps/desk/README.md
+++ b/apps/desk/README.md
@@ -1,4 +1,4 @@
-# Permafrost — Trading Desk
+# Permafrost -- Trading Desk
 
 The arctic-themed operator dashboard. React + Vite, no UI framework
 dependency. Hand-authored SVG sprites for every character (see
@@ -34,7 +34,7 @@ daemon and serve under `/ui`.
 
 | Character                 | Role                                      |
 |---------------------------|-------------------------------------------|
-| 🐻 Pole the polar bear    | Camp Director — the operator's avatar.    |
+| 🐻 Pole the polar bear    | Camp Director -- the operator's avatar.    |
 | 🐧 Penguin trader         | One per running agent.                    |
 | 🦄 Narwhal advisor        | Floats beside an agent that uses the LLM. |
 | 🦉 Aurora the snowy owl   | Risk monitor; eye blinks red on a trip.   |

--- a/apps/docs/docs/brand/cast.md
+++ b/apps/docs/docs/brand/cast.md
@@ -10,7 +10,7 @@ Each character represents one piece of the architecture; the visual
 language is consistent across the [Trading Desk UI](https://github.com/teslashibe/permafrost/tree/main/apps/desk),
 the docs, and the CLI's flavour text.
 
-The visual style is deliberately playful — hand-authored pixel art,
+The visual style is deliberately playful -- hand-authored pixel art,
 MarioKart-inspired but Nintendo-IP-free. Cute, distinct, immediately
 readable.
 
@@ -18,7 +18,7 @@ readable.
 
 ### <img src="/img/brand/pole.svg" alt="Pole the polar bear" width="64" height="64" style={{verticalAlign: 'middle'}} /> Pole the polar bear (Captain)
 
-The **Camp Director** — your avatar. Pole presides over the trading
+The **Camp Director** -- your avatar. Pole presides over the trading
 desk, holds the keystore, sets allocations, picks strategies, and
 calls the killswitch. Top of the hierarchy.
 
@@ -28,8 +28,8 @@ permanently. He's the one constant on every screen.
 ### <img src="/img/brand/owl.svg" alt="Aurora the snowy owl" width="64" height="64" style={{verticalAlign: 'middle'}} /> Aurora the snowy owl (Risk Monitor)
 
 Aurora perches in the top-right of the dashboard chrome and watches
-the circuit breakers. When a breaker trips — drawdown, daily loss,
-funding flip, RPC degradation — her eyes blink red and the operator
+the circuit breakers. When a breaker trips -- drawdown, daily loss,
+funding flip, RPC degradation -- her eyes blink red and the operator
 knows something is wrong before they read the breaker name.
 
 She doesn't *fix* anything; she just sees everything.
@@ -60,7 +60,7 @@ standalone module bolted on the side.
 
 ### <img src="/img/brand/husky.svg" alt="Skipper the husky" width="64" height="64" style={{verticalAlign: 'middle'}} /> Skipper the husky (Reconciliation)
 
-Runs between camps delivering reconcile passes — comparing the
+Runs between camps delivering reconcile passes -- comparing the
 framework's view of positions and balances against what the venues
 actually report. Catches drift, missed fills, partial swaps.
 
@@ -76,7 +76,7 @@ Hauls tokens between chains via the configured DEX aggregators
 A killer whale. Literal: a "killer whale" is the killswitch.
 
 Frostbite spends most of his life out of sight, somewhere under the
-ice. When he surfaces, the expedition is over — he cancels every open
+ice. When he surfaces, the expedition is over -- he cancels every open
 order, flattens every short, and (if configured) liquidates every
 spot leg back to USDC.
 
@@ -89,7 +89,7 @@ The full-screen "Whiteout" overlay (UI v2) is Frostbite breaching.
 ### <img src="/img/brand/mammoth.svg" alt="Tusk the mammoth" width="64" height="64" style={{verticalAlign: 'middle'}} /> Tusk the mammoth (Private Strategies)
 
 Tusk is *extinct from public view*. The maintainer's gitignored
-strategies under `strategies/private/` are mammoths — present in
+strategies under `strategies/private/` are mammoths -- present in
 the local build, invisible to the upstream. The visual is a
 permanent reminder that the open-source repo intentionally doesn't
 ship every strategy in production.
@@ -105,14 +105,14 @@ maintainer's local build, you might.
 One coin ≈ $100 of accumulated NAV. The vault panel renders coins
 stacked at the bottom; they shimmer when added.
 
-The coin metaphor predates the rest of the cast — it was always
+The coin metaphor predates the rest of the cast -- it was always
 going to be there. The arctic theme just gave it a more concrete
 home.
 
 ## Why this matters
 
 Trading is dense, fast, and unforgiving. The mental load on the
-operator is enormous — there are dozens of breakers, every venue
+operator is enormous -- there are dozens of breakers, every venue
 has a different latency profile, the LLM is sometimes saying
 something useful and sometimes filling air. Names and faces compress
 that load.

--- a/apps/docs/docs/brand/llm-as-agent.md
+++ b/apps/docs/docs/brand/llm-as-agent.md
@@ -6,7 +6,7 @@ title: LLM-as-agent
 # LLM-as-agent
 
 Permafrost is built on a thesis: the next generation of trading systems
-will treat the LLM not as a feature, but as an **agent** — a first-class
+will treat the LLM not as a feature, but as an **agent** -- a first-class
 participant in the decision loop, with structured input, structured
 output, and structured accountability.
 
@@ -46,7 +46,7 @@ narrower, much more debuggable role than "ask the AI what to do."
   and the venue.
 - **Cost-controlled.** A veto is one round-trip per refresh cycle.
   At a 60-second tick rate, that's $0.005 per cycle on a cheap model
-  — meaningful but not ruinous.
+  -- meaningful but not ruinous.
 
 ## Why other shapes fail
 
@@ -60,7 +60,7 @@ the veto pattern: a sentiment score still has to be turned into a
 decision rule, and the rule was already what you had.
 
 **\"Train a custom model on your historical trades.\"** Fine, but
-that's an ML pipeline, not an LLM. Permafrost supports both — your
+that's an ML pipeline, not an LLM. Permafrost supports both -- your
 custom model can speak the same JSON-schema veto interface as a
 hosted LLM. (See [`pkg/inference`](https://github.com/teslashibe/permafrost/tree/main/pkg/inference).)
 
@@ -74,7 +74,7 @@ inference has a **narwhal advisor** floating beside it, whose horn
 glows when the LLM is being consulted.
 
 The metaphor is intentionally a little playful. Trading is a serious
-field but it's not a sacred one — and the more concrete the mental
+field but it's not a sacred one -- and the more concrete the mental
 model, the easier it is to onboard new operators. Pip the penguin
 quoted a bid; Pip's narwhal said \"funding flip in 30 seconds, skip\";
 Pip didn't quote. That's the whole story, told in five seconds.

--- a/apps/docs/docs/concepts/agent-runtime.md
+++ b/apps/docs/docs/concepts/agent-runtime.md
@@ -28,24 +28,24 @@ stateDiagram-v2
 For a `Decision{Swaps: [s], Orders: [o], Cancels: [c]}`:
 
 1. **Cancels** are sent to the perp venue first.
-2. **Swaps** execute and are awaited until confirmation. If a swap fails, the matching `Order` (same `BasisKey`) is dropped — no half-filled basis.
+2. **Swaps** execute and are awaited until confirmation. If a swap fails, the matching `Order` (same `BasisKey`) is dropped -- no half-filled basis.
 3. **Orders** are sent only after every swap with a matching `BasisKey` confirms.
 4. The decision (with its prompt + LLM response if any) is persisted along with resulting tx hashes / venue order IDs.
 5. Reconciliation reads venue + on-chain state and updates `BasisPosition` rows.
 6. PnL is recomputed.
 
-This order is the **spot-first invariant** that makes delta-neutral strategies safe. Strategies do not have to enforce it themselves — the runtime guarantees it.
+This order is the **spot-first invariant** that makes delta-neutral strategies safe. Strategies do not have to enforce it themselves -- the runtime guarantees it.
 
 ## Concurrency
 
-One supervisor goroutine per running agent. Strategy `Decide` calls within an agent are strictly sequential — each tick waits for the previous to complete (or hit the tick deadline). Across agents, ticks happen in parallel; the runtime is goroutine-safe.
+One supervisor goroutine per running agent. Strategy `Decide` calls within an agent are strictly sequential -- each tick waits for the previous to complete (or hit the tick deadline). Across agents, ticks happen in parallel; the runtime is goroutine-safe.
 
 ## Where it lives
 
-- `internal/agent/runtime.go` — the `Runtime` itself.
-- `internal/agent/builder.go` — `BuildDeps`, `BuildStrategy`, `BuildHyperliquidVenue`.
-- `internal/agent/supervisor.go` — keeps a `Runtime` per running agent on daemon boot.
-- `internal/agent/killswitch.go` — the global stop everything switch.
+- `internal/agent/runtime.go` -- the `Runtime` itself.
+- `internal/agent/builder.go` -- `BuildDeps`, `BuildStrategy`, `BuildHyperliquidVenue`.
+- `internal/agent/supervisor.go` -- keeps a `Runtime` per running agent on daemon boot.
+- `internal/agent/killswitch.go` -- the global stop everything switch.
 
 ## Next steps
 

--- a/apps/docs/docs/concepts/inference.md
+++ b/apps/docs/docs/concepts/inference.md
@@ -11,7 +11,7 @@ Permafrost wraps an OpenAI-compatible chat-completion client (`pkg/inference.Pro
 - **Does:** veto entries based on event/news context, score candidates, classify sentiment, summarize on-chain context for the operator.
 - **Does NOT:** invent orders. Strategies are deterministic Go code; the LLM's output is consumed as a `bool` (veto / not), a number (score), or structured JSON via JSON-Schema mode. Never as raw `OrderIntent`s.
 
-This is enforced at the framework layer: the `Strategy.Decide` return value carries `Orders`, `Swaps`, and `Cancels` — typed Go structs. There is no path for an LLM response to be parsed directly into an order intent.
+This is enforced at the framework layer: the `Strategy.Decide` return value carries `Orders`, `Swaps`, and `Cancels` -- typed Go structs. There is no path for an LLM response to be parsed directly into an order intent.
 
 ## Configuring providers
 
@@ -69,16 +69,16 @@ Every inference request and response is persisted alongside the resulting `Decis
 permafrost agent decisions <id> --with-prompts
 ```
 
-This is what "auditable AI" means in practice — you can see exactly what the model saw, how it responded, and which on-chain actions followed.
+This is what "auditable AI" means in practice -- you can see exactly what the model saw, how it responded, and which on-chain actions followed.
 
 ## Errors and graceful degradation
 
 `pkg/inference` exposes two sentinel errors strategies should handle:
 
-- `ErrUnsupportedFeature` — provider/model can't do something the request asked for (e.g. JSON Schema on a base Ollama model). Strategies should fall back to a simpler prompt or skip the LLM hop.
-- `ErrRateLimited` — provider returned 429. Strategies should default to safe behaviour (e.g. don't open new positions this tick).
+- `ErrUnsupportedFeature` -- provider/model can't do something the request asked for (e.g. JSON Schema on a base Ollama model). Strategies should fall back to a simpler prompt or skip the LLM hop.
+- `ErrRateLimited` -- provider returned 429. Strategies should default to safe behaviour (e.g. don't open new positions this tick).
 
-A `Provider` that returns errors does **not** crash the runtime — `Strategy.Decide` returns whatever decision it made (often an empty one, with the error in `Notes`).
+A `Provider` that returns errors does **not** crash the runtime -- `Strategy.Decide` returns whatever decision it made (often an empty one, with the error in `Notes`).
 
 ## Next steps
 

--- a/apps/docs/docs/concepts/primitives.md
+++ b/apps/docs/docs/concepts/primitives.md
@@ -12,7 +12,7 @@ The "permafrost." Holds locked capital and realized gains. Tracks deposits, lock
 
 ## Wallet
 
-A self-custodied keypair on a chain. v1 ships with one Solana keypair plus one Hyperliquid signer per operator. The wallet's address is the spot custody endpoint — the long leg of every basis trade lives here.
+A self-custodied keypair on a chain. v1 ships with one Solana keypair plus one Hyperliquid signer per operator. The wallet's address is the spot custody endpoint -- the long leg of every basis trade lives here.
 
 ## Strategy
 

--- a/apps/docs/docs/concepts/reconcile-and-pnl.md
+++ b/apps/docs/docs/concepts/reconcile-and-pnl.md
@@ -21,11 +21,11 @@ The strategy never sees stale data. By the time `Decide` is called for the next 
 
 `internal/pnl` computes per-agent PnL from:
 
-- **Realized funding** — accumulated funding payments across the holding period.
-- **Realized basis P&L** — the profit/loss from opening at one basis and closing at another.
-- **Unrealized basis P&L** — mark-to-market of the open spot/perp pair.
-- **Fees** — perp taker/maker fees + DEX swap fees.
-- **Gas costs** — included for EVM swaps; trivial for Solana.
+- **Realized funding** -- accumulated funding payments across the holding period.
+- **Realized basis P&L** -- the profit/loss from opening at one basis and closing at another.
+- **Unrealized basis P&L** -- mark-to-market of the open spot/perp pair.
+- **Fees** -- perp taker/maker fees + DEX swap fees.
+- **Gas costs** -- included for EVM swaps; trivial for Solana.
 
 NAV is exposed via the API and CLI:
 
@@ -38,10 +38,10 @@ permafrost vault nav
 
 ## Where it lives
 
-- `internal/reconcile/` — the reconciliation loop.
-- `internal/pnl/` — PnL accounting.
-- `internal/agent/runtime.go` — schedules reconcile after each tick.
-- TimescaleDB hypertables — the underlying storage for time-series PnL data.
+- `internal/reconcile/` -- the reconciliation loop.
+- `internal/pnl/` -- PnL accounting.
+- `internal/agent/runtime.go` -- schedules reconcile after each tick.
+- TimescaleDB hypertables -- the underlying storage for time-series PnL data.
 
 ## Next steps
 

--- a/apps/docs/docs/concepts/risk-and-killswitch.md
+++ b/apps/docs/docs/concepts/risk-and-killswitch.md
@@ -29,9 +29,9 @@ Per-agent limits live on the agent record (set via `agent create --config-json '
 
 Beyond pre-trade limits, the framework runs a small set of circuit breakers continuously. Each breaker, when tripped, halts the agent and (depending on configuration) escalates to the killswitch:
 
-- **MaxDrawdownBreaker** — fraction of equity below NAV high-water mark.
-- **DailyLossBreaker** — absolute USDC loss within a UTC day.
-- **FundingFlipBreaker** — perp funding flips sign while a basis is open (the trade thesis just inverted).
+- **MaxDrawdownBreaker** -- fraction of equity below NAV high-water mark.
+- **DailyLossBreaker** -- absolute USDC loss within a UTC day.
+- **FundingFlipBreaker** -- perp funding flips sign while a basis is open (the trade thesis just inverted).
 - *Pluggable.* `risk.Breaker` is an interface; new breakers are added by implementing it and wiring into `BuildRiskEngine`.
 
 ## Killswitch

--- a/apps/docs/docs/getting-started/configuration.md
+++ b/apps/docs/docs/getting-started/configuration.md
@@ -65,7 +65,7 @@ evm:
       one_inch_api_key_env: ONEINCH_API_KEY
 ```
 
-Configured chains downgrade to paper-spot bookkeeping if either the API key or the chain signer is missing — the runtime logs a warning rather than failing.
+Configured chains downgrade to paper-spot bookkeeping if either the API key or the chain signer is missing -- the runtime logs a warning rather than failing.
 
 ## Inference
 
@@ -86,7 +86,7 @@ Multiple providers can coexist; agents pick by name in the `--inference provider
 
 ## Risk
 
-Per-agent risk lives on the agent record (set via `agent create --config-json '{"risk":{...}}'`). The framework also has installation-wide killswitch tuning — see [killswitch tuning](/operations/killswitch-tuning).
+Per-agent risk lives on the agent record (set via `agent create --config-json '{"risk":{...}}'`). The framework also has installation-wide killswitch tuning -- see [killswitch tuning](/operations/killswitch-tuning).
 
 ## Environment overrides
 
@@ -94,9 +94,9 @@ Any nested config field is overridable via environment variable using `_` separa
 
 A few first-class env variables:
 
-- `PERMAFROST_CONFIG` — path to the config file (default `./config.yaml`).
-- `PERMAFROST_HYPERLIQUID_NETWORK` — daemon-wide override of every agent's stored network. Useful for "panic switch all agents to testnet" scenarios.
-- `PERMAFROST_KEYSTORE_PASSPHRASE` — passphrase to decrypt the keystore at startup.
+- `PERMAFROST_CONFIG` -- path to the config file (default `./config.yaml`).
+- `PERMAFROST_HYPERLIQUID_NETWORK` -- daemon-wide override of every agent's stored network. Useful for "panic switch all agents to testnet" scenarios.
+- `PERMAFROST_KEYSTORE_PASSPHRASE` -- passphrase to decrypt the keystore at startup.
 
 ## Next steps
 

--- a/apps/docs/docs/getting-started/init-and-doctor.md
+++ b/apps/docs/docs/getting-started/init-and-doctor.md
@@ -21,7 +21,7 @@ Walks an operator through:
    (default `~/.permafrost/env`).
 5. **Optional inference provider** (openrouter / openai / groq /
    ollama / skip).
-6. **EVM RPC nudge** — points you at [chainlist.org](https://chainlist.org/)
+6. **EVM RPC nudge** -- points you at [chainlist.org](https://chainlist.org/)
    when you're ready to trade EVM spot legs.
 
 End state:
@@ -29,7 +29,7 @@ End state:
 - A starter `config.yaml` (copied from `config.example.yaml` if
   available; minimal stub otherwise).
 - A 64-hex-character keystore passphrase, written 0600 to a sourceable
-  env file. The wizard prints it once on stdout — back it up.
+  env file. The wizard prints it once on stdout -- back it up.
 - A clear next-steps block telling you exactly the next 5 commands to
   type.
 
@@ -74,7 +74,7 @@ Permafrost preflight ───────────────────�
   ✓  config loaded              env=dev
   ✓  database reachable         postgres://REDACTED@localhost:5432/permafrost?sslmode=disable
   ✓  keystore passphrase env    PERMAFROST_KEYSTORE_PASSPHRASE set
-  ⚠  keystore file              ~/.permafrost/keystore.json (not yet created — run `permafrost wallet generate` or `wallet import`)
+  ⚠  keystore file              ~/.permafrost/keystore.json (not yet created -- run `permafrost wallet generate` or `wallet import`)
   ⚠  inference: groq            base_url=https://api.groq.com/openai/v1 but GROQ_API_KEY not set (provider may reject auth)
   ✓  inference: ollama          base_url=http://localhost:11434/v1
   ✓  solana RPC                 https://api.mainnet-beta.solana.com (slot 414335213)
@@ -102,12 +102,12 @@ Permafrost preflight ───────────────────�
 
 ### Severity model
 
-- **`✓` (green)** — passing.
-- **`⚠` (yellow)** — degraded but won't block agent start. Common cases:
+- **`✓` (green)** -- passing.
+- **`⚠` (yellow)** -- degraded but won't block agent start. Common cases:
   rate-limited RPC, missing optional inference key, keystore not yet
   populated.
-- **`✗` (red)** — hard failure. Doctor exits 1.
-- **`─` (grey)** — intentionally skipped (e.g. Solana RPC check when
+- **`✗` (red)** -- hard failure. Doctor exits 1.
+- **`─` (grey)** -- intentionally skipped (e.g. Solana RPC check when
   no Solana RPC is configured).
 
 ### Flags
@@ -120,7 +120,7 @@ permafrost doctor --verbose    # show underlying error details for failures
 
 Doctor uses an explicit 5-second HTTP timeout per check (TLS-handshake
 hang protection). The Solana check uses `getSlot` rather than `getHealth`
-— commercial providers (Helius, Triton) restrict `getHealth`. RPC URLs
+- commercial providers (Helius, Triton) restrict `getHealth`. RPC URLs
 are redacted (API keys stripped) before being printed.
 
 ## Where they fit in your workflow

--- a/apps/docs/docs/getting-started/local-install.md
+++ b/apps/docs/docs/getting-started/local-install.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Local install (manual)
 
-The fast path is [`make demo`](/getting-started/make-demo) — one command, ~60 seconds. This page is the manual walk-through if you want to drive each step yourself, or to understand what `make demo` does under the hood.
+The fast path is [`make demo`](/getting-started/make-demo) -- one command, ~60 seconds. This page is the manual walk-through if you want to drive each step yourself, or to understand what `make demo` does under the hood.
 
 ## The four commands
 
@@ -30,7 +30,7 @@ permafrost agent create \
 permafrost agent start <id>                # supervisor picks it up
 ```
 
-Default mode is `paper` — no real orders are placed until the agent is explicitly promoted to `live` (and you pass `--confirm-live` to `agent run`). See [running noop](/getting-started/running-noop) for the full smoke-test flow and [the init wizard + doctor](/getting-started/init-and-doctor) for what `init` and `doctor` do.
+Default mode is `paper` -- no real orders are placed until the agent is explicitly promoted to `live` (and you pass `--confirm-live` to `agent run`). See [running noop](/getting-started/running-noop) for the full smoke-test flow and [the init wizard + doctor](/getting-started/init-and-doctor) for what `init` and `doctor` do.
 
 ## What `make up` does
 

--- a/apps/docs/docs/getting-started/make-demo.md
+++ b/apps/docs/docs/getting-started/make-demo.md
@@ -13,7 +13,7 @@ cd permafrost
 make demo
 ```
 
-That's the whole quickstart. Idempotent — re-running attaches to the
+That's the whole quickstart. Idempotent -- re-running attaches to the
 existing demo agent rather than duplicating it. SIGINT to stop the tail;
 the daemon keeps running until `make demo-clean`.
 
@@ -32,19 +32,19 @@ The script (`scripts/demo.sh`) is short and readable. In order:
    `.permafrost-demo/` (gitignored, isolated from your real
    `~/.permafrost/`).
 5. **Source the env file** to load the passphrase into the shell.
-6. **Doctor preflight** — bails out with a clear message if any check
+6. **Doctor preflight** -- bails out with a clear message if any check
    fails hard. Warnings (no inference key, etc.) don't fail the run.
-7. **Recruit Pip** — paper-mode `noop` agent, `--alloc 1000`,
+7. **Recruit Pip** -- paper-mode `noop` agent, `--alloc 1000`,
    `--tick-secs 5`. Reused on re-run via name lookup so you don't get
    duplicate agents.
 8. **Mark Pip runnable** and tail decisions every 2s until SIGINT.
 
-Output is themed for the project — see the [cast](/brand/cast).
+Output is themed for the project -- see the [cast](/brand/cast).
 
 ## Sample output
 
 ```
-❄  Permafrost demo — launching expedition…
+❄  Permafrost demo -- launching expedition…
   ✓ preflight: docker + go present
   ✓ binaries built (./bin/{permafrost,permafrostd})
   ✓ stack up (Postgres + permafrostd)
@@ -62,7 +62,7 @@ Permafrost preflight ───────────────────�
 ─────────────────────────────────────────────────────────────────
   ✓ Pip is on the ice
 
-❄  🐧  The Floe — funding rates
+❄  🐧  The Floe -- funding rates
 
 [tick 1] confidence=0.00 swaps=0 orders=0 notes="noop"
 [tick 2] confidence=0.00 swaps=0 orders=0 notes="noop"
@@ -90,8 +90,8 @@ Stops the docker stack and removes `.permafrost-demo/`. Your real
 
 ## Next steps
 
-- [The init wizard + doctor](/getting-started/init-and-doctor) — for
+- [The init wizard + doctor](/getting-started/init-and-doctor) -- for
   driving the same setup steps interactively without `make demo`.
-- [Running noop](/getting-started/running-noop) — manual end-to-end
+- [Running noop](/getting-started/running-noop) -- manual end-to-end
   walkthrough.
 - [Configuration reference](/getting-started/configuration).

--- a/apps/docs/docs/getting-started/running-noop.md
+++ b/apps/docs/docs/getting-started/running-noop.md
@@ -4,14 +4,14 @@ sidebar_position: 6
 
 # Running noop
 
-`noop` is the smallest strategy that satisfies the `Strategy` interface. It returns an empty `Decision` every tick — no orders, no swaps. It exists for two reasons:
+`noop` is the smallest strategy that satisfies the `Strategy` interface. It returns an empty `Decision` every tick -- no orders, no swaps. It exists for two reasons:
 
 1. **Reference implementation.** Twenty lines of Go that demonstrate the SAPI surface.
 2. **End-to-end smoke test.** All of the framework's loops (scheduler, runtime, reconcile, killswitch, PnL) execute even with `noop` selected, so a successful `noop` run proves your install, database, keystore, and venue connections are all working.
 
 ## The fast path
 
-Just run `make demo` — it does all the steps below for you. See [run the demo](/getting-started/make-demo).
+Just run `make demo` -- it does all the steps below for you. See [run the demo](/getting-started/make-demo).
 
 ## Smoke test (manual)
 
@@ -44,7 +44,7 @@ permafrost agent decisions ag-...
 
 If you see decisions appearing every 30 seconds, the daemon is healthy: the scheduler is firing, the runtime is calling `Strategy.Decide`, results are being persisted to TimescaleDB, and the kill-switch is monitoring without tripping.
 
-For one-shot foreground iteration in a single shell (no daemon), use `permafrost agent run ag-...` instead — that runs the tick loop in the foreground and exits on SIGINT.
+For one-shot foreground iteration in a single shell (no daemon), use `permafrost agent run ag-...` instead -- that runs the tick loop in the foreground and exits on SIGINT.
 
 ## Inspecting agent state
 

--- a/apps/docs/docs/introduction/architecture.md
+++ b/apps/docs/docs/introduction/architecture.md
@@ -82,7 +82,7 @@ permafrost/
 ## Layering rules
 
 - Strategies depend on `pkg/strategy` and `pkg/types`. They MAY import `internal/*` packages directly (single-module repo) but doing so couples them to internals that may change without notice.
-- `internal/agent.BuildStrategy` is a pure registry lookup — no per-strategy special-casing. Strategies own their own typed config parsing inside their `Constructor` and pull framework services from `WarmupInput.Services`.
+- `internal/agent.BuildStrategy` is a pure registry lookup -- no per-strategy special-casing. Strategies own their own typed config parsing inside their `Constructor` and pull framework services from `WarmupInput.Services`.
 - `internal/store` is the only package that imports `pgx`.
 - `internal/wallet` is the only package that touches private key bytes.
 

--- a/apps/docs/docs/introduction/what-is-permafrost.md
+++ b/apps/docs/docs/introduction/what-is-permafrost.md
@@ -7,9 +7,9 @@ slug: /introduction/what-is-permafrost
 
 Permafrost is an open-source DeFi trading framework. It is an agent runtime built around a stable Strategy SAPI: write a deterministic Go strategy, register it, and the framework handles exchange adapters, swap routing, position reconciliation, PnL accounting, risk gates, the killswitch, decision provenance, and LLM augmentation.
 
-Strategies are first-class extensions, not patches. Each strategy lives as its own subdirectory under `strategies/`, calls `strategy.Register` in `init()`, and is enabled by adding one blank-import line to `cmd/permafrostd/strategies.go`. The framework knows nothing about any specific strategy — `BuildStrategy` is a pure registry lookup.
+Strategies are first-class extensions, not patches. Each strategy lives as its own subdirectory under `strategies/`, calls `strategy.Register` in `init()`, and is enabled by adding one blank-import line to `cmd/permafrostd/strategies.go`. The framework knows nothing about any specific strategy -- `BuildStrategy` is a pure registry lookup.
 
-The OSS framework ships with `noop` as a reference implementation. Real strategies — basis trades, market makers, anything you can express as deterministic Go — are yours to build, share, or keep private.
+The OSS framework ships with `noop` as a reference implementation. Real strategies -- basis trades, market makers, anything you can express as deterministic Go -- are yours to build, share, or keep private.
 
 ## Status
 
@@ -27,10 +27,10 @@ MVP. Single-operator, local-first. v2 will introduce hosted vaults with on-chain
 
 - A deterministic agent loop with paired-execution invariants (swap-before-order for delta-neutral trades).
 - Exchange adapter for Hyperliquid (perp), with `OpenOrders` + idempotent place/cancel.
-- Swap adapters for Solana (Jupiter) and EVM chains (1inch v6 — Ethereum, Base, Avalanche, BSC).
+- Swap adapters for Solana (Jupiter) and EVM chains (1inch v6 -- Ethereum, Base, Avalanche, BSC).
 - A self-custodied keystore. Private key bytes never leave the `internal/wallet` boundary.
 - Position reconciliation, PnL accounting, NAV tracking.
-- A real killswitch — cancels every open order, flattens shorts via reduce-only market orders, and (opt-in) liquidates spot legs back to USDC via the configured swap router.
+- A real killswitch -- cancels every open order, flattens shorts via reduce-only market orders, and (opt-in) liquidates spot legs back to USDC via the configured swap router.
 - Pre-trade risk + circuit breakers (drawdown, daily loss, funding flip, …).
 - Optional LLM-veto path via an OpenAI-compatible inference client (OpenAI, OpenRouter, Groq, vLLM, Ollama, etc.).
 - Decision provenance: every order links back to the exact prompt and model response.
@@ -38,18 +38,18 @@ MVP. Single-operator, local-first. v2 will introduce hosted vaults with on-chain
 
 **Reference strategies**
 
-- `noop` — minimal smoke-test strategy.
-- `dca_buy` — deterministic dollar-cost-averaging into a configured spot asset.
-- `market_maker_basic` — paired bid/ask quoting on Hyperliquid with optional LLM veto.
+- `noop` -- minimal smoke-test strategy.
+- `dca_buy` -- deterministic dollar-cost-averaging into a configured spot asset.
+- `market_maker_basic` -- paired bid/ask quoting on Hyperliquid with optional LLM veto.
 
 **Operator tooling**
 
-- `make demo` — one command from `git clone` to a paper-mode agent posting decisions in your terminal.
-- `permafrost init` — interactive setup wizard (config + keystore passphrase + first-agent template).
-- `permafrost doctor` — preflight check for Go, Docker, DB, keystore, inference providers, RPCs, registered strategies.
-- `permafrost strategy-new <name>` — scaffolds a new strategy package and registers it in the build.
+- `make demo` -- one command from `git clone` to a paper-mode agent posting decisions in your terminal.
+- `permafrost init` -- interactive setup wizard (config + keystore passphrase + first-agent template).
+- `permafrost doctor` -- preflight check for Go, Docker, DB, keystore, inference providers, RPCs, registered strategies.
+- `permafrost strategy-new <name>` -- scaffolds a new strategy package and registers it in the build.
 - A multi-arch Docker image (`linux/amd64` + `linux/arm64`) published to GHCR, with a `cli` compose service for one-off commands.
-- A read-only **Trading Desk web UI** — arctic-themed React + Vite dashboard with hand-authored pixel-art SVG sprites of the cast.
+- A read-only **Trading Desk web UI** -- arctic-themed React + Vite dashboard with hand-authored pixel-art SVG sprites of the cast.
 
 ## Next steps
 

--- a/apps/docs/docs/introduction/why-self-custodied.md
+++ b/apps/docs/docs/introduction/why-self-custodied.md
@@ -14,18 +14,18 @@ Permafrost is built on the conviction that the long side of every trade should l
 
 ## Why it matters for a trading bot
 
-A leveraged trading bot is a fast way to lose money. The classic blow-up modes — exchange counterparty risk, key compromise, runaway strategy logic — get worse, not better, when an AI is in the loop.
+A leveraged trading bot is a fast way to lose money. The classic blow-up modes -- exchange counterparty risk, key compromise, runaway strategy logic -- get worse, not better, when an AI is in the loop.
 
 Self-custody addresses the first mode (counterparty risk) directly. The other two are addressed by the framework's design:
 
 - **Key compromise:** `internal/wallet` is the only package that touches private key bytes. Everything else uses a `Signer` abstraction. Keys live in an encrypted JSON keystore loaded with a passphrase from an environment variable.
-- **Runaway logic:** strategies are deterministic Go code. The LLM augments — it can veto entries based on news, tune thresholds — but it never invents orders. Every decision is persisted with the exact prompt + model response so you can audit what the model saw.
+- **Runaway logic:** strategies are deterministic Go code. The LLM augments -- it can veto entries based on news, tune thresholds -- but it never invents orders. Every decision is persisted with the exact prompt + model response so you can audit what the model saw.
 
 On top of that, the killswitch and circuit breakers fire on drawdown, daily loss, funding flip, and a configurable set of conditions; see [risk and the killswitch](/concepts/risk-and-killswitch).
 
 ## Trade-offs
 
-- You're responsible for backups. If you lose your keystore and your passphrase, the funds are gone — no exchange support to call.
+- You're responsible for backups. If you lose your keystore and your passphrase, the funds are gone -- no exchange support to call.
 - You need to run the daemon somewhere. v1 is local-first; the same codebase will later power hosted deployments, but right now the operator is you.
 - Spot leg execution depends on DEX liquidity and on-chain conditions (gas, RPC, MEV). The framework wires Jito bundles for Solana and per-chain RPC config for EVM, but you should understand the route for any asset you trade.
 

--- a/apps/docs/docs/operations/deployment.md
+++ b/apps/docs/docs/operations/deployment.md
@@ -6,8 +6,8 @@ sidebar_position: 1
 
 v1 of Permafrost is local-first. Three flavours of deploy, in increasing order of ceremony:
 
-1. **`make demo`** on a laptop — one command, ephemeral. See [run the demo](/getting-started/make-demo).
-2. **`make up`** on a host you control (laptop / VPS / colo) — persistent compose stack.
+1. **`make demo`** on a laptop -- one command, ephemeral. See [run the demo](/getting-started/make-demo).
+2. **`make up`** on a host you control (laptop / VPS / colo) -- persistent compose stack.
 3. **GHCR-published image** pulled into your own orchestration (compose, k3s, ECS).
 
 ## Local (laptop / dev)
@@ -28,7 +28,7 @@ The same `docker-compose.yml` works on a server. Notes:
 
 - **TimescaleDB** is configured with a small footprint by default. For production, mount a real volume and tune `shared_buffers` / `work_mem`.
 - **Persistence.** Mount `/var/lib/postgresql/data` as a named volume (compose does this) and add it to your snapshot/backup schedule.
-- **Reverse proxy.** The Fiber API listens on `:8080` by default. Front it with caddy / nginx + TLS if exposed publicly. Most operators don't expose it — they SSH in and use the CLI directly.
+- **Reverse proxy.** The Fiber API listens on `:8080` by default. Front it with caddy / nginx + TLS if exposed publicly. Most operators don't expose it -- they SSH in and use the CLI directly.
 - **Process supervision.** The compose `restart: unless-stopped` policy handles crash recovery. Systemd is the easiest non-Docker path: `ExecStart=/usr/local/bin/permafrostd`, set `PERMAFROST_KEYSTORE_PASSPHRASE` via `EnvironmentFile`, restart on failure.
 
 ## The `cli` compose service
@@ -66,14 +66,14 @@ docker run --rm --entrypoint permafrost ghcr.io/teslashibe/permafrost:latest doc
 
 Built for `linux/amd64` + `linux/arm64`. Tags: the version itself + `:latest` for non-pre-release versions (anything without a hyphen → `:latest`; pre-releases like `v0.1.0-rc1` get only the version tag).
 
-The image is **dual-binary** — both `permafrost` (CLI) and `permafrostd` (daemon) live at `/usr/local/bin/`. Override the entrypoint to pick:
+The image is **dual-binary** -- both `permafrost` (CLI) and `permafrostd` (daemon) live at `/usr/local/bin/`. Override the entrypoint to pick:
 
 ```bash
 docker run --rm --entrypoint permafrostd ghcr.io/teslashibe/permafrost:latest \
     --config /etc/permafrost/config.yaml
 ```
 
-The release workflow is in `.github/workflows/release.yml`. Triggers on `v*` tag pushes and `workflow_dispatch`. Uses the built-in `GITHUB_TOKEN` for GHCR auth — no extra secrets to configure.
+The release workflow is in `.github/workflows/release.yml`. Triggers on `v*` tag pushes and `workflow_dispatch`. Uses the built-in `GITHUB_TOKEN` for GHCR auth -- no extra secrets to configure.
 
 ## Building a custom binary
 
@@ -85,10 +85,10 @@ go build -o /usr/local/bin/permafrostd ./cmd/permafrostd
 
 Two files determine which strategies are linked into the binary:
 
-- `cmd/permafrostd/strategies.go` — committed, blank-imports community + reference strategies (`noop`, `dca_buy`, `market_maker_basic`).
-- `cmd/permafrostd/strategies_local.go` — gitignored, blank-imports your private strategies.
+- `cmd/permafrostd/strategies.go` -- committed, blank-imports community + reference strategies (`noop`, `dca_buy`, `market_maker_basic`).
+- `cmd/permafrostd/strategies_local.go` -- gitignored, blank-imports your private strategies.
 
-Rebuild whenever you add or remove a strategy. Or use `permafrost strategy-new <name>` to scaffold + register in one shot — see [scaffolding](/strategies/scaffolding).
+Rebuild whenever you add or remove a strategy. Or use `permafrost strategy-new <name>` to scaffold + register in one shot -- see [scaffolding](/strategies/scaffolding).
 
 ## Building a custom Docker image (with private strategies)
 
@@ -123,8 +123,8 @@ permafrost db migrate status
 
 The two things to back up:
 
-1. **The database** — `pg_dump` the entire `permafrost` database. Includes agent definitions, decisions, positions, PnL history, vault state.
-2. **The keystore** — encrypted, but lose it (or the passphrase) and the funds are gone.
+1. **The database** -- `pg_dump` the entire `permafrost` database. Includes agent definitions, decisions, positions, PnL history, vault state.
+2. **The keystore** -- encrypted, but lose it (or the passphrase) and the funds are gone.
 
 Plus, if you have private strategies, [back those up](/strategies/private-strategies#backups-you-have-to-think-about-this).
 

--- a/apps/docs/docs/operations/keystore-and-backups.md
+++ b/apps/docs/docs/operations/keystore-and-backups.md
@@ -10,9 +10,9 @@ Permafrost holds private keys directly. This page covers what's stored, where, h
 
 `internal/wallet` manages an encrypted JSON keystore (default path `~/.permafrost/keystore.json`; override via `wallet.keystore_path` in `config.yaml`). It contains, per chain:
 
-- **Solana** — an ed25519 private key.
-- **Hyperliquid** — an ECDSA private key used to sign Hyperliquid orders. (HL itself has no on-chain wallet to fund; this key authenticates API requests.)
-- **EVM chains** — an ECDSA private key (one for all EVM chains; addresses are derived per chain).
+- **Solana** -- an ed25519 private key.
+- **Hyperliquid** -- an ECDSA private key used to sign Hyperliquid orders. (HL itself has no on-chain wallet to fund; this key authenticates API requests.)
+- **EVM chains** -- an ECDSA private key (one for all EVM chains; addresses are derived per chain).
 
 `internal/wallet` is the **only** package that touches private key bytes. Everything else uses a `Signer` abstraction. If a key ever leaks via a log or panic, that's a bug.
 
@@ -29,13 +29,13 @@ In Docker / systemd deployments, supply `PERMAFROST_KEYSTORE_PASSPHRASE` via:
 ## Importing keys
 
 ```bash
-# Solana — from a Solana CLI keypair file
+# Solana -- from a Solana CLI keypair file
 permafrost wallet import --chain solana --from ~/.config/solana/id.json
 
-# EVM — from a hex-encoded private key
+# EVM -- from a hex-encoded private key
 permafrost wallet import --chain ethereum --hex 0x...
 
-# Hyperliquid — same flow, hex private key
+# Hyperliquid -- same flow, hex private key
 permafrost wallet import --chain hyperliquid --hex 0x...
 ```
 
@@ -59,8 +59,8 @@ The keystore + the passphrase together are the keys to the funds. **Lose either 
 
 Minimum:
 
-1. **Encrypted keystore** — backed up to two physically separate locations (e.g. Time Machine + a USB key in a safe).
-2. **Passphrase** — written down, stored separately from the keystore. A password manager works; a piece of paper in a safe works. Memorising it is not a backup.
+1. **Encrypted keystore** -- backed up to two physically separate locations (e.g. Time Machine + a USB key in a safe).
+2. **Passphrase** -- written down, stored separately from the keystore. A password manager works; a piece of paper in a safe works. Memorising it is not a backup.
 
 Better:
 

--- a/apps/docs/docs/operations/killswitch-tuning.md
+++ b/apps/docs/docs/operations/killswitch-tuning.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Killswitch tuning
 
-The killswitch is the framework's last line of defence. This page documents what it actually does today (per the v1 implementation in `internal/agent/killswitch.go`) — not aspirational behaviour.
+The killswitch is the framework's last line of defence. This page documents what it actually does today (per the v1 implementation in `internal/agent/killswitch.go`) -- not aspirational behaviour.
 
 ## What the killswitch is
 
@@ -27,7 +27,7 @@ When `Trip` fires, in order:
 2. **Set `status='halted'`** on the agent (so a daemon restart does not auto-resume it).
 3. **Cancel every open order** on the perp venue. Hyperliquid implementation reads `/info?type=openOrders` and cancels each one; per-order failures are logged and the loop continues.
 4. If `CloseShorts`: **flatten every non-flat perp position** with reduce-only market orders. Shorts → buy back, longs → sell.
-5. If `LiquidateSpot`: **swap every open spot leg back to USDC** via the chain's configured `SwapVenue` (Quote → Swap; doesn't `WaitConfirm` — killswitch is fire-and-forget).
+5. If `LiquidateSpot`: **swap every open spot leg back to USDC** via the chain's configured `SwapVenue` (Quote → Swap; doesn't `WaitConfirm` -- killswitch is fire-and-forget).
 
 Errors during steps 3-5 are logged but **do not stop the rest of the sequence**. The first error encountered is returned so the caller knows something failed; the rest is in the log.
 
@@ -68,33 +68,33 @@ permafrost agent create \
 
 The framework installs two breakers automatically:
 
-- **MaxDrawdownBreaker** — tracks NAV drawdown vs the agent's high-water mark. `max_drawdown: 0` disables it; otherwise expressed as a fraction (e.g. `0.10` = 10%).
-- **DailyLossBreaker** — tracks absolute USDC loss within a UTC day. `max_daily_loss: 0` disables it.
+- **MaxDrawdownBreaker** -- tracks NAV drawdown vs the agent's high-water mark. `max_drawdown: 0` disables it; otherwise expressed as a fraction (e.g. `0.10` = 10%).
+- **DailyLossBreaker** -- tracks absolute USDC loss within a UTC day. `max_daily_loss: 0` disables it.
 
 Additional breakers (basis blowout, funding flip, RPC health) are part of the framework's roadmap; what's in v1 today is the two above plus the pre-trade limits.
 
 ## Tuning `LiquidateSpot`
 
-Spot liquidation is **opt-in** because it requires a `SwapVenue` configured for every chain you hold spot on. Default `KillSwitchOptions.CloseShorts: true, LiquidateSpot: false` is the safe choice for the first week of operation — flatten the perp risk, leave the spot inventory in place where you can sell it manually if needed.
+Spot liquidation is **opt-in** because it requires a `SwapVenue` configured for every chain you hold spot on. Default `KillSwitchOptions.CloseShorts: true, LiquidateSpot: false` is the safe choice for the first week of operation -- flatten the perp risk, leave the spot inventory in place where you can sell it manually if needed.
 
 When you flip `LiquidateSpot: true`:
 
 - Every chain in `BasisPosition.Legs[].Asset.Chain` must have a `SwapVenue` registered in `Deps.SwapVenues`. Chains without one log a warning and the leg is left in place.
 - Every chain must have a USDC mapping. The framework ships these for Solana, Ethereum, Base, Avalanche, BSC (`internal/assets.USDCMintFor`). Chains without a mapping warn and skip.
-- `SpotSlippageBps` defaults to whatever the agent's `MaxSpotSlippageBps` risk limit is, with a 100bps safety ceiling. A killswitch is by definition urgent — typical slippage budgets here are wider than normal entry/exit. Tune deliberately.
+- `SpotSlippageBps` defaults to whatever the agent's `MaxSpotSlippageBps` risk limit is, with a 100bps safety ceiling. A killswitch is by definition urgent -- typical slippage budgets here are wider than normal entry/exit. Tune deliberately.
 
 ## Practical tuning advice
 
 Defaults are intentionally conservative; tune up only as you build confidence.
 
 - **First week of live trading:** set `max_drawdown` low (5%) and `max_daily_loss` to a small absolute number (e.g. 1% of allocation). You're catching sizing bugs, not real market moves.
-- **`CloseShorts: true`** is the safe default — leaving naked shorts running after a kill is rarely what you want.
+- **`CloseShorts: true`** is the safe default -- leaving naked shorts running after a kill is rarely what you want.
 - **`LiquidateSpot: true`** is appropriate when you want fully-flat exposure after a kill; leave it off when you'd rather sell spot manually after diagnosing.
 
 ## Known limits
 
 - **No daemon-wide killswitch trigger.** Multi-agent breaker escalation, RPC error storms, and inference rate-limit storms are not auto-triggered by the framework. An operator hitting `permafrost agent stop --all` is the manual equivalent today.
-- **Liquidation is fire-and-forget.** `Trip` does not `WaitConfirm` on liquidation swaps. Operator can inspect tx hashes from the decision log if they need to follow up — that trade-off is deliberate (a breaching whale doesn't wait politely).
+- **Liquidation is fire-and-forget.** `Trip` does not `WaitConfirm` on liquidation swaps. Operator can inspect tx hashes from the decision log if they need to follow up -- that trade-off is deliberate (a breaching whale doesn't wait politely).
 - **Per-chain policy is global.** `LiquidateSpot` either applies to every chain or none. Per-chain selectivity (e.g. "liquidate Solana legs but not EVM") needs a tiny wrapper around `Trip` for now.
 
 These are documented in `internal/agent/killswitch.go` itself; the source is the authoritative reference.
@@ -116,13 +116,13 @@ This is intentional friction. The killswitch fired (or was tripped) for a reason
 
 ## Where it lives
 
-- `internal/agent/killswitch.go` — implementation.
-- `internal/agent/killswitch_test.go` — `cancelOpenOrders` happy path / no-orders / one-failure-continues; `flattenPositions` short / long / flat-skipped; defaults regression guard; `Runtime.Trip` end-to-end.
-- `internal/exchange/exchange.go` — `Venue.OpenOrders` interface.
-- `internal/exchange/hyperliquid/venue.go` — Hyperliquid `OpenOrders` implementation.
-- `internal/risk/breakers.go` — per-agent breakers.
-- `internal/risk/policy.go` — pre-trade risk policy + `Limits()` accessor.
-- `internal/assets/usdc.go` — canonical USDC mint mapping per chain.
+- `internal/agent/killswitch.go` -- implementation.
+- `internal/agent/killswitch_test.go` -- `cancelOpenOrders` happy path / no-orders / one-failure-continues; `flattenPositions` short / long / flat-skipped; defaults regression guard; `Runtime.Trip` end-to-end.
+- `internal/exchange/exchange.go` -- `Venue.OpenOrders` interface.
+- `internal/exchange/hyperliquid/venue.go` -- Hyperliquid `OpenOrders` implementation.
+- `internal/risk/breakers.go` -- per-agent breakers.
+- `internal/risk/policy.go` -- pre-trade risk policy + `Limits()` accessor.
+- `internal/assets/usdc.go` -- canonical USDC mint mapping per chain.
 
 ## Next steps
 

--- a/apps/docs/docs/operations/trading-desk-ui.md
+++ b/apps/docs/docs/operations/trading-desk-ui.md
@@ -19,7 +19,7 @@ npm run dev          # http://127.0.0.1:5173
 
 The Vite dev server proxies `/v1/*` to `http://127.0.0.1:8080` (the permafrostd default), so the UI works against `make up` without you having to configure CORS.
 
-If the daemon isn't reachable, the UI falls back to **demo mode** — a small canned dataset (Pip + Boulder example agents) so you can preview the experience without `make up`. A yellow "demo mode (daemon unreachable)" banner makes the state unambiguous.
+If the daemon isn't reachable, the UI falls back to **demo mode** -- a small canned dataset (Pip + Boulder example agents) so you can preview the experience without `make up`. A yellow "demo mode (daemon unreachable)" banner makes the state unambiguous.
 
 ## Build
 
@@ -74,7 +74,7 @@ The UI never blank-screens. If the daemon is offline you still see a working das
 - NAV history chart (currently only the current value)
 - Trade-history view
 - Whiteout overlay when killswitch fires (Frostbite the Whale breaching)
-- Mobile breakpoints (desktop-first by design — this is an operator tool)
+- Mobile breakpoints (desktop-first by design -- this is an operator tool)
 - Light theme
 
 ## Dependencies (v1)
@@ -91,15 +91,15 @@ That's it. **No UI framework**, no state library, no router. Just React + tightl
 
 ## Where it lives
 
-- `apps/desk/src/characters/*.svg` — 8 hand-authored sprites + coin
-- `apps/desk/src/components/` — `Sprite`, `AgentCard`, `DecisionRow`, `DashboardChrome`, `Vault`, `CastShowcase`
-- `apps/desk/src/api/client.ts` — REST client + demo-mode fallback
-- `apps/desk/src/styles/global.css` — palette + animations
-- `apps/desk/vite.config.ts` — dev-proxy
-- `.github/workflows/ci.yml` `desk-ui` job — typecheck + build on every PR
+- `apps/desk/src/characters/*.svg` -- 8 hand-authored sprites + coin
+- `apps/desk/src/components/` -- `Sprite`, `AgentCard`, `DecisionRow`, `DashboardChrome`, `Vault`, `CastShowcase`
+- `apps/desk/src/api/client.ts` -- REST client + demo-mode fallback
+- `apps/desk/src/styles/global.css` -- palette + animations
+- `apps/desk/vite.config.ts` -- dev-proxy
+- `.github/workflows/ci.yml` `desk-ui` job -- typecheck + build on every PR
 
 ## Next steps
 
-- [The cast](/brand/cast) — who each sprite represents
-- [LLM-as-agent](/brand/llm-as-agent) — the thesis behind the narwhals
-- [Operations: deployment](/operations/deployment) — production deploys
+- [The cast](/brand/cast) -- who each sprite represents
+- [LLM-as-agent](/brand/llm-as-agent) -- the thesis behind the narwhals
+- [Operations: deployment](/operations/deployment) -- production deploys

--- a/apps/docs/docs/reference/cli.md
+++ b/apps/docs/docs/reference/cli.md
@@ -80,7 +80,7 @@ permafrost wallet import   --chain hyperliquid --from /tmp/hl-key   # file with 
 permafrost wallet path
 ```
 
-`--chain` accepts `solana` or `hyperliquid`. Both use `--from <file>` — the Solana importer accepts Phantom-style JSON arrays, base58 secrets, or hex; the Hyperliquid importer accepts hex (with or without `0x` prefix) in a file. (There is no `--hex` flag — write the key to a tempfile and `shred -u` it after.)
+`--chain` accepts `solana` or `hyperliquid`. Both use `--from <file>` -- the Solana importer accepts Phantom-style JSON arrays, base58 secrets, or hex; the Hyperliquid importer accepts hex (with or without `0x` prefix) in a file. (There is no `--hex` flag -- write the key to a tempfile and `shred -u` it after.)
 
 Keystore unlock uses the env var named in `wallet.passphrase_env` (defaults to `PERMAFROST_KEYSTORE_PASSPHRASE`). The [init wizard](/getting-started/init-and-doctor) generates this env file for you. See [keystore + backups](/operations/keystore-and-backups).
 
@@ -148,11 +148,11 @@ permafrost agent stop --all           # halt every agent
 `set-mode` is positional and just changes the persisted mode:
 
 ```bash
-permafrost agent set-mode <id> live      # state change only — does NOT prompt
+permafrost agent set-mode <id> live      # state change only -- does NOT prompt
 permafrost agent run     <id> --confirm-live    # explicit gate fires here
 ```
 
-The `--confirm-live` flag is currently only enforced by `agent run` (foreground). The daemon supervisor does not re-prompt — once an agent is `mode=live, status=running`, `permafrost serve` will start it. Tracked for hardening.
+The `--confirm-live` flag is currently only enforced by `agent run` (foreground). The daemon supervisor does not re-prompt -- once an agent is `mode=live, status=running`, `permafrost serve` will start it. Tracked for hardening.
 
 ### One-shot integration tick
 
@@ -169,13 +169,13 @@ permafrost strategy list
 permafrost strategy backtest <name> --csv funding.csv [--config-json '{...}']
 ```
 
-`backtest` looks the strategy name up in the registry — the same registry the daemon uses — so private strategies registered via `cmd/permafrost/strategies_local.go` are backtest-able too. See [private strategies](/strategies/private-strategies).
+`backtest` looks the strategy name up in the registry -- the same registry the daemon uses -- so private strategies registered via `cmd/permafrost/strategies_local.go` are backtest-able too. See [private strategies](/strategies/private-strategies).
 
 Reference strategies shipped in the OSS build:
 
-- `noop` — empty decision every tick; smoke-test only.
-- `dca_buy` — fixed USDC → spot every N hours. See [reference strategies](/strategies/reference-strategies).
-- `market_maker_basic` — paired bid/ask quoting on Hyperliquid with optional LLM veto.
+- `noop` -- empty decision every tick; smoke-test only.
+- `dca_buy` -- fixed USDC → spot every N hours. See [reference strategies](/strategies/reference-strategies).
+- `market_maker_basic` -- paired bid/ask quoting on Hyperliquid with optional LLM veto.
 
 To scaffold a new one: `permafrost strategy-new <name>`.
 
@@ -194,7 +194,7 @@ permafrost inference test --provider openrouter --model anthropic/claude-sonnet-
 permafrost swap quote --chain solana --in USDC --out WIF --amount 100
 ```
 
-Quotes only — does not broadcast. Useful for sanity-checking what an `OrderIntent` paired with a `SwapIntent` would experience.
+Quotes only -- does not broadcast. Useful for sanity-checking what an `OrderIntent` paired with a `SwapIntent` would experience.
 
 ## Risk
 
@@ -238,8 +238,8 @@ Equivalent to running the dedicated `permafrostd` binary. Loads every agent with
 
 ## Environment variables
 
-- `PERMAFROST_CONFIG` — config file path (default `./config.yaml`).
-- `PERMAFROST_HYPERLIQUID_NETWORK` — daemon-wide override of every agent's stored Hyperliquid network. Useful for "panic switch all agents to testnet" scenarios.
-- `PERMAFROST_KEYSTORE_PASSPHRASE` — passphrase to decrypt the keystore. Configurable via `wallet.passphrase_env` in `config.yaml` if you want a different env var name.
+- `PERMAFROST_CONFIG` -- config file path (default `./config.yaml`).
+- `PERMAFROST_HYPERLIQUID_NETWORK` -- daemon-wide override of every agent's stored Hyperliquid network. Useful for "panic switch all agents to testnet" scenarios.
+- `PERMAFROST_KEYSTORE_PASSPHRASE` -- passphrase to decrypt the keystore. Configurable via `wallet.passphrase_env` in `config.yaml` if you want a different env var name.
 - Per-provider inference API keys via the env vars referenced by `inference.providers.<name>.api_key_env` (e.g. `OPENROUTER_API_KEY`).
-- `ONEINCH_API_KEY` — for EVM swaps via 1inch.
+- `ONEINCH_API_KEY` -- for EVM swaps via 1inch.

--- a/apps/docs/docs/reference/sapi-overview.md
+++ b/apps/docs/docs/reference/sapi-overview.md
@@ -60,13 +60,13 @@ GoDoc: [pkg.go.dev/github.com/teslashibe/permafrost/pkg/inference](https://pkg.g
 
 Strategies in this single-module repo *can* import `internal/*` packages directly (Go's `internal` rule allows it within the same module), but doing so accepts that those internals may change without notice. The packages most commonly reached for:
 
-- `internal/assets` — the curated asset registry plus USDC helpers (`assets.LoadEmbedded()`, `assets.USDCMintFor(chain)`, `assets.USDCAsset(chain)`). Reasonable to import; the schema is stable.
-- `internal/wallet` — the keystore + signer abstractions. Avoid; strategies should not be touching keys.
-- `internal/agent` — the runtime itself. Avoid; you're a guest of this package, not its user.
+- `internal/assets` -- the curated asset registry plus USDC helpers (`assets.LoadEmbedded()`, `assets.USDCMintFor(chain)`, `assets.USDCAsset(chain)`). Reasonable to import; the schema is stable.
+- `internal/wallet` -- the keystore + signer abstractions. Avoid; strategies should not be touching keys.
+- `internal/agent` -- the runtime itself. Avoid; you're a guest of this package, not its user.
 
 ## Stability
 
-`pkg/strategy`, `pkg/types`, and `pkg/inference` are committed public APIs. Breaking changes follow semantic versioning — major-version bump or nothing. Anything outside `pkg/` is fair game to change between releases.
+`pkg/strategy`, `pkg/types`, and `pkg/inference` are committed public APIs. Breaking changes follow semantic versioning -- major-version bump or nothing. Anything outside `pkg/` is fair game to change between releases.
 
 ## Next steps
 

--- a/apps/docs/docs/strategies/decision-contract.md
+++ b/apps/docs/docs/strategies/decision-contract.md
@@ -44,10 +44,10 @@ type Decision struct {
 What the runtime does with each field:
 
 - **`Cancels`** are sent to the perp venue first.
-- **`Swaps`** execute and are awaited until confirmation. `BasisKey` is the join key — a swap and an order with the same `BasisKey` are treated as one paired action.
+- **`Swaps`** execute and are awaited until confirmation. `BasisKey` is the join key -- a swap and an order with the same `BasisKey` are treated as one paired action.
 - **`Orders`** are sent only after every swap with a matching `BasisKey` confirms. If a swap fails, the matching order is dropped.
 - **`Notes`** is persisted with the decision row. LLM rationales, debug strings, anything that helps you read your own decisions later.
-- **`Confidence`** is advisory — surfaced in the API and CLI for monitoring but does not influence execution.
+- **`Confidence`** is advisory -- surfaced in the API and CLI for monitoring but does not influence execution.
 
 ## `OrderIntent`
 
@@ -91,7 +91,7 @@ Same `DecisionInput` → same `Decision`. Period.
 What "same" means:
 
 - Same agent ID, same `Now`, same `Market` snapshot, same positions, same cash, same `Signals`, same `Limits` → byte-for-byte identical `Decision`.
-- Random number generators, current wall-clock time, network calls outside `Services` — all forbidden inside `Decide`.
+- Random number generators, current wall-clock time, network calls outside `Services` -- all forbidden inside `Decide`.
 - Caches that depend on previous tick output are fine but they *must* be derivable from prior `DecisionInput`s alone.
 
 This is what makes the backtester and the decision-replay machinery work. Break determinism and you break audit.

--- a/apps/docs/docs/strategies/private-strategies.md
+++ b/apps/docs/docs/strategies/private-strategies.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # Private strategies
 
-You don't have to publish a strategy to run it. The repo is laid out so you can drop a private strategy into your local clone, build, and run — without forking, without managing a second repo, and without leaking it to upstream.
+You don't have to publish a strategy to run it. The repo is laid out so you can drop a private strategy into your local clone, build, and run -- without forking, without managing a second repo, and without leaking it to upstream.
 
 ## The convention
 
@@ -21,7 +21,7 @@ strategies/
 
 ## Enabling private strategies in your build
 
-Permafrost ships **two** binaries — the daemon (`permafrostd`) and the CLI (`permafrost`) — and a strategy must be linked into *both* to be both runnable and backtest-able. Each binary has a symmetric pair of files:
+Permafrost ships **two** binaries -- the daemon (`permafrostd`) and the CLI (`permafrost`) -- and a strategy must be linked into *both* to be both runnable and backtest-able. Each binary has a symmetric pair of files:
 
 | File | Tracking | Purpose |
 |---|---|---|
@@ -70,7 +70,7 @@ For trading code, plan **at least two** of the above. Strategies that lose money
 
 Three failure modes:
 
-1. **`git add -f`** — bypasses `.gitignore`. Easy to do by accident with a wildcard. A pre-commit hook is good insurance:
+1. **`git add -f`** -- bypasses `.gitignore`. Easy to do by accident with a wildcard. A pre-commit hook is good insurance:
 
    ```bash title=".git/hooks/pre-commit"
    #!/bin/sh
@@ -85,7 +85,7 @@ Three failure modes:
 
 3. **Branch pushes.** A branch that includes a stash apply may carry private files. `git status` before every push.
 
-The `agent run` foreground iteration command lives on the CLI binary; the daemon `permafrostd` is the production-grade supervisor. Both need the same set of strategy registrations — that's why the four-file pattern exists. If you only ever run the daemon, you can skip the two `cmd/permafrost/strategies*.go` files, but `strategy backtest` will then refuse to load your private strategy by name.
+The `agent run` foreground iteration command lives on the CLI binary; the daemon `permafrostd` is the production-grade supervisor. Both need the same set of strategy registrations -- that's why the four-file pattern exists. If you only ever run the daemon, you can skip the two `cmd/permafrost/strategies*.go` files, but `strategy backtest` will then refuse to load your private strategy by name.
 
 ## Sharing a private strategy across machines
 

--- a/apps/docs/docs/strategies/reference-strategies.md
+++ b/apps/docs/docs/strategies/reference-strategies.md
@@ -9,15 +9,15 @@ The OSS build ships three strategies as reference implementations. Together they
 
 | Strategy | SwapIntent | OrderIntent | Cancels | LLM veto | Lives at |
 |---|---|---|---|---|---|
-| `noop` | — | — | — | — | `strategies/noop/` |
-| `dca_buy` | ✓ | — | — | — | `strategies/dca_buy/` |
-| `market_maker_basic` | — | ✓ | ✓ | ✓ | `strategies/market_maker_basic/` |
+| `noop` | -- | -- | -- | -- | `strategies/noop/` |
+| `dca_buy` | ✓ | -- | -- | -- | `strategies/dca_buy/` |
+| `market_maker_basic` | -- | ✓ | ✓ | ✓ | `strategies/market_maker_basic/` |
 
 ## `noop`
 
 The smallest strategy that satisfies the SAPI. ~20 lines of Go that
 return `Decision{}` every tick. Use it as a copy-paste starting point
-or as the smoke-test target for verifying your install — see
+or as the smoke-test target for verifying your install -- see
 [running noop](/getting-started/running-noop).
 
 ## `dca_buy`
@@ -145,7 +145,7 @@ tick → tickCount++
 ```
 
 `Warmup` fails fast if `use_llm_veto: true` but no inference provider
-is wired on the agent — the operator notices at startup, not on the
+is wired on the agent -- the operator notices at startup, not on the
 first decision tick.
 
 ### LLM veto
@@ -172,7 +172,7 @@ The response must match:
 ```
 
 A provider that returns `ErrUnsupportedFeature` (e.g. base Ollama
-model without JSON-Schema mode) is treated as `veto: false` — the
+model without JSON-Schema mode) is treated as `veto: false` -- the
 strategy quotes normally rather than blocking on a feature the model
 can't enforce.
 
@@ -191,9 +191,9 @@ permafrost agent start <id>
 
 ## v2 plans for the references
 
-- `dca_buy` — read prior buy times from `BasisPositions` so cooldown
+- `dca_buy` -- read prior buy times from `BasisPositions` so cooldown
   is restart-resilient.
-- `market_maker_basic` — explicit cancel emission for stale quotes
+- `market_maker_basic` -- explicit cancel emission for stale quotes
   (today the runtime's reduce-only handling drops them naturally as
   new quotes replace them).
 - A third reference (`grid_trader` or similar) demonstrating
@@ -201,6 +201,6 @@ permafrost agent start <id>
 
 ## Next steps
 
-- [Scaffolding a new strategy](/strategies/scaffolding) — `permafrost strategy-new`
+- [Scaffolding a new strategy](/strategies/scaffolding) -- `permafrost strategy-new`
 - [Decision contract](/strategies/decision-contract)
 - [Services](/strategies/services)

--- a/apps/docs/docs/strategies/sapi.md
+++ b/apps/docs/docs/strategies/sapi.md
@@ -30,7 +30,7 @@ That's it. `Name` returns the snake_case identifier; `Warmup` runs once after co
 type Constructor func(cfg map[string]any) (Strategy, error)
 ```
 
-`cfg` is the per-agent JSONB blob from the database — whatever the operator passed to `agent create --config-json`. Parse it into your typed config inside the constructor, apply defaults, validate, and return the strategy.
+`cfg` is the per-agent JSONB blob from the database -- whatever the operator passed to `agent create --config-json`. Parse it into your typed config inside the constructor, apply defaults, validate, and return the strategy.
 
 **Don't** take framework dependencies as constructor arguments. Pull them from `WarmupInput.Services` later. See [Services](/strategies/services).
 
@@ -50,11 +50,11 @@ func init() { strategy.Register(Name, New) }
 func New(cfg map[string]any) (strategy.Strategy, error) { /* ... */ }
 ```
 
-Registration is name-keyed (snake_case, must match what gets stored in `agents.strategy`). Double registration panics — that's intentional, so a typo surfaces at process start.
+Registration is name-keyed (snake_case, must match what gets stored in `agents.strategy`). Double registration panics -- that's intentional, so a typo surfaces at process start.
 
 ## End-to-end: writing your first strategy
 
-The fast path is the scaffolder — see [`strategy-new` scaffolding](/strategies/scaffolding):
+The fast path is the scaffolder -- see [`strategy-new` scaffolding](/strategies/scaffolding):
 
 ```bash
 permafrost strategy-new my_first_strategy
@@ -96,7 +96,7 @@ func (Strategy) Decide(_ context.Context, _ strategy.DecisionInput) (strategy.De
 }
 ```
 
-Enable it in both binaries (one line each — the daemon for runtime, the CLI for `strategy backtest`):
+Enable it in both binaries (one line each -- the daemon for runtime, the CLI for `strategy backtest`):
 
 ```go title="cmd/permafrostd/strategies.go"
 import _ "github.com/teslashibe/permafrost/strategies/my_first_strategy"

--- a/apps/docs/docs/strategies/scaffolding.md
+++ b/apps/docs/docs/strategies/scaffolding.md
@@ -39,7 +39,7 @@ For `permafrost strategy-new my_strategy`:
 
 ```
 strategies/my_strategy/
-├── README.md         # template — fill in your strategy's purpose + run instructions
+├── README.md         # template -- fill in your strategy's purpose + run instructions
 ├── strategy.go       # Strategy struct, init(), New(), Name(), Warmup(), Decide() stubs
 └── strategy_test.go  # Two starter tests: TestNew_ReturnsStrategy + TestDecide_NoOp
 ```
@@ -70,7 +70,7 @@ The command refuses three things up-front, before touching the filesystem:
 
 ## Idempotency
 
-`appendImport` is idempotent: re-running with the same name (after the first attempt failed mid-way) does not duplicate the import line. The directory check and the registry check stay strict — you'll get a clear error rather than a half-finished tree.
+`appendImport` is idempotent: re-running with the same name (after the first attempt failed mid-way) does not duplicate the import line. The directory check and the registry check stay strict -- you'll get a clear error rather than a half-finished tree.
 
 ## Templates
 
@@ -81,7 +81,7 @@ The command refuses three things up-front, before touching the filesystem:
 | `maker` | planned | Perp-only OrderIntent skeleton with optional LLM veto |
 | `dca` | planned | SwapIntent-only DCA skeleton |
 
-For now, `dca_buy`, `market_maker_basic`, and (for maintainers) `funding_arb_basic` are the working examples to copy from while the templates land — see [reference strategies](/strategies/reference-strategies).
+For now, `dca_buy`, `market_maker_basic`, and (for maintainers) `funding_arb_basic` are the working examples to copy from while the templates land -- see [reference strategies](/strategies/reference-strategies).
 
 ## Top-level command name
 
@@ -96,12 +96,12 @@ This is purely an internal-organisation quirk of how the command was wired into 
 
 ## Where it lives
 
-- `internal/cli/strategy_new.go` — the command body and `appendImport` helper.
-- `internal/cli/templates/strategy/noop/*.tmpl` — the embedded template files (`go:embed`).
-- `internal/cli/strategy_new_test.go` — 7 tests covering name validation, scaffolding, `--private`, registry-collision refusal, existing-dir refusal, unshipped-template refusal, `appendImport` idempotency.
+- `internal/cli/strategy_new.go` -- the command body and `appendImport` helper.
+- `internal/cli/templates/strategy/noop/*.tmpl` -- the embedded template files (`go:embed`).
+- `internal/cli/strategy_new_test.go` -- 7 tests covering name validation, scaffolding, `--private`, registry-collision refusal, existing-dir refusal, unshipped-template refusal, `appendImport` idempotency.
 
 ## Next steps
 
 - [The Strategy SAPI](/strategies/sapi)
-- [Reference strategies](/strategies/reference-strategies) — copy from `dca_buy` or `market_maker_basic` for the `basis` / `maker` / `dca` shapes
-- [Private strategies](/strategies/private-strategies) — backups, sharing across machines, leak prevention
+- [Reference strategies](/strategies/reference-strategies) -- copy from `dca_buy` or `market_maker_basic` for the `basis` / `maker` / `dca` shapes
+- [Private strategies](/strategies/private-strategies) -- backups, sharing across machines, leak prevention

--- a/apps/docs/docs/strategies/services.md
+++ b/apps/docs/docs/strategies/services.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Services
 
-`Services` is the bag of framework-provided dependencies that strategies receive in `WarmupInput`. It's the canonical extension point for new framework features that strategies may depend on — add fields here rather than expanding `WarmupInput` or `DecisionInput`.
+`Services` is the bag of framework-provided dependencies that strategies receive in `WarmupInput`. It's the canonical extension point for new framework features that strategies may depend on -- add fields here rather than expanding `WarmupInput` or `DecisionInput`.
 
 ## The struct
 
@@ -56,7 +56,7 @@ func (s *Strategy) Warmup(_ context.Context, in strategy.WarmupInput) error {
 }
 ```
 
-`Warmup` is once-guarded by the runtime — even if a foreground CLI drives ticks via `TickOnce` instead of `Start`, the framework calls `Warmup` exactly once before the first decision. Authors can rely on Warmup having completed.
+`Warmup` is once-guarded by the runtime -- even if a foreground CLI drives ticks via `TickOnce` instead of `Start`, the framework calls `Warmup` exactly once before the first decision. Authors can rely on Warmup having completed.
 
 The `Warmup` error path matters: validation failures here surface as agent-launch errors, so the operator notices immediately. Without this, the strategy would launch and fail on the first decision tick.
 
@@ -83,9 +83,9 @@ Add to `Services`:
 
 Don't add to `Services`:
 
-- Strategy-specific config — that goes on the typed `Config` struct your `Constructor` parses.
-- Per-tick state — that's `DecisionInput`.
-- Things the strategy can build for itself (e.g. an asset registry — `assets.LoadEmbedded()` is one line).
+- Strategy-specific config -- that goes on the typed `Config` struct your `Constructor` parses.
+- Per-tick state -- that's `DecisionInput`.
+- Things the strategy can build for itself (e.g. an asset registry -- `assets.LoadEmbedded()` is one line).
 
 ## Next steps
 

--- a/apps/docs/docs/strategies/testing.md
+++ b/apps/docs/docs/strategies/testing.md
@@ -4,14 +4,14 @@ sidebar_position: 5
 
 # Testing strategies
 
-Strategies are pure Go packages — `go test ./strategies/<your_strategy>/...` works exactly as you'd expect. This page covers the framework-specific patterns that make strategy testing straightforward.
+Strategies are pure Go packages -- `go test ./strategies/<your_strategy>/...` works exactly as you'd expect. This page covers the framework-specific patterns that make strategy testing straightforward.
 
 ## Unit tests
 
 Strategy logic should be testable without touching the network. Two helpers make that easy:
 
-- **`pkg/inference/mock`** — a `Provider` implementation that returns scripted responses. Use it for any LLM-veto path so unit tests don't make real network calls.
-- **A typed-config test constructor** — strategies that need to assert on edge cases of their own typed `Config` commonly ship a `NewFromTypedConfig(cfg, …)` helper alongside the registry-facing `New(map[string]any)`. The helper accepts the typed struct directly and bypasses the JSONB-style parser, so tests can stay focused on strategy logic rather than config plumbing.
+- **`pkg/inference/mock`** -- a `Provider` implementation that returns scripted responses. Use it for any LLM-veto path so unit tests don't make real network calls.
+- **A typed-config test constructor** -- strategies that need to assert on edge cases of their own typed `Config` commonly ship a `NewFromTypedConfig(cfg, …)` helper alongside the registry-facing `New(map[string]any)`. The helper accepts the typed struct directly and bypasses the JSONB-style parser, so tests can stay focused on strategy logic rather than config plumbing.
 
 Example:
 
@@ -91,7 +91,7 @@ permafrost serve                   # picks it up
 
 Paper mode reads real market data and produces real `Decision`s but does not place real orders. Pair it with `--network testnet` for the perp venue when iterating on a new strategy.
 
-Promoting to live requires `--confirm-live` and the appropriate signers in the keystore — see [risk and the killswitch](/concepts/risk-and-killswitch).
+Promoting to live requires `--confirm-live` and the appropriate signers in the keystore -- see [risk and the killswitch](/concepts/risk-and-killswitch).
 
 ## Next steps
 

--- a/apps/docs/src/pages/index.module.css
+++ b/apps/docs/src/pages/index.module.css
@@ -118,13 +118,6 @@
   letter-spacing: -0.02em;
   color: var(--ice-bright);
 }
-.heroTitle .gradient {
-  background: linear-gradient(120deg, var(--aurora-c) 0%, var(--aurora-p) 60%, var(--aurora-g) 100%);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  color: transparent;
-}
 
 .heroSubtitle {
   font-size: clamp(1rem, 2vw, 1.25rem);

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -61,7 +61,7 @@ const PROPS: PropEntry[] = [
     body: (
       <>
         Strategies are deterministic Go. The LLM can veto entries, score candidates,
-        and tune thresholds &mdash; but never produces orders directly.
+        and tune thresholds -- but never produces orders directly.
       </>
     ),
   },
@@ -107,7 +107,7 @@ function HeroBanner() {
           v0.1.0 &middot; the camp is open
         </div>
         <h1 className={styles.heroTitle}>
-          Permafrost &mdash; <span className={styles.gradient}>your AI trading desk</span>,<br />
+          Permafrost. Your AI trading desk,<br />
           locked in the ice.
         </h1>
         <p className={styles.heroSubtitle}>
@@ -259,7 +259,7 @@ function CTA() {
 export default function Home(): ReactNode {
   return (
     <Layout
-      title="Permafrost &mdash; your AI trading desk, locked in the ice"
+      title="Permafrost -- your AI trading desk, locked in the ice"
       description="Open-source Go framework for self-custodied algorithmic trading with optional LLM augmentation. Hummingbot-style strategies, real killswitch, arctic-themed operator UI.">
       <HeroBanner />
       <QuickStart />

--- a/apps/docs/static/img/brand/narwhal.svg
+++ b/apps/docs/static/img/brand/narwhal.svg
@@ -1,53 +1,104 @@
 <!--
-  Narwhal  LLM advisor floating beside its penguin. Horn glows
-  (.glow class) when the LLM is being consulted; brighter on a veto.
-
-  Hand-authored pixel art, 32x32 logical grid.
-  Palette: lavender body #B5A6E0, navy back #4D3B7C, white belly #E9E4F8,
-           horn iridescent #E0D3FF + highlight #FFFFFF, eye #1B1F2A.
+  Narwhal advisor (Elf-style). Big friendly white narwhal floating
+  beside its assigned penguin. Single continuous whale silhouette
+  with a long spiral tusk extending forward to the right. Horn glows
+  via .glow / .glow-halo classes when the LLM is consulted.
+  Hand-authored pixel art, 32x32 grid, scaled to 256x256.
+  Palette: white #ECF6FF, brighter belly #FFFFFF, navy outline #1B2A4E,
+           horn cream #FFFFFF + spiral shading #B5A6E0,
+           pink cheek #F4B6C0, eye black #1B1F2A.
 -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="256" height="256" shape-rendering="crispEdges" role="img" aria-label="Narwhal advisor">
   <title>Narwhal advisor</title>
   <desc>Floats beside its penguin trader; horn glows when the LLM is consulted.</desc>
 
-  <!-- Horn -->
-  <rect x="2"  y="13" width="1"  height="1" fill="#FFFFFF" class="glow"/>
-  <rect x="3"  y="13" width="3"  height="1" fill="#E0D3FF" class="glow"/>
-  <rect x="6"  y="13" width="2"  height="1" fill="#B5A6E0"/>
+  <!-- Glow halo around the horn (invisible by default; .glow-halo
+       opacity is bumped to ~0.85 when the parent .actor has class
+       "glowing"). -->
+  <rect x="22" y="11" width="10" height="3" fill="#E0D3FF" class="glow-halo" opacity="0"/>
 
-  <!-- Head + body outline -->
-  <rect x="7"  y="11" width="20" height="1" fill="#4D3B7C"/>
-  <rect x="6"  y="12" width="1"  height="1" fill="#4D3B7C"/>
-  <rect x="6"  y="14" width="1"  height="2" fill="#4D3B7C"/>
-  <rect x="7"  y="16" width="1"  height="1" fill="#4D3B7C"/>
-  <rect x="8"  y="17" width="20" height="1" fill="#4D3B7C"/>
+  <!-- =========================================================
+       Body silhouette (single continuous shape).
+       Navy outline first, then white fill on top.
+       ========================================================= -->
 
-  <!-- Body fill (lavender top, white belly) -->
-  <rect x="7"  y="12" width="20" height="2" fill="#4D3B7C"/>
-  <rect x="7"  y="14" width="20" height="2" fill="#B5A6E0"/>
-  <rect x="8"  y="16" width="20" height="1" fill="#E9E4F8"/>
+  <!-- Top edge (curving up from tail to head) -->
+  <rect x="9"  y="9"  width="14" height="1" fill="#1B2A4E"/>
+  <rect x="7"  y="10" width="2"  height="1" fill="#1B2A4E"/>
+  <rect x="23" y="10" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="6"  y="11" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="23" y="11" width="1"  height="3" fill="#1B2A4E"/>
+  <!-- Tail/fluke spine on far left -->
+  <rect x="2"  y="11" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="3"  y="12" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="4"  y="13" width="2"  height="1" fill="#1B2A4E"/>
+  <rect x="5"  y="14" width="1"  height="3" fill="#1B2A4E"/>
+  <rect x="2"  y="19" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="3"  y="18" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="4"  y="17" width="2"  height="1" fill="#1B2A4E"/>
+  <!-- Bottom edge (mirror of top) -->
+  <rect x="6"  y="17" width="2"  height="1" fill="#1B2A4E"/>
+  <rect x="6"  y="18" width="1"  height="1" fill="#1B2A4E"/>
+  <rect x="7"  y="19" width="2"  height="1" fill="#1B2A4E"/>
+  <rect x="9"  y="20" width="14" height="1" fill="#1B2A4E"/>
+  <rect x="22" y="19" width="1"  height="1" fill="#1B2A4E"/>
 
-  <!-- Eye -->
-  <rect x="10" y="13" width="1"  height="1" fill="#1B1F2A"/>
+  <!-- =========================================================
+       Body fill (white) - one continuous interior
+       ========================================================= -->
+  <rect x="9"  y="10" width="14" height="10" fill="#ECF6FF"/>
+  <rect x="7"  y="11" width="16" height="8"  fill="#ECF6FF"/>
+  <rect x="6"  y="12" width="17" height="6"  fill="#ECF6FF"/>
+  <rect x="5"  y="13" width="18" height="4"  fill="#ECF6FF"/>
 
-  <!-- Smile -->
-  <rect x="11" y="15" width="2"  height="1" fill="#4D3B7C"/>
+  <!-- Brighter belly highlight -->
+  <rect x="9"  y="16" width="13" height="3" fill="#FFFFFF"/>
+  <rect x="11" y="17" width="9"  height="2" fill="#FFFFFF"/>
 
-  <!-- Tail -->
-  <rect x="27" y="11" width="1"  height="1" fill="#4D3B7C"/>
-  <rect x="28" y="10" width="2"  height="2" fill="#4D3B7C"/>
-  <rect x="27" y="17" width="1"  height="1" fill="#4D3B7C"/>
-  <rect x="28" y="17" width="2"  height="2" fill="#4D3B7C"/>
-  <rect x="29" y="13" width="1"  height="3" fill="#B5A6E0"/>
+  <!-- Top highlight (sleek look) -->
+  <rect x="11" y="11" width="9"  height="1" fill="#FFFFFF"/>
 
-  <!-- Spots (lavender) -->
-  <rect x="14" y="14" width="1"  height="1" fill="#4D3B7C"/>
-  <rect x="18" y="13" width="1"  height="1" fill="#4D3B7C"/>
-  <rect x="22" y="14" width="1"  height="1" fill="#4D3B7C"/>
+  <!-- =========================================================
+       Spiral tusk - extends from snout to right edge
+       ========================================================= -->
+  <!-- Tusk outline (slim, 1px tall) -->
+  <rect x="24" y="11" width="7" height="1" fill="#1B2A4E"/>
+  <rect x="24" y="13" width="7" height="1" fill="#1B2A4E"/>
+  <!-- Tusk fill (cream/white) -->
+  <rect x="24" y="12" width="7" height="1" fill="#FFFFFF" class="glow"/>
+  <!-- Spiral marks (every 2px) -->
+  <rect x="25" y="12" width="1" height="1" fill="#B5A6E0" class="glow"/>
+  <rect x="27" y="12" width="1" height="1" fill="#B5A6E0" class="glow"/>
+  <rect x="29" y="12" width="1" height="1" fill="#B5A6E0" class="glow"/>
+  <!-- Tusk tip -->
+  <rect x="31" y="12" width="1" height="1" fill="#FFFFFF" class="glow"/>
 
-  <!-- Optional glow halo around horn (visible only when .glow CSS class
-       opacity is bumped from 0 ? 1 in the stylesheet) -->
-  <rect x="1"  y="13" width="1"  height="1" fill="#E0D3FF" class="glow-halo" opacity="0"/>
-  <rect x="2"  y="12" width="4"  height="1" fill="#E0D3FF" class="glow-halo" opacity="0"/>
-  <rect x="2"  y="14" width="4"  height="1" fill="#E0D3FF" class="glow-halo" opacity="0"/>
+  <!-- =========================================================
+       Face (right side of the body)
+       ========================================================= -->
+  <!-- Big friendly eye -->
+  <rect x="18" y="13" width="2" height="2" fill="#1B1F2A"/>
+  <rect x="18" y="13" width="1" height="1" fill="#FFFFFF"/>
+
+  <!-- Pink cheek blush -->
+  <rect x="20" y="15" width="2" height="1" fill="#F4B6C0"/>
+
+  <!-- Smile (a couple of pixels suggesting an upturn) -->
+  <rect x="20" y="16" width="1" height="1" fill="#1B2A4E"/>
+  <rect x="21" y="17" width="1" height="1" fill="#1B2A4E"/>
+  <rect x="22" y="17" width="1" height="1" fill="#1B2A4E"/>
+
+  <!-- =========================================================
+       Tail fluke (left edge, vertical spread)
+       ========================================================= -->
+  <rect x="3"  y="13" width="1" height="2" fill="#ECF6FF"/>
+  <rect x="2"  y="12" width="1" height="2" fill="#ECF6FF"/>
+  <rect x="3"  y="15" width="2" height="2" fill="#ECF6FF"/>
+  <rect x="3"  y="17" width="1" height="1" fill="#ECF6FF"/>
+  <rect x="2"  y="18" width="1" height="1" fill="#ECF6FF"/>
+
+  <!-- Subtle dorsal nub -->
+  <rect x="14" y="9"  width="3" height="1" fill="#ECF6FF"/>
+  <rect x="15" y="8"  width="2" height="1" fill="#ECF6FF"/>
+  <rect x="14" y="9"  width="3" height="1" fill="#1B2A4E"/>
 </svg>


### PR DESCRIPTION
Three small UX fixes per user feedback.

## (1) Narwhal sprite reverted to v0.1.0

The earlier in-branch swing at a rounder narwhal was unnecessary -- the existing Trading Desk sprite is the source of truth and the docs should show what's actually in the shipped product. Reverted both copies:
- `apps/desk/src/characters/narwhal.svg`
- `apps/docs/static/img/brand/narwhal.svg`

via `git show v0.1.0:...`. They now match.

## (2) Dropped the gradient text on the docs hero title

The "your AI trading desk" slice was rendered as a cyan/purple/green `-webkit-background-clip: text` gradient. Flagged as tacky. Title is now solid white:

> Permafrost. Your AI trading desk, locked in the ice.

Em-dash separator dropped too (see below); the period gives the same beat without the flourish. Also removed the `.gradient` class from `index.module.css` so no dead CSS lingers.

## (3) Stripped em-dashes from every doc + README

Replacement rules:
- `' \u2014 '` (em-dash with surrounding spaces) -> `' -- '`
- bare `\u2014` (no surrounding spaces) -> `-`
- `&mdash;` HTML entity in JSX -> `--`

**31 files updated.** Verified: zero em-dashes or `&mdash;` entities remain anywhere in `apps/docs/`, `apps/desk/README.md`, or root `README.md`.

## Verification

- `npm run build` in `apps/docs/` clean (zero broken-link errors)
- In-IDE browser preview: title renders solid white, cast section shows the v0.1.0 narwhal, no em-dash anywhere

## Test plan

- [x] Docusaurus build clean
- [x] Visual smoke test
- [x] Grep for remaining em-dashes returns 0 hits