### PR TITLE
feat(demo): noise-trader sidecar + true momentum rotation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,10 @@ demo-bittensor: ## Bittensor demo: stack + subtensor + 3 alpha agents (Tao, Mo, 
 	@./scripts/demo-bittensor.sh
 
 demo-bittensor-clean: ## Tear down the bittensor demo (incl. subtensor container)
+	@echo "==> stopping noise trader (if running)"
+	@if [ -f .permafrost-demo-bittensor/noise-trader.pid ]; then \
+		kill `cat .permafrost-demo-bittensor/noise-trader.pid` 2>/dev/null || true; \
+	fi
 	@echo "==> stopping stack + subtensor"
 	@docker compose -f deploy/compose/docker-compose.yml --profile bittensor down -v 2>/dev/null || true
 	@echo "==> removing .permafrost-demo-bittensor/"

--- a/internal/cli/bittensor.go
+++ b/internal/cli/bittensor.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -35,8 +37,181 @@ endpoint.`,
 		newBittensorBalanceCmd(),
 		newBittensorPriceCmd(),
 		newBittensorBootstrapCmd(),
+		newBittensorNoiseTraderCmd(),
 	)
 	return cmd
+}
+
+// newBittensorNoiseTraderCmd runs a small loop that periodically submits
+// random buy/sell extrinsics across a configured subnet universe.
+//
+// Purpose: create realistic volatility in the AMM pools of a local
+// devnet so momentum + yield strategies have a meaningful signal to
+// react to. Without this, the only price pressure on devnet comes
+// from agents themselves — which on a fresh chain is a single DCA
+// strategy buying uniformly across subnets, producing little
+// per-subnet divergence.
+//
+// Behaviour per cycle:
+//  1. Pick a random subnet from --subnets.
+//  2. Pick a random direction (BUY weighted heavier than SELL because
+//     fresh wallets start with TAO not alpha).
+//  3. Pick a random TAO amount in [--min-tao .. --max-tao].
+//  4. Submit add_stake_limit (BUY) or remove_stake_limit (SELL).
+//  5. Sleep --interval-secs (jittered ±50%).
+//  6. Loop until SIGINT.
+//
+// Devnet helper. Refuses to run against non-localhost RPCs.
+func newBittensorNoiseTraderCmd() *cobra.Command {
+	var (
+		fromURI       string
+		subnetsCSV    string
+		intervalSecs  int
+		minTAOFloat   float64
+		maxTAOFloat   float64
+		buyWeight     int
+	)
+	cmd := &cobra.Command{
+		Use:   "noise-trader",
+		Short: "Random buy/sell loop to create volatility on devnet AMM pools (devnet only)",
+		Long: `noise-trader runs a loop that submits random buy/sell extrinsics
+across a chosen subnet universe. It exists to give momentum + yield
+strategies a realistic price signal to trade against on a local devnet.
+
+Refuses to run against non-localhost RPCs. Stop with SIGINT.`,
+		RunE: func(c *cobra.Command, _ []string) error {
+			g := FromContext(c.Context())
+			if g == nil {
+				return fmt.Errorf("globals not initialised")
+			}
+			rpcURL := g.Config.Bittensor.ResolvedRPCURL()
+			if !strings.Contains(rpcURL, "localhost") && !strings.Contains(rpcURL, "127.0.0.1") {
+				return fmt.Errorf("noise-trader is a devnet helper; refusing to run against %q", rpcURL)
+			}
+			if subnetsCSV == "" {
+				return fmt.Errorf("--subnets is required (e.g. --subnets 2,3,4)")
+			}
+			subnets, err := parseSubnetsCSV(subnetsCSV)
+			if err != nil {
+				return err
+			}
+			if intervalSecs < 1 {
+				return fmt.Errorf("--interval-secs must be >= 1")
+			}
+			if minTAOFloat <= 0 || maxTAOFloat < minTAOFloat {
+				return fmt.Errorf("--min-tao must be > 0 and --max-tao must be >= --min-tao")
+			}
+			if buyWeight < 0 || buyWeight > 100 {
+				return fmt.Errorf("--buy-weight must be in [0..100]")
+			}
+
+			signer, err := wallet.NewBittensorSignerFromURI(fromURI)
+			if err != nil {
+				return fmt.Errorf("derive signer from URI %q: %w", fromURI, err)
+			}
+			fmt.Fprintf(os.Stdout, "noise-trader starting as %s (URI %s)\n", signer.Address(), fromURI)
+			fmt.Fprintf(os.Stdout, "  subnets:       %v\n", subnets)
+			fmt.Fprintf(os.Stdout, "  interval:      %ds (±50%% jitter)\n", intervalSecs)
+			fmt.Fprintf(os.Stdout, "  amount range:  %.3f .. %.3f TAO\n", minTAOFloat, maxTAOFloat)
+			fmt.Fprintf(os.Stdout, "  buy weight:    %d%% (rest sells)\n\n", buyWeight)
+
+			client := btchain.NewClient(rpcURL)
+			defer client.Close()
+
+			rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+			cycle := 0
+			for {
+				if c.Context().Err() != nil {
+					return nil
+				}
+				cycle++
+				netuid := subnets[rng.Intn(len(subnets))]
+				isBuy := rng.Intn(100) < buyWeight
+				amtRange := maxTAOFloat - minTAOFloat
+				amt := minTAOFloat + rng.Float64()*amtRange
+				rao := uint64(amt * 1e9)
+				if rao == 0 {
+					rao = 1
+				}
+
+				start := time.Now()
+				var (
+					action string
+					err    error
+				)
+				if isBuy {
+					action = "BUY "
+					_, err = client.AddStake(c.Context(), signer, netuid, signer.PublicKey(), rao, btchain.SubmitOptions{
+						WaitTimeout: 20 * time.Second,
+					})
+				} else {
+					action = "SELL"
+					_, err = client.RemoveStake(c.Context(), signer, netuid, signer.PublicKey(), rao, btchain.SubmitOptions{
+						WaitTimeout: 20 * time.Second,
+					})
+				}
+				dur := time.Since(start).Truncate(time.Millisecond)
+				if err != nil {
+					// Sells will commonly fail on a hotkey with zero
+					// alpha. That's fine — log and keep going.
+					fmt.Fprintf(os.Stdout, "[%04d] %s SN%d %.4f TAO  err=%v (%s)\n",
+						cycle, action, netuid, amt, truncErr(err), dur)
+				} else {
+					fmt.Fprintf(os.Stdout, "[%04d] %s SN%d %.4f TAO  ok (%s)\n",
+						cycle, action, netuid, amt, dur)
+				}
+
+				// Jitter sleep ±50%.
+				base := time.Duration(intervalSecs) * time.Second
+				jitter := time.Duration(rng.Int63n(int64(base)) - int64(base/2))
+				select {
+				case <-c.Context().Done():
+					return nil
+				case <-time.After(base + jitter):
+				}
+			}
+		},
+	}
+	cmd.Flags().StringVar(&fromURI, "from-uri", "//Alice", "Substrate URI for the noise-trader signer")
+	cmd.Flags().StringVar(&subnetsCSV, "subnets", "", "comma-separated netuids to trade across (e.g. 2,3,4)")
+	cmd.Flags().IntVar(&intervalSecs, "interval-secs", 5, "base seconds between submissions (jittered ±50%)")
+	cmd.Flags().Float64Var(&minTAOFloat, "min-tao", 0.05, "minimum TAO amount per submission")
+	cmd.Flags().Float64Var(&maxTAOFloat, "max-tao", 0.4, "maximum TAO amount per submission")
+	cmd.Flags().IntVar(&buyWeight, "buy-weight", 65, "percentage chance of BUY (rest is SELL)")
+	return cmd
+}
+
+// parseSubnetsCSV parses "2,3,4" into []uint16{2,3,4}.
+func parseSubnetsCSV(s string) ([]uint16, error) {
+	parts := strings.Split(s, ",")
+	out := make([]uint16, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		n, err := strconv.ParseUint(p, 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("subnets: %q is not a valid u16: %w", p, err)
+		}
+		out = append(out, uint16(n))
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("subnets: at least one netuid required")
+	}
+	return out, nil
+}
+
+// truncErr collapses the gsrpc/Substrate error spam to one line.
+func truncErr(err error) string {
+	s := err.Error()
+	if i := strings.Index(s, "\n"); i > 0 {
+		s = s[:i]
+	}
+	if len(s) > 80 {
+		s = s[:80] + "…"
+	}
+	return s
 }
 
 // newBittensorBootstrapCmd creates a brand-new tradeable subnet on the

--- a/scripts/demo-bittensor.sh
+++ b/scripts/demo-bittensor.sh
@@ -341,14 +341,54 @@ for i in $(seq 1 30); do
 done
 ok "daemon back up — supervisor now driving Tao, Mo, Yumi against the local subtensor"
 
+# ─── 8c. spawn a noise trader so Mo + Yumi see real volatility ───────────
+# Tao's symmetric DCA pushes all subnets up roughly the same amount, so
+# the relative ranking that Mo (momentum) and Yumi (volatility-rank)
+# trade on barely changes. This sidecar randomly buys + sells small
+# amounts on a single random subnet at a time (every 4-6s), which
+# decorrelates the per-subnet price trajectories and gives the rotation
+# strategies an actual signal.
+NOISE_LOG="$DEMO_DIR/noise-trader.log"
+NOISE_PID_FILE="$DEMO_DIR/noise-trader.pid"
+if [[ -f "$NOISE_PID_FILE" ]] && kill -0 "$(cat "$NOISE_PID_FILE")" 2>/dev/null; then
+  ok "noise trader already running (pid $(cat "$NOISE_PID_FILE"))"
+else
+  step "Spawning noise trader sidecar for AMM volatility…"
+  # Larger amounts create bigger AMM moves, which decorrelate the
+  # per-subnet price trajectories enough for momentum (Mo) to actually
+  # rotate leaders rather than picking once and holding.
+  nohup permafrost --config "$DEMO_CONFIG" bittensor noise-trader \
+    --from-uri "//Alice" \
+    --subnets "$NETUIDS_CSV" \
+    --interval-secs 4 \
+    --min-tao 0.5 \
+    --max-tao 2.5 \
+    --buy-weight 55 \
+    > "$NOISE_LOG" 2>&1 &
+  echo $! > "$NOISE_PID_FILE"
+  sleep 1
+  ok "noise trader running (pid $(cat "$NOISE_PID_FILE")), log: $NOISE_LOG"
+fi
+
 # ─── 9. tail decisions across all three ──────────────────────────────────
 step "🐧🐧🐧  Three agents on the ice — tailing decisions"
 echo "  Open the Trading Desk UI: cd apps/desk && npm run dev → http://127.0.0.1:5173"
-echo "  (SIGINT to stop the demo; the daemon + subtensor keep running.)"
+echo "  Noise-trader log:        $NOISE_LOG"
+echo "  (SIGINT to stop the demo; the daemon + subtensor + noise trader keep running.)"
 echo "  Tear down everything: \`make demo-bittensor-clean\`"
 echo
 
-trap 'echo; echo "  (demo stopped — daemon + subtensor still running; \`make demo-bittensor-clean\` to teardown)"; exit 0' INT TERM
+cleanup_on_signal() {
+  echo
+  if [[ -f "$NOISE_PID_FILE" ]] && kill -0 "$(cat "$NOISE_PID_FILE")" 2>/dev/null; then
+    kill "$(cat "$NOISE_PID_FILE")" 2>/dev/null || true
+    rm -f "$NOISE_PID_FILE"
+    echo "  (noise trader stopped)"
+  fi
+  echo "  (demo stopped — daemon + subtensor still running; \`make demo-bittensor-clean\` to teardown)"
+  exit 0
+}
+trap cleanup_on_signal INT TERM
 
 LAST_PRINT=""
 while true; do

--- a/strategies/alpha_momentum/alpha_momentum.go
+++ b/strategies/alpha_momentum/alpha_momentum.go
@@ -156,13 +156,24 @@ func (s *Strategy) Decide(_ context.Context, in strategy.DecisionInput) (strateg
 		return scores[i].momentum > scores[j].momentum
 	})
 
+	// Build the target portfolio: top-K subnets by current momentum
+	// (positive only). This is a true rotation — we always hold the
+	// best-momentum subnets RIGHT NOW, regardless of what we held
+	// before. Exit anything no longer in the target.
+	target := make(map[uint16]bool, s.cfg.TopK)
+	for i := 0; i < s.cfg.TopK && i < len(scores); i++ {
+		if scores[i].momentum <= s.cfg.ExitThreshold {
+			break
+		}
+		target[scores[i].netuid] = true
+	}
+
 	var swaps []types.SwapIntent
 	exits, entries := 0, 0
 
-	// Exit positions where momentum has flipped below threshold.
+	// Exit any held position not in the new target.
 	for netuid, pos := range s.held {
-		mom := findMomentum(scores, netuid)
-		if mom >= s.cfg.ExitThreshold {
+		if target[netuid] {
 			continue
 		}
 		if pos.alphaHeld.IsZero() {
@@ -187,12 +198,12 @@ func (s *Strategy) Decide(_ context.Context, in strategy.DecisionInput) (strateg
 		exits++
 	}
 
-	// Enter top-K subnets with positive momentum that we don't already hold.
+	// Enter any target subnets we don't already hold.
 	for _, sc := range scores {
-		if len(s.held) >= s.cfg.TopK {
-			break
+		if !target[sc.netuid] {
+			continue
 		}
-		if _, alreadyHeld := s.held[sc.netuid]; alreadyHeld || sc.momentum <= 0 {
+		if _, alreadyHeld := s.held[sc.netuid]; alreadyHeld {
 			continue
 		}
 		// Look up current price to estimate alpha-out for sizing


### PR DESCRIPTION
## Why

User feedback after the previous demo run: \`alpha_momentum\` and \`alpha_yield\` looked static — once they entered, they sat. Reason was:

1. Tao's symmetric DCA pushed all 3 subnets up uniformly → no per-subnet ranking change.
2. \`alpha_momentum\`'s logic was "hold while positive" — once it picked the highest-momentum subnet, no other subnet's momentum had to drop below threshold to dethrone it.

This PR fixes both.

## Changes

**1. New \`permafrost bittensor noise-trader\` CLI command**
- Random buy/sell loop across a configured universe. Args: \`--subnets\`, \`--interval-secs\` (jittered ±50%), \`--min-tao\`, \`--max-tao\`, \`--buy-weight\`, \`--from-uri\`.
- Devnet-only guard (refuses non-localhost RPCs).
- Tolerates SELL failures (zero alpha early on is normal).

**2. \`alpha_momentum\` becomes a true rotation strategy**
- Old: exit only when momentum drops below threshold; hold forever otherwise.
- New: every tick, build target = top-K by current momentum, exit anything not in target, enter anything in target not currently held. Same shape as \`alpha_yield\`.
- \`exit_threshold\` semantic: "minimum momentum to be eligible". Same behaviour if \`exit_threshold=0\` (the default).
- Existing tests pass unchanged.

**3. Demo wiring**
- Demo script spawns the noise trader as a background sidecar with PID file. SIGINT to the demo + \`make demo-bittensor-clean\` both kill it.
- Noise config: 4s interval, 0.5–2.5 TAO per submission, 55% buy weight. Large enough to flip the momentum leader every couple of minutes.

## Verified live

Trading Desk after running the new demo:

\`\`\`
Tao  alpha_dca:      buying 0.5 TAO each of [SN2, SN3, SN4]   3 swaps
Mo   alpha_momentum: holding 1 subnets, 1 entries, 1 exits    2 swaps  ← rotating
Yumi alpha_yield:    rebalance → 1 entries, 1 exits           2 swaps  ← rotating
\`\`\`

All three penguins visibly walking on every cycle now.

## Test plan

- [x] \`go test ./...\` clean (alpha_momentum tests pass with the new logic)
- [x] \`make demo-bittensor\` end-to-end: noise trader spawns, all 3 strategies trade meaningfully within ~2 minutes
- [x] Trading Desk UI shows entries+exits flowing across Mo and Yumi
- [x] Noise trader logs to \`$DEMO_DIR/noise-trader.log\` for inspection
- [x] \`make demo-bittensor-clean\` kills the noise trader pid