### PR TITLE
feat(demo): three-subnet market so alpha_momentum and alpha_yield actually trade

### DIFF
--- a/internal/agent/store.go
+++ b/internal/agent/store.go
@@ -552,11 +552,21 @@ ORDER BY opened_at`, agentID)
 	return out, rows.Err()
 }
 
-// RecentDecisions returns the most recent decisions for an agent, oldest first.
+// RecentDecisions returns the most recent decisions for an agent, newest first.
+// NumOrders + NumSwaps are computed at read time from the JSONB
+// `decision` column so callers don't have to re-parse the rationale.
 func (s *Store) RecentDecisions(ctx context.Context, agentID string, since time.Time, limit int) ([]DecisionRow, error) {
 	rows, err := s.pool.Query(ctx, `
-SELECT time, decision_id, COALESCE(rationale,''), COALESCE(provider,''), COALESCE(model,''), tokens_in, tokens_out, cost_usd
-FROM agent_decisions WHERE agent_id = $1 AND time >= $2 ORDER BY time DESC LIMIT $3`,
+SELECT time, decision_id, COALESCE(rationale,''),
+       COALESCE(provider,''), COALESCE(model,''),
+       tokens_in, tokens_out, cost_usd,
+       CASE WHEN jsonb_typeof(decision->'Orders') = 'array'
+            THEN jsonb_array_length(decision->'Orders') ELSE 0 END AS num_orders,
+       CASE WHEN jsonb_typeof(decision->'Swaps') = 'array'
+            THEN jsonb_array_length(decision->'Swaps') ELSE 0 END AS num_swaps
+FROM agent_decisions
+WHERE agent_id = $1 AND time >= $2
+ORDER BY time DESC LIMIT $3`,
 		agentID, since, limit)
 	if err != nil {
 		return nil, err
@@ -565,7 +575,12 @@ FROM agent_decisions WHERE agent_id = $1 AND time >= $2 ORDER BY time DESC LIMIT
 	out := make([]DecisionRow, 0)
 	for rows.Next() {
 		var r DecisionRow
-		if err := rows.Scan(&r.Time, &r.DecisionID, &r.Rationale, &r.Provider, &r.Model, &r.TokensIn, &r.TokensOut, &r.CostUSD); err != nil {
+		if err := rows.Scan(
+			&r.Time, &r.DecisionID, &r.Rationale,
+			&r.Provider, &r.Model,
+			&r.TokensIn, &r.TokensOut, &r.CostUSD,
+			&r.NumOrders, &r.NumSwaps,
+		); err != nil {
 			return nil, err
 		}
 		out = append(out, r)
@@ -573,7 +588,8 @@ FROM agent_decisions WHERE agent_id = $1 AND time >= $2 ORDER BY time DESC LIMIT
 	return out, rows.Err()
 }
 
-// DecisionRow is a row-shaped subset of agent_decisions used by the CLI.
+// DecisionRow is a row-shaped subset of agent_decisions used by the CLI
+// and HTTP API.
 type DecisionRow struct {
 	Time       time.Time
 	DecisionID string
@@ -583,6 +599,8 @@ type DecisionRow struct {
 	TokensIn   int
 	TokensOut  int
 	CostUSD    float64
+	NumOrders  int
+	NumSwaps   int
 }
 
 func orZero(m map[string]any) map[string]any {

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -128,49 +128,18 @@ func (s *Server) listDecisionsHandler(c *fiber.Ctx) error {
 	}
 	out := make([]DecisionLite, 0, len(rows))
 	for _, r := range rows {
-		num := parseDecisionCounters(r.Rationale)
 		out = append(out, DecisionLite{
-			ID:        r.DecisionID,
-			AgentID:   id,
-			TS:        r.Time.UTC(),
+			ID:         r.DecisionID,
+			AgentID:    id,
+			TS:         r.Time.UTC(),
 			Confidence: 0, // not persisted in agent_decisions today
-			Notes:     r.Rationale,
-			NumOrders: num.orders,
-			NumSwaps:  num.swaps,
-			LLMUsed:   r.Provider != "",
+			Notes:      r.Rationale,
+			NumOrders:  r.NumOrders,
+			NumSwaps:   r.NumSwaps,
+			LLMUsed:    r.Provider != "",
 		})
 	}
 	return c.JSON(out)
-}
-
-type decisionCounters struct{ orders, swaps int }
-
-// parseDecisionCounters extracts swap/order counts from the rationale
-// string. Runtime.tick logs "swaps=N orders=N cancels=N" tails on every
-// tick; we look for those literals as a cheap proxy until the schema
-// gains explicit columns. Absent counters → zero.
-func parseDecisionCounters(rationale string) decisionCounters {
-	var d decisionCounters
-	d.orders = parseAfter(rationale, "orders=")
-	d.swaps = parseAfter(rationale, "swaps=")
-	return d
-}
-
-func parseAfter(s, marker string) int {
-	i := strings.Index(s, marker)
-	if i < 0 {
-		return 0
-	}
-	rest := s[i+len(marker):]
-	end := 0
-	for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
-		end++
-	}
-	if end == 0 {
-		return 0
-	}
-	n, _ := strconv.Atoi(rest[:end])
-	return n
 }
 
 // _ ensures the agent package import is not optimised out when the

--- a/internal/api/agents_test.go
+++ b/internal/api/agents_test.go
@@ -9,28 +9,6 @@ import (
 	"github.com/teslashibe/permafrost/internal/telemetry"
 )
 
-func TestParseDecisionCounters(t *testing.T) {
-	cases := []struct {
-		in     string
-		orders int
-		swaps  int
-	}{
-		{"alpha_dca: buying 1 TAO each of [SN8] swaps=3 orders=0 cancels=0", 0, 3},
-		{"swaps=1", 0, 1},
-		{"orders=42 swaps=7", 42, 7},
-		{"no counters here", 0, 0},
-		{"swaps=", 0, 0},
-		{"swaps=abc", 0, 0},
-	}
-	for _, tc := range cases {
-		got := parseDecisionCounters(tc.in)
-		if got.orders != tc.orders || got.swaps != tc.swaps {
-			t.Errorf("parseDecisionCounters(%q): got orders=%d swaps=%d, want orders=%d swaps=%d",
-				tc.in, got.orders, got.swaps, tc.orders, tc.swaps)
-		}
-	}
-}
-
 // TestListAgents_NoStore proves the handler returns 503 (not crash, not
 // leaking nil) when the daemon was started without a database.
 func TestListAgents_NoStore(t *testing.T) {

--- a/internal/cli/bittensor.go
+++ b/internal/cli/bittensor.go
@@ -48,24 +48,33 @@ endpoint.`,
 // signer (default //Alice for devnet). Prints the new netuid so the
 // caller can pipe it into agent configs.
 func newBittensorBootstrapCmd() *cobra.Command {
-	var fromURI string
+	var (
+		fromURI string
+		count   int
+	)
 	cmd := &cobra.Command{
 		Use:   "bootstrap",
-		Short: "Create + activate a fresh tradeable subnet (devnet helper)",
-		Long: `Bootstrap creates a new subnet via SubtensorModule.register_network and
-activates it via start_call. The new subnet has a populated AMM pool
+		Short: "Create + activate fresh tradeable subnet(s) (devnet helper)",
+		Long: `Bootstrap creates one or more new subnets via SubtensorModule.register_network
+and activates each via start_call. Each new subnet has a populated AMM pool
 and accepts add_stake immediately.
+
+--count N creates N subnets in sequence so a multi-subnet universe can be
+spun up in a single command (used by make demo-bittensor to give the
+momentum/yield strategies a real choice of subnets to trade).
 
 Use against a local subtensor-localnet docker image. The default signer
 is //Alice (the well-known devnet sudo account).
 
 Mainnet usage: don't. The registration burn cost on mainnet is several
-hundred TAO; if you really want to do this, use btcli or call
-SubtensorModule.register_network from a real wallet.`,
+hundred TAO per subnet.`,
 		RunE: func(c *cobra.Command, _ []string) error {
 			g := FromContext(c.Context())
 			if g == nil {
 				return fmt.Errorf("globals not initialised")
+			}
+			if count < 1 {
+				return fmt.Errorf("--count must be >= 1, got %d", count)
 			}
 			rpcURL := g.Config.Bittensor.ResolvedRPCURL()
 			if !strings.Contains(rpcURL, "localhost") && !strings.Contains(rpcURL, "127.0.0.1") {
@@ -78,53 +87,65 @@ SubtensorModule.register_network from a real wallet.`,
 			if err != nil {
 				return fmt.Errorf("derive signer from URI %q: %w", fromURI, err)
 			}
-			fmt.Fprintf(os.Stdout, "Bootstrapping subnet as %s (URI %s)\n", signer.Address(), fromURI)
+			fmt.Fprintf(os.Stdout, "Bootstrapping %d subnet(s) as %s (URI %s)\n",
+				count, signer.Address(), fromURI)
 
 			client := btchain.NewClient(rpcURL)
 			defer client.Close()
 
-			countBefore, err := client.SubnetCount(c.Context())
-			if err != nil {
-				return fmt.Errorf("subnet count: %w", err)
+			netuids := make([]uint16, 0, count)
+			for i := 0; i < count; i++ {
+				countBefore, err := client.SubnetCount(c.Context())
+				if err != nil {
+					return fmt.Errorf("subnet count: %w", err)
+				}
+				fmt.Fprintf(os.Stdout, "\n[%d/%d] → register_network …\n", i+1, count)
+				if _, err := client.RegisterNetwork(c.Context(), signer, signer.PublicKey(), btchain.SubmitOptions{
+					WaitTimeout: 30 * time.Second,
+				}); err != nil {
+					return fmt.Errorf("register_network: %w", err)
+				}
+				time.Sleep(2 * time.Second)
+
+				countAfter, err := client.SubnetCount(c.Context())
+				if err != nil {
+					return fmt.Errorf("subnet count after: %w", err)
+				}
+				if countAfter <= countBefore {
+					return fmt.Errorf("subnet count did not grow: %d → %d", countBefore, countAfter)
+				}
+				netuid := countAfter - 1
+				fmt.Fprintf(os.Stdout, "      ✓ new subnet netuid = %d\n", netuid)
+
+				fmt.Fprintln(os.Stdout, "      → start_call …")
+				if _, err := client.StartCall(c.Context(), signer, netuid, btchain.SubmitOptions{
+					WaitTimeout: 30 * time.Second,
+				}); err != nil {
+					return fmt.Errorf("start_call netuid=%d: %w", netuid, err)
+				}
+				time.Sleep(2 * time.Second)
+
+				if price, err := client.CurrentAlphaPrice(c.Context(), netuid); err == nil {
+					fmt.Fprintf(os.Stdout, "      ✓ AMM live: SN%d alpha price = %s TAO\n",
+						netuid, price.StringFixed(9))
+				}
+				netuids = append(netuids, netuid)
 			}
 
-			fmt.Fprintln(os.Stdout, "  → register_network …")
-			if _, err := client.RegisterNetwork(c.Context(), signer, signer.PublicKey(), btchain.SubmitOptions{
-				WaitTimeout: 30 * time.Second,
-			}); err != nil {
-				return fmt.Errorf("register_network: %w", err)
+			// Build the subnets list as JSON for easy consumption by
+			// scripts (`subnets: [2,3,4]`).
+			parts := make([]string, len(netuids))
+			for i, n := range netuids {
+				parts[i] = fmt.Sprintf("%d", n)
 			}
-			time.Sleep(2 * time.Second)
-
-			countAfter, err := client.SubnetCount(c.Context())
-			if err != nil {
-				return fmt.Errorf("subnet count after: %w", err)
-			}
-			if countAfter <= countBefore {
-				return fmt.Errorf("subnet count did not grow: %d → %d", countBefore, countAfter)
-			}
-			netuid := countAfter - 1
-			fmt.Fprintf(os.Stdout, "  ✓ new subnet netuid = %d\n", netuid)
-
-			fmt.Fprintln(os.Stdout, "  → start_call …")
-			if _, err := client.StartCall(c.Context(), signer, netuid, btchain.SubmitOptions{
-				WaitTimeout: 30 * time.Second,
-			}); err != nil {
-				return fmt.Errorf("start_call: %w", err)
-			}
-			time.Sleep(2 * time.Second)
-
-			price, err := client.CurrentAlphaPrice(c.Context(), netuid)
-			if err == nil {
-				fmt.Fprintf(os.Stdout, "  ✓ AMM live: SN%d alpha price = %s TAO\n", netuid, price.StringFixed(9))
-			}
-
 			fmt.Fprintln(os.Stdout, "")
-			fmt.Fprintf(os.Stdout, "Subnet %d ready. Configure strategies with subnets: [%d]\n", netuid, netuid)
+			fmt.Fprintf(os.Stdout, "%d subnet(s) ready. Configure strategies with subnets: [%s]\n",
+				len(netuids), strings.Join(parts, ","))
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&fromURI, "from-uri", "//Alice", "Substrate URI for the bootstrap signer")
+	cmd.Flags().IntVar(&count, "count", 1, "number of subnets to create (default 1)")
 	return cmd
 }
 

--- a/scripts/demo-bittensor.sh
+++ b/scripts/demo-bittensor.sh
@@ -236,24 +236,29 @@ else
   ok "bittensor key already in keystore"
 fi
 
-# ─── 7b. bootstrap a tradeable subnet on the local subtensor ─────────────
-step "Bootstrapping a tradeable subnet on the local subtensor…"
-NETUID_FILE="$DEMO_DIR/netuid"
-if [[ ! -f "$NETUID_FILE" ]]; then
-  bootstrap_out=$(permafrost --config "$DEMO_CONFIG" bittensor bootstrap --from-uri "//Alice" 2>&1) \
+# ─── 7b. bootstrap THREE tradeable subnets on the local subtensor ────────
+# Three subnets give the momentum + yield strategies a real universe to
+# choose from. Without multiple subnets they have no signal: there's
+# nothing to rotate INTO and nothing to compare stability ACROSS.
+step "Bootstrapping 3 tradeable subnets on the local subtensor…"
+NETUIDS_FILE="$DEMO_DIR/netuids"
+if [[ ! -f "$NETUIDS_FILE" ]]; then
+  bootstrap_out=$(permafrost --config "$DEMO_CONFIG" bittensor bootstrap --from-uri "//Alice" --count 3 2>&1) \
     || { fail "bootstrap failed: $bootstrap_out"; exit 3; }
   echo "$bootstrap_out"
-  NETUID=$(echo "$bootstrap_out" | grep -oE 'subnets: \[[0-9]+\]' | grep -oE '[0-9]+')
-  if [[ -z "$NETUID" ]]; then
-    fail "could not parse netuid from bootstrap output"
+  NETUIDS_CSV=$(echo "$bootstrap_out" | grep -oE 'subnets: \[[0-9,]+\]' | grep -oE '[0-9,]+')
+  if [[ -z "$NETUIDS_CSV" ]]; then
+    fail "could not parse netuids from bootstrap output"
     exit 3
   fi
-  echo "$NETUID" > "$NETUID_FILE"
+  echo "$NETUIDS_CSV" > "$NETUIDS_FILE"
 else
-  NETUID=$(cat "$NETUID_FILE")
-  ok "re-using existing tradeable subnet: SN$NETUID"
+  NETUIDS_CSV=$(cat "$NETUIDS_FILE")
+  ok "re-using existing tradeable subnets: $NETUIDS_CSV"
 fi
-ok "tradeable netuid: SN$NETUID"
+ok "tradeable netuids: [$NETUIDS_CSV]"
+# Use the first netuid for any single-subnet legacy paths (none today).
+NETUID=$(echo "$NETUIDS_CSV" | cut -d, -f1)
 
 # ─── 8. recruit Tao, Mo, and Yumi ────────────────────────────────────────
 step "Recruiting alpha-trading expedition…"
@@ -278,7 +283,7 @@ recruit() {
     --mode live \
     --alloc "$alloc" \
     --tick-secs "$tick" \
-    --universe "SN${NETUID}" \
+    --universe "$UNIVERSE_FLAG" \
     --config-json "$cfg_json" 2>&1) \
     || { fail "agent create $name: $out"; exit 3; }
   local id
@@ -288,9 +293,31 @@ recruit() {
   echo "$id"
 }
 
-TAO_CFG=$(printf '{"subnets":[%s],"tao_per_buy":1.0,"interval_ticks":2,"slippage_bps":100}' "$NETUID")
-MO_CFG=$(printf  '{"universe":[%s],"window_ticks":5,"top_k":1,"exit_threshold":-0.05,"tao_per_position":2.0,"slippage_bps":100}' "$NETUID")
-YUMI_CFG=$(printf '{"universe":[%s],"top_k":1,"rebalance_ticks":5,"volatility_window":5,"tao_per_position":2.0,"slippage_bps":100}' "$NETUID")
+# Build a JSON int array literal from the NETUIDS_CSV. Each strategy
+# config takes a list of subnet IDs.
+NETUIDS_JSON="[$NETUIDS_CSV]"
+# Universe is comma-separated full symbol form. The Bittensor swap
+# venue's MarketSnapshot extension parses these as "SN{n}/TAO" so the
+# strategies see real on-chain prices keyed by symbol.
+UNIVERSE_FLAG=$(echo "$NETUIDS_CSV" | tr ',' '\n' | sed 's|^|SN|;s|$|/TAO|' | tr '\n' ',' | sed 's/,$//')
+
+# Tao: DCAs into ALL three subnets every 2 ticks. Each buy moves the
+# AMM price upward, creating real on-chain price action that Mo's
+# momentum and Yumi's volatility readings respond to. The AMM's
+# non-linear bonding curve makes the per-subnet price trajectories
+# diverge as Tao keeps buying — that divergence is the signal Mo and
+# Yumi rotate on.
+TAO_CFG=$(printf '{"subnets":%s,"tao_per_buy":0.5,"interval_ticks":2,"slippage_bps":150}' "$NETUIDS_JSON")
+# Mo: top_k=1 so it always picks the SINGLE highest-momentum subnet.
+# Combined with the short window, this means Mo actively rotates as
+# the leader changes — visible in the decision log every couple of
+# ticks. exit_threshold=0 means any flat-or-down subnet gets dropped.
+MO_CFG=$(printf  '{"universe":%s,"window_ticks":3,"top_k":1,"exit_threshold":0,"tao_per_position":1.0,"slippage_bps":150}' "$NETUIDS_JSON")
+# Yumi: top_k=1 so it picks the single most-stable subnet. Rebalance
+# every 3 ticks (~90s) for visible cadence in the demo. volatility
+# window of 4 ticks is now safe (the strategy was hard-coded to need
+# ≥5 prior to today's fix).
+YUMI_CFG=$(printf '{"universe":%s,"top_k":1,"rebalance_ticks":3,"volatility_window":4,"tao_per_position":1.0,"slippage_bps":150}' "$NETUIDS_JSON")
 
 TAO_ID=$(recruit "Tao"  "alpha_dca"      "$TAO_CFG"  "500"  "30")
 MO_ID=$(recruit  "Mo"   "alpha_momentum" "$MO_CFG"   "750"  "30")

--- a/strategies/alpha_yield/alpha_yield.go
+++ b/strategies/alpha_yield/alpha_yield.go
@@ -159,7 +159,12 @@ func (s *Strategy) Decide(_ context.Context, in strategy.DecisionInput) (strateg
 	var scores []scored
 	for _, netuid := range s.cfg.Universe {
 		hist := s.history[netuid]
-		if len(hist) < 5 {
+		// relativeStdDev needs ≥ 2 prices to compute a return series. We
+		// previously gated on ≥ 5 here, but that conflicted with operator
+		// configs that set volatility_window < 5: history would never grow
+		// long enough to score, so the strategy entered nothing forever.
+		// Use the actual lower bound of the math instead.
+		if len(hist) < 2 {
 			continue
 		}
 		vol := relativeStdDev(hist)


### PR DESCRIPTION
## Summary

The Bittensor demo previously bootstrapped a single subnet, so \`alpha_momentum\` and \`alpha_yield\` had no universe to choose from — they sat idle while only \`alpha_dca\` traded. This PR fixes that.

## Changes

**Multi-subnet bootstrap**
- \`permafrost bittensor bootstrap --count N\` creates N subnets in one command (loops register_network → start_call). Output ends with \`subnets: [n1,n2,...]\` for easy script consumption.
- \`scripts/demo-bittensor.sh\` now bootstraps **3 subnets** and writes \`$DEMO_DIR/netuids\` (idempotent).
- Strategy configs:
  - **Tao** (alpha_dca) → DCAs 0.5 TAO into all 3 subnets every 2 ticks. The AMM's bonding curve makes the per-subnet trajectories diverge — that divergence is the signal Mo and Yumi rotate on.
  - **Mo** (alpha_momentum) → top_k=1, window_ticks=3, exit_threshold=0 so Mo always picks the single highest-momentum subnet and actively rotates.
  - **Yumi** (alpha_yield) → top_k=1, rebalance_ticks=3, volatility_window=4 so Yumi periodically rotates into the most-stable subnet.
- \`agent --universe\` now passes comma-separated \`SN<n>/TAO\` symbols matching what the Bittensor swap venue's \`MarketSnapshot\` extension parses, so each strategy actually receives prices.

**alpha_yield off-by-three fix**
- \`strategies/alpha_yield/alpha_yield.go\` had a hard-coded \`if len(hist) < 5\` gate but the config-driven \`volatility_window\` could be set lower. With \`volatility_window < 5\` the history could never grow to 5, so the strategy held nothing forever. Now uses \`< 2\` (the actual lower bound for \`relativeStdDev\`).

**Decision counters in the API**
- \`store.RecentDecisions\` now returns \`NumOrders\` + \`NumSwaps\`, computed in SQL via \`jsonb_array_length\` on the persisted \`Decision\` JSONB.
- Uses \`jsonb_typeof = 'array'\` guard since empty \`[]types.OrderIntent\` marshals to JSON null, not \`[]\`.
- API handler drops the rationale-string parser stopgap and reads counters directly.

## Verified live

After \`make demo-bittensor\`, the Trading Desk Decision Log shows:

\`\`\`
Tao  alpha_dca: buying 0.5 TAO each of [SN2, SN3, SN4]    swaps=3
Mo   alpha_momentum: holding 1 subnets, 1 entries         swaps=1
Yumi alpha_yield: rebalance → 1 entries, 1 exits          swaps=2
\`\`\`

All three strategies trading meaningfully against the local devnet within ~2 minutes of demo start.

## Test plan

- [x] \`go test ./...\` clean
- [x] \`make demo-bittensor\` end-to-end: 3 subnets bootstrapped, daemon ticks all 3 agents, all 3 emit non-zero \`swaps\` within ~2 min
- [x] Trading Desk UI shows Tao/Mo/Yumi with live decisions and accurate swap counts
- [x] Tao buys, Mo rotates, Yumi rebalances — all visibly active